### PR TITLE
fix: add bounded buffering for stream responses

### DIFF
--- a/src/azure_functions_langgraph/app.py
+++ b/src/azure_functions_langgraph/app.py
@@ -62,6 +62,7 @@ class LangGraphApp:
     """
 
     auth_level: func.AuthLevel = func.AuthLevel.ANONYMOUS
+    max_stream_response_bytes: int = 1024 * 1024
     _registrations: dict[str, _GraphRegistration] = field(default_factory=dict)
     _function_app: Optional[func.FunctionApp] = field(default=None, init=False, repr=False)
 
@@ -209,6 +210,25 @@ class LangGraphApp:
 
         config = request.config or {}
         chunks: list[str] = []
+        buffered_bytes = 0
+
+        def _append_chunk(chunk: str) -> bool:
+            nonlocal buffered_bytes
+            chunk_bytes = len(chunk.encode())
+            if buffered_bytes + chunk_bytes > self.max_stream_response_bytes:
+                error_payload = json.dumps(
+                    {
+                        "error": (
+                            "stream response exceeded max buffered size "
+                            f"({self.max_stream_response_bytes} bytes)"
+                        )
+                    }
+                )
+                chunks.append(f"event: error\ndata: {error_payload}\n\n")
+                return False
+            chunks.append(chunk)
+            buffered_bytes += chunk_bytes
+            return True
 
         try:
             for event in reg.graph.stream(
@@ -220,13 +240,14 @@ class LangGraphApp:
                     event if isinstance(event, dict) else {"data": str(event)},
                     default=str,
                 )
-                chunks.append(f"event: data\ndata: {serialized}\n\n")
+                if not _append_chunk(f"event: data\ndata: {serialized}\n\n"):
+                    break
         except Exception as exc:
             logger.exception("Graph %s stream failed", reg.name)
             error_payload = json.dumps({"error": str(exc)})
-            chunks.append(f"event: error\ndata: {error_payload}\n\n")
+            _append_chunk(f"event: error\ndata: {error_payload}\n\n")
 
-        chunks.append("event: end\ndata: {}\n\n")
+        _append_chunk("event: end\ndata: {}\n\n")
 
         return func.HttpResponse(
             body="".join(chunks),

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -261,6 +261,25 @@ class TestStreamHandler:
         assert body.count("event: data") == 2
         assert body.count("event: end") == 1
 
+    def test_stream_enforces_bounded_buffer(self) -> None:
+        large_events = [
+            {"messages": [{"role": "assistant", "content": "x" * 400}]},
+            {"messages": [{"role": "assistant", "content": "y" * 400}]},
+            {"messages": [{"role": "assistant", "content": "z" * 400}]},
+        ]
+        app = LangGraphApp(max_stream_response_bytes=700)
+        app.register(graph=FakeCompiledGraph(stream_results=large_events), name="agent")
+        req = self._make_request({"input": {"messages": []}})
+
+        resp = app._handle_stream(req, app._registrations["agent"])
+
+        assert resp.status_code == 200
+        body = resp.get_body().decode()
+        assert "event: data" in body
+        assert "event: error" in body
+        assert "exceeded max buffered size" in body
+        assert body.count("event: data") == 1
+
     def test_stream_invoke_only_graph_returns_501(
         self, fake_invoke_only_graph: FakeInvokeOnlyGraph
     ) -> None:


### PR DESCRIPTION
## Summary
- prevent unbounded memory growth when building buffered SSE responses
- stop streaming once the configured response buffer limit is reached

## Changes
- add `max_stream_response_bytes` configuration to `LangGraphApp` (default 1 MiB)
- track accumulated buffered bytes while serializing stream chunks
- emit an SSE error event and stop collecting chunks when the configured size limit is exceeded
- add a stress-style test that streams large chunks and verifies bounded behavior

## Validation
- source .venv/bin/activate && python -m pytest --no-cov -x -q
- source .venv/bin/activate && python -m ruff check src/ tests/
- source .venv/bin/activate && python -m mypy src/

Closes #8