### PR TITLE
feat: add per-graph auth_level override

### DIFF
--- a/src/azure_functions_langgraph/app.py
+++ b/src/azure_functions_langgraph/app.py
@@ -32,7 +32,7 @@ class _GraphRegistration:
     name: str
     description: Optional[str] = None
     stream_enabled: bool = True
-
+    auth_level: Optional[func.AuthLevel] = None
 
 @dataclass
 class LangGraphApp:
@@ -84,6 +84,7 @@ class LangGraphApp:
         name: str,
         description: Optional[str] = None,
         stream: bool = True,
+        auth_level: Optional[func.AuthLevel] = None,
     ) -> None:
         """Register a compiled LangGraph graph.
 
@@ -92,6 +93,9 @@ class LangGraphApp:
                 (typically a ``CompiledStateGraph`` from ``langgraph``).
             name: Unique name for this graph (used in URL routes).
             description: Optional human-readable description.
+            stream: Whether to enable the stream endpoint for this graph.
+            auth_level: Override app-level auth for this graph's endpoints.
+                When ``None`` (default), the app-level ``auth_level`` is used.
 
         Raises:
             TypeError: If *graph* does not satisfy the required protocol.
@@ -106,6 +110,7 @@ class LangGraphApp:
             name=name,
             description=description,
             stream_enabled=stream,
+            auth_level=auth_level,
         )
         # Reset cached function app so routes are re-generated
         self._function_app = None
@@ -165,9 +170,10 @@ class LangGraphApp:
         route = f"graphs/{reg.name}/invoke"
         fn_name = f"aflg_{reg.name}_invoke"
         captured_reg = reg
+        effective_auth = self._effective_auth_level(reg)
 
         @app.function_name(name=fn_name)
-        @app.route(route=route, methods=["POST"], auth_level=self.auth_level)
+        @app.route(route=route, methods=["POST"], auth_level=effective_auth)
         def invoke_handler(req: func.HttpRequest) -> func.HttpResponse:
             return self._handle_invoke(req, captured_reg)
 
@@ -175,11 +181,18 @@ class LangGraphApp:
         route = f"graphs/{reg.name}/stream"
         fn_name = f"aflg_{reg.name}_stream"
         captured_reg = reg
+        effective_auth = self._effective_auth_level(reg)
 
         @app.function_name(name=fn_name)
-        @app.route(route=route, methods=["POST"], auth_level=self.auth_level)
+        @app.route(route=route, methods=["POST"], auth_level=effective_auth)
         def stream_handler(req: func.HttpRequest) -> func.HttpResponse:
             return self._handle_stream(req, captured_reg)
+
+    def _effective_auth_level(self, reg: _GraphRegistration) -> func.AuthLevel:
+        """Return per-graph auth if set, otherwise app-level auth."""
+        if reg.auth_level is not None:
+            return reg.auth_level
+        return self.auth_level
 
     # ------------------------------------------------------------------
     # Request handlers

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -88,7 +88,90 @@ class TestRegistration:
         app.register(graph=fake_invoke_only_graph, name="invoke_only")
         assert "invoke_only" in app._registrations
 
+    def test_register_with_auth_level_override(self, fake_graph: FakeCompiledGraph) -> None:
+        app = LangGraphApp(auth_level=func.AuthLevel.FUNCTION)
+        app.register(graph=fake_graph, name="agent", auth_level=func.AuthLevel.ADMIN)
+        assert app._registrations["agent"].auth_level == func.AuthLevel.ADMIN
 
+    def test_register_auth_level_defaults_to_none(self, fake_graph: FakeCompiledGraph) -> None:
+        app = LangGraphApp()
+        app.register(graph=fake_graph, name="agent")
+        assert app._registrations["agent"].auth_level is None
+
+    def test_register_anonymous_auth_override(self, fake_graph: FakeCompiledGraph) -> None:
+        """AuthLevel.ANONYMOUS is falsy-ish; ensure 'is not None' check preserves it."""
+        app = LangGraphApp(auth_level=func.AuthLevel.ADMIN)
+        app.register(graph=fake_graph, name="agent", auth_level=func.AuthLevel.ANONYMOUS)
+        assert app._registrations["agent"].auth_level == func.AuthLevel.ANONYMOUS
+
+
+# ------------------------------------------------------------------
+# Per-graph auth level tests
+# ------------------------------------------------------------------
+
+
+class TestPerGraphAuth:
+    """Verify per-graph auth_level overrides propagate to Azure Functions routes."""
+
+    @staticmethod
+    def _get_trigger_auth(fa: func.FunctionApp, fn_name: str) -> func.AuthLevel:
+        """Extract the auth_level from a registered function's HTTP trigger."""
+        # Reset bindings cache to avoid duplicate-name validation on repeat calls
+        fa.functions_bindings = {}
+        for f in fa.get_functions():
+            if f.get_function_name() == fn_name:
+                return f.get_trigger().auth_level  # type: ignore[union-attr, no-any-return]
+        raise ValueError(f"Function {fn_name!r} not found")
+
+    def test_per_graph_auth_overrides_invoke_route(self) -> None:
+        app = LangGraphApp(auth_level=func.AuthLevel.FUNCTION)
+        app.register(graph=FakeCompiledGraph(), name="secure", auth_level=func.AuthLevel.ADMIN)
+        fa = app.function_app
+        assert self._get_trigger_auth(fa, "aflg_secure_invoke") == func.AuthLevel.ADMIN
+
+    def test_per_graph_auth_overrides_stream_route(self) -> None:
+        app = LangGraphApp(auth_level=func.AuthLevel.FUNCTION)
+        app.register(graph=FakeCompiledGraph(), name="secure", auth_level=func.AuthLevel.ADMIN)
+        fa = app.function_app
+        assert self._get_trigger_auth(fa, "aflg_secure_stream") == func.AuthLevel.ADMIN
+
+    def test_fallback_to_app_auth_when_none(self) -> None:
+        app = LangGraphApp(auth_level=func.AuthLevel.FUNCTION)
+        app.register(graph=FakeCompiledGraph(), name="default")
+        fa = app.function_app
+        assert self._get_trigger_auth(fa, "aflg_default_invoke") == func.AuthLevel.FUNCTION
+        assert self._get_trigger_auth(fa, "aflg_default_stream") == func.AuthLevel.FUNCTION
+
+    def test_anonymous_override_is_preserved(self) -> None:
+        """AuthLevel.ANONYMOUS must not be swallowed by falsy check."""
+        app = LangGraphApp(auth_level=func.AuthLevel.ADMIN)
+        app.register(
+            graph=FakeCompiledGraph(), name="public", auth_level=func.AuthLevel.ANONYMOUS
+        )
+        fa = app.function_app
+        assert self._get_trigger_auth(fa, "aflg_public_invoke") == func.AuthLevel.ANONYMOUS
+        assert self._get_trigger_auth(fa, "aflg_public_stream") == func.AuthLevel.ANONYMOUS
+
+    def test_mixed_graphs_use_correct_auth(self) -> None:
+        """Two graphs: one with override, one with default — each gets correct auth."""
+        app = LangGraphApp(auth_level=func.AuthLevel.FUNCTION)
+        app.register(graph=FakeCompiledGraph(), name="private", auth_level=func.AuthLevel.ADMIN)
+        app.register(graph=FakeCompiledGraph(), name="default")
+        fa = app.function_app
+        # Private graph → ADMIN
+        assert self._get_trigger_auth(fa, "aflg_private_invoke") == func.AuthLevel.ADMIN
+        assert self._get_trigger_auth(fa, "aflg_private_stream") == func.AuthLevel.ADMIN
+        # Default graph → FUNCTION (app-level)
+        assert self._get_trigger_auth(fa, "aflg_default_invoke") == func.AuthLevel.FUNCTION
+        assert self._get_trigger_auth(fa, "aflg_default_stream") == func.AuthLevel.FUNCTION
+
+    def test_health_always_uses_app_auth(self) -> None:
+        """Health/OpenAPI endpoints must use app-level auth, not per-graph."""
+        app = LangGraphApp(auth_level=func.AuthLevel.FUNCTION)
+        app.register(graph=FakeCompiledGraph(), name="agent", auth_level=func.AuthLevel.ADMIN)
+        fa = app.function_app
+        assert self._get_trigger_auth(fa, "aflg_health") == func.AuthLevel.FUNCTION
+        assert self._get_trigger_auth(fa, "aflg_openapi") == func.AuthLevel.FUNCTION
 # ------------------------------------------------------------------
 # Function app creation tests
 # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Adds per-graph `auth_level` override to `LangGraphApp.register()`, allowing individual graphs to use different Azure Functions auth levels.

### Changes
- Added `auth_level: Optional[AuthLevel] = None` to `_GraphRegistration` dataclass
- Added `auth_level` parameter to `register()` method
- Added `_effective_auth_level(reg)` helper using `is not None` check (preserves `AuthLevel.ANONYMOUS` which may be falsy)
- Applied per-graph auth to invoke and stream routes
- Health/OpenAPI endpoints always use app-level auth (unchanged)
- Added 9 tests covering override, fallback, ANONYMOUS edge case, mixed graphs, health isolation

### Design Decisions
- Uses `is not None` check instead of `or` to correctly handle `AuthLevel.ANONYMOUS` (which could be falsy)
- Per-graph auth only applies to graph-specific endpoints (invoke, stream); shared endpoints (health, OpenAPI) stay on app-level auth

Closes #18