### PR TITLE
feat: re-export contracts and protocols from package root

### DIFF
--- a/src/azure_functions_langgraph/__init__.py
+++ b/src/azure_functions_langgraph/__init__.py
@@ -8,6 +8,19 @@ __version__ = "0.1.0a0"
 
 if TYPE_CHECKING:
     from azure_functions_langgraph.app import LangGraphApp
+    from azure_functions_langgraph.contracts import (
+        ErrorResponse,
+        GraphInfo,
+        HealthResponse,
+        InvokeRequest,
+        InvokeResponse,
+        StreamRequest,
+    )
+    from azure_functions_langgraph.protocols import (
+        InvocableGraph,
+        LangGraphLike,
+        StreamableGraph,
+    )
 
 
 def __getattr__(name: str) -> object:
@@ -21,7 +34,59 @@ def __getattr__(name: str) -> object:
                 "LangGraphApp requires 'azure-functions' and 'langgraph'. "
                 "Install them with: pip install azure-functions-langgraph"
             ) from exc
+    # Contracts
+    if name == "InvokeRequest":
+        from azure_functions_langgraph.contracts import InvokeRequest
+
+        return InvokeRequest
+    if name == "InvokeResponse":
+        from azure_functions_langgraph.contracts import InvokeResponse
+
+        return InvokeResponse
+    if name == "StreamRequest":
+        from azure_functions_langgraph.contracts import StreamRequest
+
+        return StreamRequest
+    if name == "HealthResponse":
+        from azure_functions_langgraph.contracts import HealthResponse
+
+        return HealthResponse
+    if name == "GraphInfo":
+        from azure_functions_langgraph.contracts import GraphInfo
+
+        return GraphInfo
+    if name == "ErrorResponse":
+        from azure_functions_langgraph.contracts import ErrorResponse
+
+        return ErrorResponse
+    # Protocols
+    if name == "InvocableGraph":
+        from azure_functions_langgraph.protocols import InvocableGraph
+
+        return InvocableGraph
+    if name == "StreamableGraph":
+        from azure_functions_langgraph.protocols import StreamableGraph
+
+        return StreamableGraph
+    if name == "LangGraphLike":
+        from azure_functions_langgraph.protocols import LangGraphLike
+
+        return LangGraphLike
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
-__all__ = ["LangGraphApp", "__version__"]
+__all__ = [
+    "LangGraphApp",
+    "__version__",
+    # Contracts
+    "InvokeRequest",
+    "InvokeResponse",
+    "StreamRequest",
+    "HealthResponse",
+    "GraphInfo",
+    "ErrorResponse",
+    # Protocols
+    "InvocableGraph",
+    "StreamableGraph",
+    "LangGraphLike",
+]

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -20,6 +20,17 @@ def test_all_exports() -> None:
 
     assert "LangGraphApp" in azure_functions_langgraph.__all__
     assert "__version__" in azure_functions_langgraph.__all__
+    # Contracts
+    assert "InvokeRequest" in azure_functions_langgraph.__all__
+    assert "InvokeResponse" in azure_functions_langgraph.__all__
+    assert "StreamRequest" in azure_functions_langgraph.__all__
+    assert "HealthResponse" in azure_functions_langgraph.__all__
+    assert "GraphInfo" in azure_functions_langgraph.__all__
+    assert "ErrorResponse" in azure_functions_langgraph.__all__
+    # Protocols
+    assert "InvocableGraph" in azure_functions_langgraph.__all__
+    assert "StreamableGraph" in azure_functions_langgraph.__all__
+    assert "LangGraphLike" in azure_functions_langgraph.__all__
 
 
 def test_contracts_importable() -> None:
@@ -38,6 +49,36 @@ def test_contracts_importable() -> None:
     assert HealthResponse is not None
     assert GraphInfo is not None
     assert ErrorResponse is not None
+
+
+def test_all_contracts_importable() -> None:
+    from azure_functions_langgraph import (
+        ErrorResponse,
+        GraphInfo,
+        HealthResponse,
+        InvokeRequest,
+        InvokeResponse,
+        StreamRequest,
+    )
+
+    assert InvokeRequest is not None
+    assert InvokeResponse is not None
+    assert StreamRequest is not None
+    assert HealthResponse is not None
+    assert GraphInfo is not None
+    assert ErrorResponse is not None
+
+
+def test_all_protocols_importable() -> None:
+    from azure_functions_langgraph import (
+        InvocableGraph,
+        LangGraphLike,
+        StreamableGraph,
+    )
+
+    assert InvocableGraph is not None
+    assert StreamableGraph is not None
+    assert LangGraphLike is not None
 
 
 def test_invalid_attr_raises() -> None:


### PR DESCRIPTION
## Summary

Re-exports all contracts and protocols from the package root `__init__.py` so users can import directly from `azure_functions_langgraph`.

### Changes
- Added `TYPE_CHECKING` imports for all contracts (ErrorResponse, GraphInfo, HealthResponse, InvokeRequest, InvokeResponse, StreamRequest) and protocols (InvocableGraph, LangGraphLike, StreamableGraph)
- Added lazy `__getattr__` entries for each symbol
- Updated `__all__` list to include all public symbols
- Added `test_all_contracts_importable()` and `test_all_protocols_importable()` tests
- Extended `test_all_exports()` assertions

### Note
`StateResponse` and `StatefulGraph` (from #24) will be added to exports in a follow-up commit after merge.

Closes #21