### PR TITLE
docs: update all documentation for v0.2.0 release

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -14,9 +14,11 @@
 User Code                     azure-functions-langgraph           Azure Functions
 ─────────────────────────────────────────────────────────────────────────────────
 StateGraph → compile()  →  LangGraphApp.register(graph)  →  FunctionApp with routes
-                           ├─ POST /graphs/{name}/invoke  →  graph.invoke(input, config)
-                           ├─ POST /graphs/{name}/stream  →  graph.stream(input, config)
-                           └─ GET /health                 →  list registered graphs
+                            ├─ POST /graphs/{name}/invoke  →  graph.invoke(input, config)
+                            ├─ POST /graphs/{name}/stream  →  graph.stream(input, config)
+                            ├─ GET /graphs/{name}/threads/{id}/state → graph.get_state(config)
+                            ├─ GET /health                 →  list registered graphs
+                            └─ GET /openapi.json           →  auto-generated spec
 ```
 
 ## Key Decisions
@@ -38,19 +40,27 @@ Following LangGraph conventions, `thread_id` is passed in `config.configurable.t
 ### 4. No Durable Functions dependency (v0.1)
 The v0.1 release is HTTP-only. This keeps the dependency footprint small and the mental model simple. Durable Functions can be added later for timeout extension and fan-out patterns.
 
+### 5. Per-graph auth override (v0.2)
+Each graph registration can override the app-level `auth_level`. This enables mixed-auth deployments where public-facing graphs use `ANONYMOUS` while admin graphs require `FUNCTION` keys. The override is stored per-registration and applied at route creation time.
+
+### 6. State endpoint via StatefulGraph protocol (v0.2)
+Graphs that implement `get_state(config)` (i.e., graphs compiled with a checkpointer) expose a `GET /graphs/{name}/threads/{thread_id}/state` endpoint. This uses a new `StatefulGraph` protocol added to `protocols.py`, keeping the protocol-based design consistent.
+
 ## Module Structure
 
 ```
 src/azure_functions_langgraph/
-├── __init__.py       # Package init, lazy LangGraphApp import
+├── __init__.py       # Package init, lazy imports, __version__
 ├── app.py            # LangGraphApp class, route registration, request handlers
-├── contracts.py      # Pydantic request/response models
+├── contracts.py      # Pydantic request/response models (InvokeRequest, StreamRequest, InvokeResponse, StateResponse, etc.)
+├── protocols.py      # Protocol interfaces (InvocableGraph, StreamableGraph, StatefulGraph, LangGraphLike)
 └── py.typed          # PEP 561 marker
 ```
 
 ## Testing Strategy
 
-- Unit tests use `FakeCompiledGraph` (mock with `invoke()`/`stream()` methods)
+- Unit tests use `FakeCompiledGraph` and `FakeStatefulGraph` mock objects
 - No real LLM calls in unit tests
+- 105 tests, 98%+ coverage as of v0.2.0
 - Integration tests (future) would use LangGraph with mock tools
 - E2E tests (future) deploy to Azure Functions and hit real endpoints

--- a/README.ja.md
+++ b/README.ja.md
@@ -12,7 +12,7 @@
 
 この文書の言語: [한국어](README.ko.md) | **日本語** | [简体中文](README.zh-CN.md) | [English](README.md)
 
