### PR TITLE
feat: export StateResponse and StatefulGraph in public API

### DIFF
--- a/src/azure_functions_langgraph/__init__.py
+++ b/src/azure_functions_langgraph/__init__.py
@@ -14,11 +14,13 @@ if TYPE_CHECKING:
         HealthResponse,
         InvokeRequest,
         InvokeResponse,
+        StateResponse,
         StreamRequest,
     )
     from azure_functions_langgraph.protocols import (
         InvocableGraph,
         LangGraphLike,
+        StatefulGraph,
         StreamableGraph,
     )
 
@@ -59,6 +61,10 @@ def __getattr__(name: str) -> object:
         from azure_functions_langgraph.contracts import ErrorResponse
 
         return ErrorResponse
+    if name == "StateResponse":
+        from azure_functions_langgraph.contracts import StateResponse
+
+        return StateResponse
     # Protocols
     if name == "InvocableGraph":
         from azure_functions_langgraph.protocols import InvocableGraph
@@ -72,6 +78,10 @@ def __getattr__(name: str) -> object:
         from azure_functions_langgraph.protocols import LangGraphLike
 
         return LangGraphLike
+    if name == "StatefulGraph":
+        from azure_functions_langgraph.protocols import StatefulGraph
+
+        return StatefulGraph
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
@@ -85,8 +95,10 @@ __all__ = [
     "HealthResponse",
     "GraphInfo",
     "ErrorResponse",
+    "StateResponse",
     # Protocols
     "InvocableGraph",
     "StreamableGraph",
     "LangGraphLike",
+    "StatefulGraph",
 ]

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -27,10 +27,12 @@ def test_all_exports() -> None:
     assert "HealthResponse" in azure_functions_langgraph.__all__
     assert "GraphInfo" in azure_functions_langgraph.__all__
     assert "ErrorResponse" in azure_functions_langgraph.__all__
+    assert "StateResponse" in azure_functions_langgraph.__all__
     # Protocols
     assert "InvocableGraph" in azure_functions_langgraph.__all__
     assert "StreamableGraph" in azure_functions_langgraph.__all__
     assert "LangGraphLike" in azure_functions_langgraph.__all__
+    assert "StatefulGraph" in azure_functions_langgraph.__all__
 
 
 def test_contracts_importable() -> None:
@@ -58,6 +60,7 @@ def test_all_contracts_importable() -> None:
         HealthResponse,
         InvokeRequest,
         InvokeResponse,
+        StateResponse,
         StreamRequest,
     )
 
@@ -67,18 +70,21 @@ def test_all_contracts_importable() -> None:
     assert HealthResponse is not None
     assert GraphInfo is not None
     assert ErrorResponse is not None
+    assert StateResponse is not None
 
 
 def test_all_protocols_importable() -> None:
     from azure_functions_langgraph import (
         InvocableGraph,
         LangGraphLike,
+        StatefulGraph,
         StreamableGraph,
     )
 
     assert InvocableGraph is not None
     assert StreamableGraph is not None
     assert LangGraphLike is not None
+    assert StatefulGraph is not None
 
 
 def test_invalid_attr_raises() -> None:


### PR DESCRIPTION
## Summary
- Export `StateResponse` and `StatefulGraph` as public API symbols via `__all__`, `TYPE_CHECKING` imports, and lazy `__getattr__`
- Add corresponding test assertions in `test_public_api.py`

## Context
Addresses Oracle implementation review feedback (issue #2 from review): these types should be importable directly from the package for downstream type checking.

## Testing
- 105 tests pass ✅
- 98.43% coverage ✅
- Lint clean ✅