### PR TITLE
release: v0.2.0 — Milestone 1 complete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,28 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-04-05
+
+### Added
+
+- State endpoint: `GET /api/graphs/{name}/threads/{thread_id}/state` for retrieving thread state from stateful graphs (#17)
+- Per-graph auth level override via `register(graph, name, auth_level=...)` (#18)
+- `StateResponse` contract model for state endpoint responses
+- `StatefulGraph` protocol for graphs that support `get_state()`
+- `StateResponse` and `StatefulGraph` exported in public API `__all__`
+- Release automation: auto GitHub Release on tag push via `release.yml` workflow (#22)
+- 105 tests total, 98%+ coverage with `fail_under=90` (#19)
+
+### Changed
+
+- `__all__` cleaned up with proper re-exports of all contracts and protocols from package root (#21)
+- CI/Release automation validated and hardened (#20)
+- `git-cliff` pinned to `>=2.12,<3` in release workflow
+
+### Fixed
+
+- Narrowed exception handling in `_handle_state`: `KeyError`/`ValueError` → 404, unexpected errors → 500
+
 ## [0.1.0a0] - 2026-04-02
 
 ### Added

--- a/src/azure_functions_langgraph/__init__.py
+++ b/src/azure_functions_langgraph/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-__version__ = "0.1.0a0"
+__version__ = "0.2.0"
 
 if TYPE_CHECKING:
     from azure_functions_langgraph.app import LangGraphApp

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 def test_version_string() -> None:
     from azure_functions_langgraph import __version__
 
-    assert __version__ == "0.1.0a0"
+    assert __version__ == "0.2.0"
 
 
 def test_langgraph_app_importable() -> None:


### PR DESCRIPTION
## Summary
- Bump version from `0.1.0a0` → `0.2.0`
- Update CHANGELOG.md with all Milestone 1 (v0.2.0) changes
- Update version assertion in `test_public_api.py`

## Milestone 1 Features (all merged to main)
- **State endpoint**: `GET /api/graphs/{name}/threads/{thread_id}/state` (#17)
- **Per-graph auth**: `register(graph, name, auth_level=...)` override (#18)
- **Coverage**: 105 tests, 98%+ coverage, `fail_under=90` (#19)
- **CI hardening**: Validated CI/release automation (#20)
- **Public API**: `__all__` cleanup, contracts + protocols re-export (#21)
- **Release automation**: `release.yml` workflow for auto GitHub Releases (#22)
- **Oracle feedback**: `StateResponse`/`StatefulGraph` exported, exception handling narrowed

## Testing
- 105 tests pass ✅
- 98.43% coverage ✅
- Lint clean ✅

After merge, tag `v0.2.0` to trigger release automation.