-> **アルファ版について** — このパッケージは初期開発段階（`0.1.0a0`）です。リリース間でAPIが予告なく変更される場合があります。本番環境での使用前に十分なテストを実施してください。
+> **ベータ版について** — このパッケージは活発に開発中（`0.2.0`）です。コアAPIは安定化に向かっていますが、マイナーリリース間で変更される可能性があります。GitHubでイシューを報告してください。
 
 [LangGraph](https://github.com/langchain-ai/langgraph) エージェントを **Azure Functions** HTTPエンドポイントとしてボイラープレートなしでデプロイできます。
 
@@ -37,6 +37,9 @@ LangGraphエージェントをAzureにデプロイするのは、思ったより
 - **Healthエンドポイント** — `GET /api/health` で登録済みグラフ一覧とチェックポインターの状態を確認
 - **プロトコルベース** — `invoke()` と `stream()` メソッドを持つ任意のオブジェクトで動作し、LangGraphに限定されません
 - **チェックポインター転送** — LangGraphネイティブのconfigによるスレッドベースの会話状態管理
+- **Stateエンドポイント** — `GET /api/graphs/{name}/threads/{thread_id}/state` でスレッド状況を検查（StatefulGraphのみ）
+- **グラフごとの認証** — `register(graph, name, auth_level=...)` でアプリレベルの認証をグラフごとにオーバーライド
+- **OpenAPIエンドポイント** — `GET /api/openapi.json` 自動生成APIスペック
 
 ## LangGraph Platformとの比較
 
@@ -44,7 +47,7 @@ LangGraphエージェントをAzureにデプロイするのは、思ったより
 |------|-------------------|--------------------------|
 | ホスティング | LangChain Cloud（有料） | ユーザーのAzureサブスクリプション |
 | Invoke | `POST /runs/stream` | `POST /api/graphs/{name}/invoke` |
-| ストリーミング | True SSE | バッファリングSSE（v0.1） |
+|| ストリーミング | True SSE | バッファリングSSE（v0.2） |
 | スレッド | 組み込み | LangGraphチェックポインター経由 |
 | インフラ | マネージド | Azure Functions（サーバーレス） |
 | コストモデル | 使用量/シートベース | Azure Functions料金プラン |
@@ -116,7 +119,9 @@ func_app = app.function_app  # ← Azure Functionsアプリとして使用
 
 1. `POST /api/graphs/echo_agent/invoke` — エージェントの呼び出し
 2. `POST /api/graphs/echo_agent/stream` — エージェントレスポンスのストリーミング（バッファリングSSE）
-3. `GET /api/health` — ヘルスチェック
+3. `GET /api/graphs/echo_agent/threads/{thread_id}/state` — スレッド状況の検查
+4. `GET /api/health` — ヘルスチェック
+5. `GET /api/openapi.json` — OpenAPIスペック
 
 ### リクエスト形式
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -12,7 +12,7 @@
 
 이 문서의 언어: **한국어** | [日本語](README.ja.md) | [简体中文](README.zh-CN.md) | [English](README.md)
 
-> **알파 버전 안내** — 이 패키지는 초기 개발 단계(`0.1.0a0`)입니다. 릴리스 사이에 API가 예고 없이 변경될 수 있습니다. 프로덕션 사용 전 충분한 테스트를 수행하세요.
+> **베타 버전 안내** — 이 패키지는 활발히 개발 중(`0.2.0`)입니다. 핵심 API가 안정화되고 있으나 마이너 릴리스 간에 변경될 수 있습니다. GitHub에서 이슈를 보고해 주세요.
 
 [LangGraph](https://github.com/langchain-ai/langgraph) 에이전트를 **Azure Functions** HTTP 엔드포인트로 보일러플레이트 없이 배포하세요.
 
@@ -37,6 +37,9 @@ LangGraph 에이전트를 Azure에 배포하는 것은 생각보다 어렵습니
 - **Health 엔드포인트** — `GET /api/health`로 등록된 그래프 목록과 체크포인터 상태 확인
 - **프로토콜 기반** — `invoke()`와 `stream()` 메서드를 가진 모든 객체에서 동작하며, LangGraph에 한정되지 않습니다
 - **체크포인터 전달** — LangGraph 네이티브 config를 통한 스레드 기반 대화 상태 관리
+- **State 엔드포인트** — `GET /api/graphs/{name}/threads/{thread_id}/state`로 스레드 상태 조회 (StatefulGraph만 해당)
+- **그래프별 인증** — `register(graph, name, auth_level=...)`로 앱 수준 인증을 그래프별로 재정의
+- **OpenAPI 엔드포인트** — `GET /api/openapi.json` 자동 생성 API 스펙
 
 ## LangGraph Platform 비교
 
@@ -44,7 +47,7 @@ LangGraph 에이전트를 Azure에 배포하는 것은 생각보다 어렵습니
 |------|-------------------|--------------------------|
 | 호스팅 | LangChain Cloud (유료) | 사용자의 Azure 구독 |
 | Invoke | `POST /runs/stream` | `POST /api/graphs/{name}/invoke` |
-| 스트리밍 | True SSE | 버퍼링된 SSE (v0.1) |
+|| 스트리밍 | True SSE | 버퍼링된 SSE (v0.2) |
 | 스레드 | 내장 | LangGraph 체크포인터 사용 |
 | 인프라 | 관리형 | Azure Functions (서버리스) |
 | 비용 모델 | 사용량/좌석 기반 | Azure Functions 요금제 |
@@ -116,7 +119,9 @@ func_app = app.function_app  # ← Azure Functions 앱으로 사용
 
 1. `POST /api/graphs/echo_agent/invoke` — 에이전트 호출
 2. `POST /api/graphs/echo_agent/stream` — 에이전트 응답 스트리밍 (버퍼링된 SSE)
-3. `GET /api/health` — 헬스 체크
+3. `GET /api/graphs/echo_agent/threads/{thread_id}/state` — 스레드 상태 조회
+4. `GET /api/health` — 헬스 체크
+5. `GET /api/openapi.json` — OpenAPI 스펙
 
 ### 요청 형식
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -12,7 +12,7 @@
 
 本文档语言: [한국어](README.ko.md) | [日本語](README.ja.md) | **简体中文** | [English](README.md)
 
-> **Alpha 版本说明** — 此软件包处于早期开发阶段（`0.1.0a0`）。API 可能在版本之间发生不兼容变更。在生产环境使用前请进行充分测试。
+> **Beta 版本说明** — 此软件包正在积极开发中（`0.2.0`）。核心 API 趋于稳定，但可能在小版本之间发生变更。请在 GitHub 上报告问题。
 
 将 [LangGraph](https://github.com/langchain-ai/langgraph) 智能体零样板代码部署为 **Azure Functions** HTTP 端点。
 
@@ -37,6 +37,9 @@
 - **Health 端点** — `GET /api/health` 列出已注册图及检查点器状态
 - **基于协议** — 与任何具有 `invoke()` 和 `stream()` 方法的对象兼容，不限于 LangGraph
 - **检查点器透传** — 通过 LangGraph 原生 config 实现基于线程的对话状态管理
+- **State 端点** — `GET /api/graphs/{name}/threads/{thread_id}/state` 用于线程状态检查（仅 StatefulGraph）
+- **按图认证** — `register(graph, name, auth_level=...)` 按图覆盖应用级认证
+- **OpenAPI 端点** — `GET /api/openapi.json` 自动生成 API 规范
 
 ## 与 LangGraph Platform 对比
 
@@ -44,7 +47,7 @@
 |------|-------------------|--------------------------|
 | 托管 | LangChain Cloud（付费） | 您的 Azure 订阅 |
 | Invoke | `POST /runs/stream` | `POST /api/graphs/{name}/invoke` |
-| 流式传输 | True SSE | 缓冲式 SSE（v0.1） |
+|| 流式传输 | True SSE | 缓冲式 SSE（v0.2） |
 | 线程 | 内置 | 通过 LangGraph 检查点器 |
 | 基础设施 | 托管服务 | Azure Functions（无服务器） |
 | 成本模型 | 按使用量/座位 | Azure Functions 定价 |
@@ -116,7 +119,9 @@ func_app = app.function_app  # ← 用作 Azure Functions 应用
 
 1. `POST /api/graphs/echo_agent/invoke` — 调用智能体
 2. `POST /api/graphs/echo_agent/stream` — 流式传输智能体响应（缓冲式 SSE）
-3. `GET /api/health` — 健康检查
+3. `GET /api/graphs/echo_agent/threads/{thread_id}/state` — 检查线程状态
+4. `GET /api/health` — 健康检查
+5. `GET /api/openapi.json` — OpenAPI 规范
 
 ### 请求格式
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -13,6 +13,8 @@ flowchart LR
     E --> F["POST /graphs/{name}/invoke"]
     E --> G["POST /graphs/{name}/stream"]
     E --> H[GET /health]
+    E --> I["GET /graphs/{name}/threads/{id}/state"]
+    E --> J[GET /openapi.json]
 ```
 
 ## Request flow
@@ -67,7 +69,7 @@ src/azure_functions_langgraph/
 ├── __init__.py       # Package init, lazy LangGraphApp import, __version__
 ├── app.py            # LangGraphApp class, route registration, request handlers
 ├── contracts.py      # Pydantic request/response models
-├── protocols.py      # Protocol interfaces (InvocableGraph, StreamableGraph, LangGraphLike)
+├── protocols.py      # Protocol interfaces (InvocableGraph, StreamableGraph, StatefulGraph, LangGraphLike)
 └── py.typed          # PEP 561 marker for typed package
 ```
 
@@ -78,6 +80,9 @@ The core module. Contains:
 - `LangGraphApp` — main class, a dataclass that holds graph registrations and builds an `azure.functions.FunctionApp`
 - `_GraphRegistration` — internal record for a registered graph
 - `_handle_invoke()` — parses request, calls `graph.invoke()`, returns JSON
+- `_handle_stream()` — parses request, calls `graph.stream()`, collects chunks into buffered SSE
+- `_handle_state()` — retrieves thread state via `graph.get_state()` for StatefulGraph instances
+- `_build_openapi()` — generates OpenAPI 3.0 spec from registered graphs
 - `_handle_stream()` — parses request, calls `graph.stream()`, collects chunks into buffered SSE
 - `_error_response()` — consistent error response builder
 
@@ -91,12 +96,17 @@ Pydantic v2 models for request/response validation:
 - `HealthResponse` — status + list of GraphInfo
 - `ErrorResponse` — error + detail
 - `GraphInfo` — name, description, has_checkpointer
+- `StateResponse` — thread state values, next steps, metadata, config, timestamps
+- `GraphInfo` — name, description, has_checkpointer
 
 ### `protocols.py`
 
 `typing.Protocol` interfaces with `@runtime_checkable`:
 
 - `InvocableGraph` — has `invoke(input, config)`
+- `StreamableGraph` — has `stream(input, config, stream_mode)`
+- `LangGraphLike` — combines both (matches `CompiledStateGraph`)
+- `StatefulGraph` — has `get_state(config)` for thread state inspection
 - `StreamableGraph` — has `stream(input, config, stream_mode)`
 - `LangGraphLike` — combines both (matches `CompiledStateGraph`)
 
@@ -127,3 +137,11 @@ Azure Functions Python worker does not support true chunked HTTP streaming. In v
 ### Thread ID in request body
 
 Following LangGraph conventions, `thread_id` is passed in `config.configurable.thread_id`, not as a URL path parameter. This keeps the API surface minimal and matches LangGraph's native client expectations.
+
+### Per-graph auth override (v0.2)
+
+Each graph registration can override the app-level `auth_level`. This allows mixed-auth deployments (e.g., public-facing graphs with `ANONYMOUS` auth and admin graphs with `FUNCTION` keys).
+
+### State endpoint via StatefulGraph (v0.2)
+
+Graphs compiled with a checkpointer implement the `StatefulGraph` protocol (`get_state(config)`). These graphs automatically get a state inspection endpoint. The protocol check uses `isinstance()` with `@runtime_checkable`, consistent with the existing protocol pattern.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -15,7 +15,7 @@ app.register(graph=builder, name="agent")
 
 ## Does this support true SSE streaming?
 
-Not in v0.1. The stream endpoint collects all chunks from `graph.stream()` into memory, then returns them as a single SSE-formatted HTTP response. This is a limitation of the Azure Functions Python worker, which does not support chunked transfer encoding.
+Not yet. In v0.2, the stream endpoint collects all chunks from `graph.stream()` into memory, then returns them as a single SSE-formatted HTTP response. This is a limitation of the Azure Functions Python worker, which does not support chunked transfer encoding.
 
 True streaming support is planned for a future release.
 
@@ -79,7 +79,7 @@ app = LangGraphApp(auth_level=func.AuthLevel.FUNCTION)
 | Feature | LangGraph Platform | azure-functions-langgraph |
 |---------|-------------------|--------------------------|
 | Hosting | LangChain Cloud (paid) | Your Azure subscription |
-| Streaming | True SSE | Buffered SSE (v0.1) |
+| Streaming | True SSE | Buffered SSE (v0.2) |
 | Threads | Built-in | Via LangGraph checkpointer |
 | Infrastructure | Managed | Azure Functions (serverless) |
 | Cost model | Per-seat/usage | Azure Functions pricing |
@@ -91,3 +91,24 @@ No. This package requires the Azure Functions Python **v2 programming model** (t
 ## What Python versions are supported?
 
 Python 3.10, 3.11, 3.12, 3.13, and 3.14.
+
+Python 3.10, 3.11, 3.12, 3.13, and 3.14.
+
+## What is the state endpoint?
+
+The state endpoint (`GET /api/graphs/{name}/threads/{thread_id}/state`) lets you inspect the current state of a conversation thread. It's only available for graphs compiled with a checkpointer (graphs satisfying the `StatefulGraph` protocol).
+
+## Can I set different auth levels per graph?
+
+Yes, as of v0.2.0. Use the `auth_level` parameter in `register()`:
+
+```python
+app.register(graph=public_graph, name="public", auth_level=func.AuthLevel.ANONYMOUS)
+app.register(graph=private_graph, name="private", auth_level=func.AuthLevel.FUNCTION)
+```
+
+This overrides the app-level `auth_level` for that specific graph's endpoints.
+
+## What is the OpenAPI endpoint?
+
+`GET /api/openapi.json` returns an auto-generated OpenAPI 3.0 specification for all registered graphs. This is useful for API documentation and client generation.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -10,6 +10,8 @@ When you register a graph named `my_agent`, the following endpoints are created:
 |--------|-------|-------------|
 | `POST` | `/api/graphs/my_agent/invoke` | Synchronous graph invocation |
 | `POST` | `/api/graphs/my_agent/stream` | Buffered SSE streaming |
+| `GET` | `/api/graphs/my_agent/threads/{thread_id}/state` | Thread state inspection |
+| `GET` | `/api/openapi.json` | OpenAPI specification |
 | `GET` | `/api/health` | Health check with registered graph list |
 
 ## Invoke endpoint
@@ -104,7 +106,8 @@ event: end
 data: {}
 ```
 
-!!! warning "Buffered streaming (v0.1)"
+!!! warning "Buffered streaming (v0.2)"
+    In v0.2, streaming is **buffered** — all chunks are collected first, then returned as a single SSE-formatted HTTP response. This is not true chunked streaming. True streaming support is planned for a future release.
     In v0.1, streaming is **buffered** — all chunks are collected first, then returned as a single SSE-formatted HTTP response. This is not true chunked streaming. True streaming support is planned for a future release.
 
 ### Stream error handling
@@ -142,6 +145,58 @@ GET /api/health
 }
 ```
 
+## State endpoint
+
+### Request
+
+```
+GET /api/graphs/{name}/threads/{thread_id}/state
+```
+
+Returns the current state of a thread for graphs compiled with a checkpointer (graphs satisfying the `StatefulGraph` protocol).
+
+### Response
+
+```json
+{
+    "values": {"messages": [...]},
+    "next": [],
+    "metadata": {"source": "loop", "step": 2},
+    "config": {"configurable": {"thread_id": "session-123"}},
+    "created_at": "2025-01-01T00:00:00Z",
+    "parent_config": null
+}
+```
+
+| Status Code | Condition |
+|-------------|----------|
+| 200 | Thread state found |
+| 404 | Thread not found or graph is not stateful |
+| 500 | Internal error |
+
+## OpenAPI endpoint
+
+### Request
+
+```
+GET /api/openapi.json
+```
+
+Returns an auto-generated OpenAPI 3.0 specification for all registered graphs.
+
+### Response
+
+```json
+{
+    "openapi": "3.0.3",
+    "info": {"title": "LangGraph API", "version": "0.2.0"},
+    "paths": {
+        "/api/graphs/my_agent/invoke": {...},
+        "/api/graphs/my_agent/stream": {...}
+    }
+}
+```
+
 ## Error responses
 
 All error responses follow a consistent format:
@@ -159,6 +214,7 @@ All error responses follow a consistent format:
 | 422 | Request validation error (missing/invalid fields) |
 | 500 | Graph execution failed |
 | 501 | Stream requested on a graph that does not support `stream()` |
+| 404 | Thread not found (state endpoint) |
 
 ## Using with checkpointers
 
@@ -202,3 +258,21 @@ If your graph only supports `invoke()` (no `stream()` method), you can still reg
     "detail": "Graph 'my_agent' does not support streaming"
 }
 ```
+
+## Per-graph authentication
+
+Override the app-level auth for individual graphs:
+
+```python
+import azure.functions as func
+
+app = LangGraphApp(auth_level=func.AuthLevel.FUNCTION)
+
+# Public graph — no auth required
+app.register(graph=public_graph, name="public", auth_level=func.AuthLevel.ANONYMOUS)
+
+# Admin graph — requires master key
+app.register(graph=admin_graph, name="admin", auth_level=func.AuthLevel.ADMIN)
+```
+
+When `auth_level` is passed to `register()`, it overrides the app-level setting for that graph's endpoints only.


### PR DESCRIPTION
## Summary

Comprehensive documentation update to reflect all v0.2.0 features across 7 files.

## Changes

### DESIGN.md
- Architecture diagram now shows state endpoint and OpenAPI routes
- Added Key Decisions #5 (per-graph auth override) and #6 (StatefulGraph protocol)
- Module structure includes `protocols.py`
- Testing strategy updated: 105 tests, 98%+ coverage, FakeStatefulGraph

### i18n READMEs (ko, ja, zh-CN)
- Alpha → Beta notice (0.1.0a0 → 0.2.0)
- Added state endpoint, per-graph auth, OpenAPI features
- Comparison table updated to v0.2
- Endpoint list expanded from 3 to 5

### docs/usage.md
- State endpoint section with request/response format
- OpenAPI endpoint section
- Per-graph authentication section
- Updated buffered streaming version references
- Added 404 status code for state endpoint errors

### docs/architecture.md
- Mermaid flowchart includes state + openapi routes
- Module descriptions updated (StatefulGraph, StateResponse)
- New design decision sections for per-graph auth and StatefulGraph

### docs/faq.md
- FAQ: "What is the state endpoint?"
- FAQ: "Can I set different auth levels per graph?"
- FAQ: "What is the OpenAPI endpoint?"
- Comparison table updated to v0.2

## Tests
- 105 tests pass, 98.43% coverage (doc-only changes, no code impact)

## Milestone
v0.3.0 — Phase 1: Documentation Debt

Closes #32, closes #33, closes #34