### PR TITLE
refactor: Extract handlers and create platform/ subpackage

### DIFF
--- a/src/azure_functions_langgraph/_handlers.py
+++ b/src/azure_functions_langgraph/_handlers.py
@@ -1,0 +1,214 @@
+"""Internal request handlers for native graph endpoints.
+
+These are standalone functions extracted from ``LangGraphApp`` to keep
+``app.py`` focused on registration and route wiring.  Each function
+receives only the explicit dependencies it needs — no reference to
+``LangGraphApp`` itself.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+import azure.functions as func
+
+from azure_functions_langgraph.contracts import (
+    ErrorResponse,
+    InvokeRequest,
+    InvokeResponse,
+    StateResponse,
+    StreamRequest,
+)
+from azure_functions_langgraph.protocols import StatefulGraph, StreamableGraph
+
+logger = logging.getLogger(__name__)
+
+
+# ------------------------------------------------------------------
+# Shared helper
+# ------------------------------------------------------------------
+
+
+def _error_response(status_code: int, detail: str) -> func.HttpResponse:
+    body = ErrorResponse(error="error", detail=detail)
+    return func.HttpResponse(
+        body=body.model_dump_json(),
+        mimetype="application/json",
+        status_code=status_code,
+    )
+
+
+# ------------------------------------------------------------------
+# Invoke handler
+# ------------------------------------------------------------------
+
+
+def handle_invoke(
+    req: func.HttpRequest,
+    reg: Any,
+) -> func.HttpResponse:
+    """Handle a synchronous invoke request."""
+    try:
+        body = req.get_json()
+    except ValueError:
+        return _error_response(400, "Invalid JSON body")
+
+    try:
+        request = InvokeRequest.model_validate(body)
+    except Exception as exc:
+        return _error_response(422, f"Validation error: {exc}")
+
+    config = request.config or {}
+    try:
+        result = reg.graph.invoke(request.input, config=config)
+    except Exception as exc:
+        logger.exception("Graph %s invoke failed", reg.name)
+        _ = exc
+        return _error_response(500, "Graph execution failed")
+
+    output = result if isinstance(result, dict) else {"result": result}
+    response = InvokeResponse(output=output)
+    return func.HttpResponse(
+        body=response.model_dump_json(),
+        mimetype="application/json",
+        status_code=200,
+    )
+
+
+# ------------------------------------------------------------------
+# Stream handler
+# ------------------------------------------------------------------
+
+
+def handle_stream(
+    req: func.HttpRequest,
+    reg: Any,
+    *,
+    max_stream_response_bytes: int,
+) -> func.HttpResponse:
+    """Handle a streaming request.
+
+    Returns a **buffered** SSE-formatted response.  All stream chunks are
+    collected first, then returned in a single HTTP response.  This is a
+    known v0.1 limitation — true chunked streaming will follow once Azure
+    Functions Python HTTP streaming is fully stable.
+    """
+    if not reg.stream_enabled:
+        return _error_response(501, f"Graph {reg.name!r} is configured as invoke-only")
+
+    if not isinstance(reg.graph, StreamableGraph):
+        return _error_response(501, f"Graph {reg.name!r} does not support streaming")
+
+    try:
+        body = req.get_json()
+    except ValueError:
+        return _error_response(400, "Invalid JSON body")
+
+    try:
+        request = StreamRequest.model_validate(body)
+    except Exception as exc:
+        return _error_response(422, f"Validation error: {exc}")
+
+    config = request.config or {}
+    chunks: list[str] = []
+    buffered_bytes = 0
+
+    def _append_chunk(chunk: str) -> bool:
+        nonlocal buffered_bytes
+        chunk_bytes = len(chunk.encode())
+        if buffered_bytes + chunk_bytes > max_stream_response_bytes:
+            error_payload = json.dumps(
+                {
+                    "error": (
+                        "stream response exceeded max buffered size "
+                        f"({max_stream_response_bytes} bytes)"
+                    )
+                }
+            )
+            chunks.append(f"event: error\ndata: {error_payload}\n\n")
+            return False
+        chunks.append(chunk)
+        buffered_bytes += chunk_bytes
+        return True
+
+    try:
+        for event in reg.graph.stream(
+            request.input,
+            config=config,
+            stream_mode=request.stream_mode,
+        ):
+            serialized = json.dumps(
+                event if isinstance(event, dict) else {"data": str(event)},
+                default=str,
+            )
+            if not _append_chunk(f"event: data\ndata: {serialized}\n\n"):
+                break
+    except Exception as exc:
+        logger.exception("Graph %s stream failed", reg.name)
+        _ = exc
+        error_payload = json.dumps({"error": "stream processing failed"})
+        _append_chunk(f"event: error\ndata: {error_payload}\n\n")
+
+    _append_chunk("event: end\ndata: {}\n\n")
+
+    return func.HttpResponse(
+        body="".join(chunks),
+        mimetype="text/event-stream",
+        status_code=200,
+        headers={
+            "Cache-Control": "no-cache",
+            "X-Accel-Buffering": "no",
+        },
+    )
+
+
+# ------------------------------------------------------------------
+# State handler
+# ------------------------------------------------------------------
+
+
+def handle_state(
+    req: func.HttpRequest,
+    reg: Any,
+) -> func.HttpResponse:
+    """Handle a GET request for thread state."""
+    if not isinstance(reg.graph, StatefulGraph):
+        return _error_response(
+            409, f"Graph {reg.name!r} does not support state retrieval"
+        )
+
+    thread_id = req.route_params.get("thread_id")
+    if not thread_id:
+        return _error_response(400, "Missing thread_id in URL path")
+
+    config: dict[str, Any] = {"configurable": {"thread_id": thread_id}}
+
+    try:
+        snapshot = reg.graph.get_state(config)
+    except (KeyError, ValueError):
+        logger.warning(
+            "Graph %s: thread %s not found", reg.name, thread_id
+        )
+        return _error_response(404, f"Thread {thread_id!r} not found")
+    except Exception:
+        logger.exception(
+            "Graph %s get_state failed for thread %s", reg.name, thread_id
+        )
+        return _error_response(
+            500, "Internal error while retrieving thread state"
+        )
+
+    values = snapshot.values if isinstance(snapshot.values, dict) else {}
+    next_nodes: list[str] = list(snapshot.next) if hasattr(snapshot, "next") else []
+    metadata = (
+        dict(snapshot.metadata) if hasattr(snapshot, "metadata") and snapshot.metadata else None
+    )
+
+    response = StateResponse(values=values, next=next_nodes, metadata=metadata)
+    return func.HttpResponse(
+        body=json.dumps(response.model_dump(), default=str),
+        mimetype="application/json",
+        status_code=200,
+    )

--- a/src/azure_functions_langgraph/app.py
+++ b/src/azure_functions_langgraph/app.py
@@ -11,16 +11,16 @@ from typing import Any, Optional
 import azure.functions as func
 
 from azure_functions_langgraph import __version__
+from azure_functions_langgraph._handlers import (
+    handle_invoke,
+    handle_state,
+    handle_stream,
+)
 from azure_functions_langgraph.contracts import (
-    ErrorResponse,
     GraphInfo,
     HealthResponse,
-    InvokeRequest,
-    InvokeResponse,
-    StateResponse,
-    StreamRequest,
 )
-from azure_functions_langgraph.protocols import InvocableGraph, StatefulGraph, StreamableGraph
+from azure_functions_langgraph.protocols import InvocableGraph, StatefulGraph
 
 logger = logging.getLogger(__name__)
 
@@ -211,156 +211,26 @@ class LangGraphApp:
         return self.auth_level
 
     # ------------------------------------------------------------------
-    # Request handlers
+    # Request handlers (thin delegation to _handlers module)
     # ------------------------------------------------------------------
 
     def _handle_invoke(self, req: func.HttpRequest, reg: _GraphRegistration) -> func.HttpResponse:
         """Handle a synchronous invoke request."""
-        try:
-            body = req.get_json()
-        except ValueError:
-            return _error_response(400, "Invalid JSON body")
-
-        try:
-            request = InvokeRequest.model_validate(body)
-        except Exception as exc:
-            return _error_response(422, f"Validation error: {exc}")
-
-        config = request.config or {}
-        try:
-            result = reg.graph.invoke(request.input, config=config)
-        except Exception as exc:
-            logger.exception("Graph %s invoke failed", reg.name)
-            _ = exc
-            return _error_response(500, "Graph execution failed")
-
-        output = result if isinstance(result, dict) else {"result": result}
-        response = InvokeResponse(output=output)
-        return func.HttpResponse(
-            body=response.model_dump_json(),
-            mimetype="application/json",
-            status_code=200,
-        )
+        return handle_invoke(req, reg)
 
     def _handle_stream(self, req: func.HttpRequest, reg: _GraphRegistration) -> func.HttpResponse:
-        """Handle a streaming request.
-
-        Returns a **buffered** SSE-formatted response.  All stream chunks are
-        collected first, then returned in a single HTTP response.  This is a
-        known v0.1 limitation — true chunked streaming will follow once Azure
-        Functions Python HTTP streaming is fully stable.
-        """
-        if not reg.stream_enabled:
-            return _error_response(501, f"Graph {reg.name!r} is configured as invoke-only")
-
-        if not isinstance(reg.graph, StreamableGraph):
-            return _error_response(501, f"Graph {reg.name!r} does not support streaming")
-
-        try:
-            body = req.get_json()
-        except ValueError:
-            return _error_response(400, "Invalid JSON body")
-
-        try:
-            request = StreamRequest.model_validate(body)
-        except Exception as exc:
-            return _error_response(422, f"Validation error: {exc}")
-
-        config = request.config or {}
-        chunks: list[str] = []
-        buffered_bytes = 0
-
-        def _append_chunk(chunk: str) -> bool:
-            nonlocal buffered_bytes
-            chunk_bytes = len(chunk.encode())
-            if buffered_bytes + chunk_bytes > self.max_stream_response_bytes:
-                error_payload = json.dumps(
-                    {
-                        "error": (
-                            "stream response exceeded max buffered size "
-                            f"({self.max_stream_response_bytes} bytes)"
-                        )
-                    }
-                )
-                chunks.append(f"event: error\ndata: {error_payload}\n\n")
-                return False
-            chunks.append(chunk)
-            buffered_bytes += chunk_bytes
-            return True
-
-        try:
-            for event in reg.graph.stream(
-                request.input,
-                config=config,
-                stream_mode=request.stream_mode,
-            ):
-                serialized = json.dumps(
-                    event if isinstance(event, dict) else {"data": str(event)},
-                    default=str,
-                )
-                if not _append_chunk(f"event: data\ndata: {serialized}\n\n"):
-                    break
-        except Exception as exc:
-            logger.exception("Graph %s stream failed", reg.name)
-            _ = exc
-            error_payload = json.dumps({"error": "stream processing failed"})
-            _append_chunk(f"event: error\ndata: {error_payload}\n\n")
-
-        _append_chunk("event: end\ndata: {}\n\n")
-
-        return func.HttpResponse(
-            body="".join(chunks),
-            mimetype="text/event-stream",
-            status_code=200,
-            headers={
-                "Cache-Control": "no-cache",
-                "X-Accel-Buffering": "no",
-            },
-        )
-
+        """Handle a streaming request."""
+        return handle_stream(req, reg, max_stream_response_bytes=self.max_stream_response_bytes)
 
     def _handle_state(
         self, req: func.HttpRequest, reg: _GraphRegistration
     ) -> func.HttpResponse:
         """Handle a GET request for thread state."""
-        if not isinstance(reg.graph, StatefulGraph):
-            return _error_response(
-                409, f"Graph {reg.name!r} does not support state retrieval"
-            )
+        return handle_state(req, reg)
 
-        thread_id = req.route_params.get("thread_id")
-        if not thread_id:
-            return _error_response(400, "Missing thread_id in URL path")
-
-        config: dict[str, Any] = {"configurable": {"thread_id": thread_id}}
-
-        try:
-            snapshot = reg.graph.get_state(config)
-        except (KeyError, ValueError):
-            logger.warning(
-                "Graph %s: thread %s not found", reg.name, thread_id
-            )
-            return _error_response(404, f"Thread {thread_id!r} not found")
-        except Exception:
-            logger.exception(
-                "Graph %s get_state failed for thread %s", reg.name, thread_id
-            )
-            return _error_response(
-                500, "Internal error while retrieving thread state"
-            )
-
-        values = snapshot.values if isinstance(snapshot.values, dict) else {}
-        next_nodes: list[str] = list(snapshot.next) if hasattr(snapshot, "next") else []
-        metadata = (
-            dict(snapshot.metadata) if hasattr(snapshot, "metadata") and snapshot.metadata else None
-        )
-
-        response = StateResponse(values=values, next=next_nodes, metadata=metadata)
-        return func.HttpResponse(
-            body=json.dumps(response.model_dump(), default=str),
-            mimetype="application/json",
-            status_code=200,
-        )
+    # ------------------------------------------------------------------
+    # OpenAPI
+    # ------------------------------------------------------------------
 
     def _build_openapi(self) -> dict[str, Any]:
         """Build OpenAPI 3.0.3 specification from registered graphs."""
@@ -425,12 +295,3 @@ class LangGraphApp:
 def _has_checkpointer(graph: Any) -> bool:
     """Check whether a compiled graph has a checkpointer attached."""
     return getattr(graph, "checkpointer", None) is not None
-
-
-def _error_response(status_code: int, detail: str) -> func.HttpResponse:
-    body = ErrorResponse(error="error", detail=detail)
-    return func.HttpResponse(
-        body=body.model_dump_json(),
-        mimetype="application/json",
-        status_code=status_code,
-    )

--- a/src/azure_functions_langgraph/platform/__init__.py
+++ b/src/azure_functions_langgraph/platform/__init__.py
@@ -1,0 +1,16 @@
+"""LangGraph Platform API compatibility layer.
+
+This subpackage provides opt-in compatibility with the LangGraph Platform
+SDK (``langgraph-sdk``).  When enabled via ``LangGraphApp(platform_compat=True)``,
+additional routes are registered that mirror the LangGraph Platform REST API,
+allowing the official SDK client to communicate with Azure Functions–hosted graphs.
+
+Modules:
+
+- ``contracts`` — Pydantic models for Platform API request/response shapes
+- ``stores`` — ThreadStore protocol and in-memory implementation
+- ``routes`` — Route registration for Platform-compatible endpoints
+- ``sse`` — SSE format rewriter (Platform wire format)
+
+.. versionadded:: 0.3.0
+"""


### PR DESCRIPTION
## Summary

Extract request handler logic from `LangGraphApp` into standalone functions in `_handlers.py` and create the `platform/` subpackage structure for upcoming LangGraph Platform API compatibility (v0.3.0).

## Changes

### `_handlers.py` (NEW — 215 lines)
- `handle_invoke(req, reg)` — synchronous invoke request handling
- `handle_stream(req, reg, *, max_stream_response_bytes)` — buffered SSE stream handling
- `handle_state(req, reg)` — thread state retrieval handling
- `_error_response(status_code, detail)` — shared error response helper

### `app.py` (436 → 297 lines)
- `LangGraphApp._handle_invoke/stream/state` are now thin delegation stubs
- Route registration, health/openapi endpoints, and orchestration remain
- All imports updated; unused contract imports removed

### `platform/__init__.py` (NEW — 17 lines)
- Docstring placeholder for `contracts`, `stores`, `routes`, `sse` modules
- Ready for #36-#39 implementation

## Design Decisions (Oracle-reviewed)
- **Option B (narrowed)**: Extract handlers, skip `_helpers.py` junk drawer, keep route registration in app.py
- Thin delegation stubs preserve all 73 test_app.py call patterns → zero test changes
- `_GraphRegistration` stays private, cross-module use within package is acceptable
- Platform integration hook deferred to #38 (explicit call in `_build_function_app()`)

## Verification
- ✅ 105 tests pass (zero test changes required)
- ✅ Coverage: 98.50% (up from 98.43%)
- ✅ `make lint` clean
- ✅ `make typecheck` clean
- ✅ Public API surface unchanged

Closes #35