### PR TITLE
fix: add TYPE_CHECKING import so mkdocstrings can discover LangGraphApp

### DIFF
--- a/src/azure_functions_langgraph/__init__.py
+++ b/src/azure_functions_langgraph/__init__.py
@@ -1,6 +1,13 @@
 """Azure Functions LangGraph — Deploy LangGraph agents as Azure Functions."""
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 __version__ = "0.1.0a0"
+
+if TYPE_CHECKING:
+    from azure_functions_langgraph.app import LangGraphApp
 
 
 def __getattr__(name: str) -> object:


### PR DESCRIPTION
## Summary
- `Deploy MkDocs to GitHub Pages` CI was failing because `mkdocstrings` (via griffe) uses static analysis and cannot resolve `__getattr__`-based lazy exports
- Added `TYPE_CHECKING` block with a static import of `LangGraphApp` so griffe can discover the class
- Runtime lazy import behavior via `__getattr__` is preserved — no behavioral change

## Changes
- `src/azure_functions_langgraph/__init__.py`: Added `from __future__ import annotations`, `TYPE_CHECKING` guard import

## Verification
- `hatch run mkdocs build --strict` passes
- All tests pass (94.61% coverage)
- Oracle reviewed and approved