### PR TITLE
ci: add release automation workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install git-cliff
-        run: pip install git-cliff
+        run: pip install "git-cliff>=2.12,<3"
 
       - name: Generate changelog
         run: git-cliff --latest --strip header -o RELEASE_NOTES.md


### PR DESCRIPTION
## Summary

Adds automated GitHub Release creation on tag push via `.github/workflows/release.yml`.

### Changes
- Created `.github/workflows/release.yml`
- Triggers on `v*` tag push
- Uses git-cliff (pinned `>=2.12,<3`) to generate release notes from conventional commits
- Uses `softprops/action-gh-release@v2` to create the release
- Automatically detects pre-releases (alpha, beta, rc tags)
- Actions are pinned to commit SHAs (checkout, setup-python)

Closes #22