### PR TITLE
fix: return 501 for stream requests on invoke-only graphs

### DIFF
--- a/src/azure_functions_langgraph/app.py
+++ b/src/azure_functions_langgraph/app.py
@@ -29,6 +29,7 @@ class _GraphRegistration:
     graph: InvocableGraph
     name: str
     description: Optional[str] = None
+    stream_enabled: bool = True
 
 
 @dataclass
@@ -70,6 +71,7 @@ class LangGraphApp:
         graph: Any,
         name: str,
         description: Optional[str] = None,
+        stream: bool = True,
     ) -> None:
         """Register a compiled LangGraph graph.
 
@@ -91,6 +93,7 @@ class LangGraphApp:
             graph=graph,
             name=name,
             description=description,
+            stream_enabled=stream,
         )
         # Reset cached function app so routes are re-generated
         self._function_app = None
@@ -194,6 +197,9 @@ class LangGraphApp:
         known v0.1 limitation — true chunked streaming will follow once Azure
         Functions Python HTTP streaming is fully stable.
         """
+        if not reg.stream_enabled:
+            return _error_response(501, f"Graph {reg.name!r} is configured as invoke-only")
+
         if not isinstance(reg.graph, StreamableGraph):
             return _error_response(501, f"Graph {reg.name!r} does not support streaming")
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -40,6 +40,11 @@ class TestRegistration:
         app.register(graph=fake_graph, name="agent", description="My agent")
         assert app._registrations["agent"].description == "My agent"
 
+    def test_register_invoke_only_mode(self, fake_graph: FakeCompiledGraph) -> None:
+        app = LangGraphApp()
+        app.register(graph=fake_graph, name="agent", stream=False)
+        assert app._registrations["agent"].stream_enabled is False
+
     def test_register_invalid_graph_raises(self) -> None:
         app = LangGraphApp()
         with pytest.raises(TypeError, match="invoke"):
@@ -269,6 +274,17 @@ class TestStreamHandler:
         req = self._make_request({"input": {"messages": []}})
         resp = app._handle_stream(req, app._registrations["agent"])
         assert resp.status_code == 501
+
+    def test_stream_returns_501_when_registered_in_invoke_only_mode(self) -> None:
+        app = LangGraphApp()
+        app.register(graph=FakeCompiledGraph(), name="agent", stream=False)
+        req = self._make_request({"input": {"messages": []}})
+
+        resp = app._handle_stream(req, app._registrations["agent"])
+
+        assert resp.status_code == 501
+        payload = json.loads(resp.get_body())
+        assert "invoke-only" in payload["detail"]
 
 
 # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- enforce explicit invoke-only registrations for graphs that should not stream
- return HTTP 501 with a clear message when stream endpoint is called for invoke-only registrations

## Changes
- add `stream: bool = True` parameter to `LangGraphApp.register(...)`
- persist the stream capability flag per registration
- update stream handler to short-circuit with 501 when registration is invoke-only
- add tests for registration flag storage and invoke-only stream behavior

## Validation
- source .venv/bin/activate && python -m pytest --no-cov -x -q
- source .venv/bin/activate && python -m ruff check src/ tests/
- source .venv/bin/activate && python -m mypy src/

Closes #7