### PR TITLE
feat: add ThreadStore protocol and InMemoryThreadStore (#37)

### DIFF
--- a/src/azure_functions_langgraph/platform/stores.py
+++ b/src/azure_functions_langgraph/platform/stores.py
@@ -1,0 +1,243 @@
+"""Thread storage protocol and in-memory implementation.
+
+The ``ThreadStore`` protocol defines CRUD + search for Platform API
+thread metadata.  Threads are independent of LangGraph checkpoint state
+and can exist before any graph execution.
+
+``InMemoryThreadStore`` is the default implementation for development and
+single-process deployments.  For production scale-out, implement
+``ThreadStore`` against a durable backend (e.g. Azure Table Storage).
+
+.. versionadded:: 0.3.0
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import threading
+from typing import Any, Callable, Mapping, Optional, Protocol, runtime_checkable
+import uuid
+
+from azure_functions_langgraph.platform.contracts import (
+    Interrupt,
+    Thread,
+    ThreadStatus,
+)
+
+# ---------------------------------------------------------------------------
+# Protocol
+# ---------------------------------------------------------------------------
+
+
+@runtime_checkable
+class ThreadStore(Protocol):
+    """Protocol for thread metadata persistence.
+
+    Implementations must be safe for concurrent use from multiple request
+    handlers.
+
+    * ``get`` returns ``None`` when the thread does not exist.
+    * ``update`` and ``delete`` raise ``KeyError`` for missing threads.
+    * ``search`` filters by exact top-level metadata subset match.
+    """
+
+    def create(self, *, metadata: Mapping[str, Any] | None = None) -> Thread:
+        """Create a new thread and return it."""
+        ...
+
+    def get(self, thread_id: str) -> Thread | None:
+        """Return the thread or ``None`` if not found."""
+        ...
+
+    def update(
+        self,
+        thread_id: str,
+        *,
+        metadata: Mapping[str, Any] | None = None,
+        status: ThreadStatus | None = None,
+        values: dict[str, Any] | None = None,
+        interrupts: dict[str, list[Interrupt]] | None = None,
+    ) -> Thread:
+        """Partially update a thread.
+
+        Only provided (non-``None``) fields are changed.  Raises
+        ``KeyError`` if the thread does not exist.
+        """
+        ...
+
+    def delete(self, thread_id: str) -> None:
+        """Delete a thread.
+
+        Raises ``KeyError`` if the thread does not exist.
+        """
+        ...
+
+    def search(
+        self,
+        *,
+        metadata: Mapping[str, Any] | None = None,
+        status: ThreadStatus | None = None,
+        limit: int = 10,
+        offset: int = 0,
+    ) -> list[Thread]:
+        """Search threads with optional filters.
+
+        Filters:
+        * ``metadata`` — exact top-level key/value subset match.
+        * ``status`` — exact status match.
+
+        Results are ordered by ``created_at`` descending (newest first).
+        """
+        ...
+
+
+# ---------------------------------------------------------------------------
+# In-memory implementation
+# ---------------------------------------------------------------------------
+
+
+class InMemoryThreadStore:
+    """Thread store backed by an in-process dictionary.
+
+    All public methods are thread-safe (guarded by ``threading.RLock``)
+    and return deep copies so callers cannot mutate persisted state.
+
+    Parameters
+    ----------
+    id_factory:
+        Callable that returns a new unique thread ID string.
+        Defaults to ``lambda: str(uuid.uuid4())``.
+    """
+
+    def __init__(
+        self,
+        *,
+        id_factory: Optional[Callable[[], str]] = None,
+    ) -> None:
+        self._threads: dict[str, Thread] = {}
+        self._lock = threading.RLock()
+        self._id_factory = id_factory or (lambda: str(uuid.uuid4()))
+
+    # -- helpers -------------------------------------------------------------
+
+    @staticmethod
+    def _now() -> datetime:
+        return datetime.now(timezone.utc)
+
+    def _deep_copy(self, thread: Thread) -> Thread:
+        """Return a deep copy of a Thread to prevent reference leaks."""
+        return thread.model_copy(deep=True)
+
+    # -- public API ----------------------------------------------------------
+
+    def create(self, *, metadata: Mapping[str, Any] | None = None) -> Thread:
+        """Create a new thread with status ``idle``."""
+        with self._lock:
+            now = self._now()
+            thread_id = self._id_factory()
+            if thread_id in self._threads:
+                raise ValueError(
+                    f"Duplicate thread ID generated: {thread_id!r}"
+                )
+            thread = Thread(
+                thread_id=thread_id,
+                created_at=now,
+                updated_at=now,
+                metadata=dict(metadata) if metadata is not None else None,
+                status="idle",
+            )
+            self._threads[thread_id] = thread
+        return self._deep_copy(thread)
+
+    def get(self, thread_id: str) -> Thread | None:
+        """Return the thread or ``None`` if not found."""
+        with self._lock:
+            thread = self._threads.get(thread_id)
+            if thread is None:
+                return None
+            return self._deep_copy(thread)
+
+    def update(
+        self,
+        thread_id: str,
+        *,
+        metadata: Mapping[str, Any] | None = None,
+        status: ThreadStatus | None = None,
+        values: dict[str, Any] | None = None,
+        interrupts: dict[str, list[Interrupt]] | None = None,
+    ) -> Thread:
+        """Partially update a thread.  Raises ``KeyError`` if not found."""
+        with self._lock:
+            if thread_id not in self._threads:
+                raise KeyError(thread_id)
+
+            existing = self._threads[thread_id]
+            data = existing.model_dump()
+            data["updated_at"] = self._now()
+
+            if metadata is not None:
+                data["metadata"] = dict(metadata)
+            if status is not None:
+                data["status"] = status
+            if values is not None:
+                data["values"] = values
+            if interrupts is not None:
+                data["interrupts"] = interrupts
+
+            updated = Thread.model_validate(data)
+            self._threads[thread_id] = updated
+            return self._deep_copy(updated)
+
+    def delete(self, thread_id: str) -> None:
+        """Delete a thread.  Raises ``KeyError`` if not found."""
+        with self._lock:
+            if thread_id not in self._threads:
+                raise KeyError(thread_id)
+            del self._threads[thread_id]
+
+    def search(
+        self,
+        *,
+        metadata: Mapping[str, Any] | None = None,
+        status: ThreadStatus | None = None,
+        limit: int = 10,
+        offset: int = 0,
+    ) -> list[Thread]:
+        """Search threads with optional filters, newest first."""
+        if limit < 0:
+            raise ValueError(f"limit must be non-negative, got {limit}")
+        if offset < 0:
+            raise ValueError(f"offset must be non-negative, got {offset}")
+        with self._lock:
+            results: list[Thread] = []
+            for thread in self._threads.values():
+                # Status filter
+                if status is not None and thread.status != status:
+                    continue
+                # Metadata subset match
+                if metadata is not None:
+                    if thread.metadata is None:
+                        continue
+                    if not all(
+                        k in thread.metadata and thread.metadata[k] == v
+                        for k, v in metadata.items()
+                    ):
+                        continue
+                results.append(thread)
+
+            # Sort by created_at descending (newest first)
+            results.sort(key=lambda t: t.created_at, reverse=True)
+
+            # Apply offset/limit
+            page = results[offset : offset + limit]
+            return [self._deep_copy(t) for t in page]
+
+
+# ---------------------------------------------------------------------------
+# Public surface
+# ---------------------------------------------------------------------------
+
+__all__ = [
+    "ThreadStore",
+    "InMemoryThreadStore",
+]

--- a/tests/test_platform_stores.py
+++ b/tests/test_platform_stores.py
@@ -1,0 +1,511 @@
+"""Tests for platform ThreadStore protocol and InMemoryThreadStore.
+
+Validates CRUD operations, search filtering, thread-safety invariants,
+deep-copy isolation, and protocol conformance.
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import Any, Mapping
+
+import pytest
+
+from azure_functions_langgraph.platform.contracts import Interrupt, Thread, ThreadStatus
+from azure_functions_langgraph.platform.stores import InMemoryThreadStore, ThreadStore
+
+# ---------------------------------------------------------------------------
+# Protocol conformance
+# ---------------------------------------------------------------------------
+
+
+class TestProtocolConformance:
+    def test_inmemory_is_threadstore(self) -> None:
+        store = InMemoryThreadStore()
+        assert isinstance(store, ThreadStore)
+
+    def test_runtime_checkable(self) -> None:
+        """ThreadStore is @runtime_checkable."""
+        assert isinstance(InMemoryThreadStore(), ThreadStore)
+
+
+# ---------------------------------------------------------------------------
+# Create
+# ---------------------------------------------------------------------------
+
+
+class TestCreate:
+    def test_create_returns_thread(self) -> None:
+        store = InMemoryThreadStore()
+        thread = store.create()
+        assert isinstance(thread, Thread)
+        assert thread.thread_id
+        assert thread.status == "idle"
+        assert thread.metadata is None
+        assert thread.values is None
+        assert thread.interrupts == {}
+
+    def test_create_with_metadata(self) -> None:
+        store = InMemoryThreadStore()
+        thread = store.create(metadata={"user_id": "u-1", "env": "test"})
+        assert thread.metadata == {"user_id": "u-1", "env": "test"}
+
+    def test_create_sets_timestamps(self) -> None:
+        store = InMemoryThreadStore()
+        thread = store.create()
+        assert thread.created_at.tzinfo is not None
+        assert thread.updated_at.tzinfo is not None
+        assert thread.created_at == thread.updated_at
+
+    def test_create_generates_unique_ids(self) -> None:
+        store = InMemoryThreadStore()
+        ids = {store.create().thread_id for _ in range(50)}
+        assert len(ids) == 50
+
+    def test_create_with_custom_id_factory(self) -> None:
+        counter = iter(range(100))
+        store = InMemoryThreadStore(id_factory=lambda: f"custom-{next(counter)}")
+        t1 = store.create()
+        t2 = store.create()
+        assert t1.thread_id == "custom-0"
+        assert t2.thread_id == "custom-1"
+
+    def test_create_returns_deep_copy(self) -> None:
+        """Mutating the returned thread must not affect stored state."""
+        store = InMemoryThreadStore()
+        thread = store.create(metadata={"key": "original"})
+        # Mutate the returned object
+        assert thread.metadata is not None
+        thread.metadata["key"] = "mutated"
+        # Verify stored state is unchanged
+        stored = store.get(thread.thread_id)
+        assert stored is not None
+        assert stored.metadata == {"key": "original"}
+
+
+# ---------------------------------------------------------------------------
+# Get
+# ---------------------------------------------------------------------------
+
+
+class TestGet:
+    def test_get_existing(self) -> None:
+        store = InMemoryThreadStore()
+        created = store.create(metadata={"k": "v"})
+        fetched = store.get(created.thread_id)
+        assert fetched is not None
+        assert fetched.thread_id == created.thread_id
+        assert fetched.metadata == {"k": "v"}
+
+    def test_get_nonexistent_returns_none(self) -> None:
+        store = InMemoryThreadStore()
+        assert store.get("nonexistent") is None
+
+    def test_get_returns_deep_copy(self) -> None:
+        """Mutating a fetched thread must not affect stored state."""
+        store = InMemoryThreadStore()
+        created = store.create(metadata={"key": "val"})
+        fetched = store.get(created.thread_id)
+        assert fetched is not None
+        assert fetched.metadata is not None
+        fetched.metadata["key"] = "mutated"
+        refetched = store.get(created.thread_id)
+        assert refetched is not None
+        assert refetched.metadata == {"key": "val"}
+
+
+# ---------------------------------------------------------------------------
+# Update
+# ---------------------------------------------------------------------------
+
+
+class TestUpdate:
+    def test_update_metadata(self) -> None:
+        store = InMemoryThreadStore()
+        thread = store.create()
+        updated = store.update(thread.thread_id, metadata={"new": "data"})
+        assert updated.metadata == {"new": "data"}
+
+    def test_update_status(self) -> None:
+        store = InMemoryThreadStore()
+        thread = store.create()
+        updated = store.update(thread.thread_id, status="busy")
+        assert updated.status == "busy"
+
+    def test_update_values(self) -> None:
+        store = InMemoryThreadStore()
+        thread = store.create()
+        updated = store.update(thread.thread_id, values={"messages": [{"role": "user"}]})
+        assert updated.values == {"messages": [{"role": "user"}]}
+
+    def test_update_interrupts(self) -> None:
+        store = InMemoryThreadStore()
+        thread = store.create()
+        interrupts = {"node_a": [Interrupt(id="i-1", value="pause")]}
+        updated = store.update(thread.thread_id, interrupts=interrupts)
+        assert len(updated.interrupts["node_a"]) == 1
+
+    def test_update_is_partial(self) -> None:
+        """Only provided fields are changed; others remain untouched."""
+        store = InMemoryThreadStore()
+        thread = store.create(metadata={"original": True})
+        updated = store.update(thread.thread_id, status="busy")
+        assert updated.status == "busy"
+        assert updated.metadata == {"original": True}  # unchanged
+
+    def test_update_bumps_updated_at(self) -> None:
+        store = InMemoryThreadStore()
+        thread = store.create()
+        original_updated = thread.updated_at
+        updated = store.update(thread.thread_id, status="busy")
+        assert updated.updated_at >= original_updated
+
+    def test_update_preserves_created_at(self) -> None:
+        store = InMemoryThreadStore()
+        thread = store.create()
+        updated = store.update(thread.thread_id, status="busy")
+        assert updated.created_at == thread.created_at
+
+    def test_update_nonexistent_raises_keyerror(self) -> None:
+        store = InMemoryThreadStore()
+        with pytest.raises(KeyError):
+            store.update("nonexistent", status="busy")
+
+    def test_update_returns_deep_copy(self) -> None:
+        store = InMemoryThreadStore()
+        thread = store.create(metadata={"key": "val"})
+        updated = store.update(thread.thread_id, status="busy")
+        assert updated.metadata is not None
+        updated.metadata["key"] = "mutated"
+        refetched = store.get(thread.thread_id)
+        assert refetched is not None
+        assert refetched.metadata == {"key": "val"}
+
+    def test_update_multiple_fields(self) -> None:
+        store = InMemoryThreadStore()
+        thread = store.create()
+        updated = store.update(
+            thread.thread_id,
+            status="error",
+            metadata={"error": "timeout"},
+            values={"messages": []},
+        )
+        assert updated.status == "error"
+        assert updated.metadata == {"error": "timeout"}
+        assert updated.values == {"messages": []}
+
+
+# ---------------------------------------------------------------------------
+# Delete
+# ---------------------------------------------------------------------------
+
+
+class TestDelete:
+    def test_delete_existing(self) -> None:
+        store = InMemoryThreadStore()
+        thread = store.create()
+        store.delete(thread.thread_id)
+        assert store.get(thread.thread_id) is None
+        assert store.get(thread.thread_id) is None
+
+    def test_delete_nonexistent_raises_keyerror(self) -> None:
+        store = InMemoryThreadStore()
+        with pytest.raises(KeyError):
+            store.delete("nonexistent")
+
+    def test_delete_twice_raises_keyerror(self) -> None:
+        store = InMemoryThreadStore()
+        thread = store.create()
+        store.delete(thread.thread_id)
+        with pytest.raises(KeyError):
+            store.delete(thread.thread_id)
+
+
+# ---------------------------------------------------------------------------
+# Search
+# ---------------------------------------------------------------------------
+
+
+class TestSearch:
+    def _populate(
+        self,
+        store: InMemoryThreadStore,
+        count: int = 5,
+        metadata: Mapping[str, Any] | None = None,
+        status: ThreadStatus = "idle",
+    ) -> list[Thread]:
+        threads: list[Thread] = []
+        for _ in range(count):
+            t = store.create(metadata=dict(metadata) if metadata is not None else None)
+            if status != "idle":
+                t = store.update(t.thread_id, status=status)
+            threads.append(t)
+        return threads
+
+    def test_search_all(self) -> None:
+        store = InMemoryThreadStore()
+        self._populate(store, count=3)
+        results = store.search()
+        assert len(results) == 3
+
+    def test_search_empty_store(self) -> None:
+        store = InMemoryThreadStore()
+        results = store.search()
+        assert results == []
+
+    def test_search_by_status(self) -> None:
+        store = InMemoryThreadStore()
+        self._populate(store, count=2, status="idle")
+        self._populate(store, count=3, status="busy")
+        idle = store.search(status="idle")
+        busy = store.search(status="busy")
+        assert len(idle) == 2
+        assert len(busy) == 3
+
+    def test_search_by_metadata(self) -> None:
+        store = InMemoryThreadStore()
+        self._populate(store, count=2, metadata={"env": "prod"})
+        self._populate(store, count=3, metadata={"env": "dev"})
+        prod = store.search(metadata={"env": "prod"})
+        dev = store.search(metadata={"env": "dev"})
+        assert len(prod) == 2
+        assert len(dev) == 3
+
+    def test_search_metadata_subset_match(self) -> None:
+        """Search matches if all query keys are present in thread metadata."""
+        store = InMemoryThreadStore()
+        store.create(metadata={"env": "prod", "tier": "premium", "region": "us"})
+        store.create(metadata={"env": "prod", "tier": "free"})
+        store.create(metadata={"env": "dev"})
+
+        results = store.search(metadata={"env": "prod", "tier": "premium"})
+        assert len(results) == 1
+
+        results = store.search(metadata={"env": "prod"})
+        assert len(results) == 2
+
+    def test_search_metadata_no_match_on_none(self) -> None:
+        """Threads with None metadata should not match metadata filters."""
+        store = InMemoryThreadStore()
+        store.create()  # No metadata
+        store.create(metadata={"key": "val"})
+        results = store.search(metadata={"key": "val"})
+        assert len(results) == 1
+
+    def test_search_combined_filters(self) -> None:
+        store = InMemoryThreadStore()
+        t1 = store.create(metadata={"env": "prod"})
+        store.update(t1.thread_id, status="busy")
+        store.create(metadata={"env": "prod"})
+        # t2 stays idle
+        store.create(metadata={"env": "dev"})
+
+        results = store.search(metadata={"env": "prod"}, status="busy")
+        assert len(results) == 1
+        assert results[0].thread_id == t1.thread_id
+
+    def test_search_limit(self) -> None:
+        store = InMemoryThreadStore()
+        self._populate(store, count=10)
+        results = store.search(limit=3)
+        assert len(results) == 3
+
+    def test_search_offset(self) -> None:
+        store = InMemoryThreadStore()
+        self._populate(store, count=5)
+        all_results = store.search(limit=100)
+        offset_results = store.search(offset=2, limit=100)
+        assert len(offset_results) == 3
+        assert offset_results[0].thread_id == all_results[2].thread_id
+
+    def test_search_offset_beyond_results(self) -> None:
+        store = InMemoryThreadStore()
+        self._populate(store, count=3)
+        results = store.search(offset=10)
+        assert results == []
+
+    def test_search_ordered_newest_first(self) -> None:
+        store = InMemoryThreadStore()
+        t1 = store.create()
+        store.create()  # middle thread
+        t3 = store.create()
+        results = store.search()
+        assert results[0].thread_id == t3.thread_id
+        assert results[2].thread_id == t1.thread_id
+
+    def test_search_returns_deep_copies(self) -> None:
+        store = InMemoryThreadStore()
+        store.create(metadata={"key": "val"})
+        results = store.search()
+        assert results[0].metadata is not None
+        results[0].metadata["key"] = "mutated"
+        refetched = store.search()
+        assert refetched[0].metadata == {"key": "val"}
+
+
+# ---------------------------------------------------------------------------
+# Thread safety
+# ---------------------------------------------------------------------------
+
+
+class TestThreadSafety:
+    def test_concurrent_creates(self) -> None:
+        """Multiple threads creating simultaneously should not lose data."""
+        store = InMemoryThreadStore()
+        errors: list[Exception] = []
+
+        def create_threads(n: int) -> None:
+            try:
+                for _ in range(n):
+                    store.create(metadata={"worker": threading.current_thread().name})
+            except Exception as e:
+                errors.append(e)
+
+        threads = [threading.Thread(target=create_threads, args=(20,)) for _ in range(5)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert not errors
+        all_threads = store.search(limit=200)
+        assert len(all_threads) == 100
+
+    def test_concurrent_updates(self) -> None:
+        """Concurrent updates should not corrupt state."""
+        store = InMemoryThreadStore()
+        thread = store.create()
+        errors: list[Exception] = []
+
+        def update_thread(status: ThreadStatus) -> None:
+            try:
+                for _ in range(20):
+                    store.update(thread.thread_id, status=status)
+            except Exception as e:
+                errors.append(e)
+
+        workers = [
+            threading.Thread(target=update_thread, args=("busy",)),
+            threading.Thread(target=update_thread, args=("idle",)),
+        ]
+        for w in workers:
+            w.start()
+        for w in workers:
+            w.join()
+
+        assert not errors
+        result = store.get(thread.thread_id)
+        assert result is not None
+        assert result.status in ("busy", "idle")
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    def test_create_with_empty_metadata(self) -> None:
+        """Empty dict metadata is distinct from None metadata."""
+        store = InMemoryThreadStore()
+        thread = store.create(metadata={})
+        assert thread.metadata == {}
+
+    def test_update_metadata_to_empty_dict(self) -> None:
+        """Updating metadata to {} should set it to empty, not None."""
+        store = InMemoryThreadStore()
+        thread = store.create(metadata={"key": "val"})
+        updated = store.update(thread.thread_id, metadata={})
+        assert updated.metadata == {}
+
+    def test_all_thread_statuses(self) -> None:
+        """All valid ThreadStatus values should be settable."""
+        store = InMemoryThreadStore()
+        for status in ("idle", "busy", "interrupted", "error"):
+            thread = store.create()
+            updated = store.update(thread.thread_id, status=status)
+            assert updated.status == status
+
+    def test_create_and_immediately_delete(self) -> None:
+        store = InMemoryThreadStore()
+        thread = store.create()
+        store.delete(thread.thread_id)
+        assert store.get(thread.thread_id) is None
+
+    def test_mapping_metadata_input(self) -> None:
+        """create/update should accept Mapping, not just dict."""
+        from types import MappingProxyType
+
+        store = InMemoryThreadStore()
+        frozen: MappingProxyType[str, Any] = MappingProxyType({"key": "val"})
+        thread = store.create(metadata=frozen)
+        assert thread.metadata == {"key": "val"}
+
+        updated = store.update(thread.thread_id, metadata=frozen)
+        assert updated.metadata == {"key": "val"}
+
+
+# ---------------------------------------------------------------------------
+# Oracle-requested gap tests
+# ---------------------------------------------------------------------------
+
+
+class TestOracleGapTests:
+    """Tests requested by Oracle post-implementation review."""
+
+    def test_duplicate_id_raises_valueerror(self) -> None:
+        """Custom id_factory that returns duplicates should raise ValueError."""
+        store = InMemoryThreadStore(id_factory=lambda: "fixed-id")
+        store.create()  # first succeeds
+        with pytest.raises(ValueError, match="Duplicate thread ID"):
+            store.create()  # second collides
+
+    def test_search_negative_limit_raises(self) -> None:
+        store = InMemoryThreadStore()
+        with pytest.raises(ValueError, match="limit must be non-negative"):
+            store.search(limit=-1)
+
+    def test_search_negative_offset_raises(self) -> None:
+        store = InMemoryThreadStore()
+        with pytest.raises(ValueError, match="offset must be non-negative"):
+            store.search(offset=-1)
+
+    def test_delete_returns_none(self) -> None:
+        """delete() should return None (not bool) after Oracle review."""
+        store = InMemoryThreadStore()
+        thread = store.create()
+        store.delete(thread.thread_id)  # should not raise
+
+    def test_deep_copy_isolation_values(self) -> None:
+        """Mutating returned values dict must not affect stored state."""
+        store = InMemoryThreadStore()
+        thread = store.create()
+        updated = store.update(
+            thread.thread_id, values={"messages": [{"role": "user", "content": "hi"}]}
+        )
+        # Mutate the returned values
+        assert updated.values is not None
+        updated.values["messages"].append({"role": "assistant", "content": "bye"})
+        # Verify stored state is unchanged
+        refetched = store.get(thread.thread_id)
+        assert refetched is not None
+        assert refetched.values == {"messages": [{"role": "user", "content": "hi"}]}
+
+    def test_deep_copy_isolation_interrupts(self) -> None:
+        """Mutating returned interrupts must not affect stored state."""
+        store = InMemoryThreadStore()
+        thread = store.create()
+        interrupts = {"node_a": [Interrupt(id="i-1", value="pause")]}
+        updated = store.update(thread.thread_id, interrupts=interrupts)
+        # Mutate the returned interrupts
+        updated.interrupts["node_a"].append(Interrupt(id="i-2", value="extra"))
+        # Verify stored state is unchanged
+        refetched = store.get(thread.thread_id)
+        assert refetched is not None
+        assert len(refetched.interrupts["node_a"]) == 1
+
+    def test_populate_helper_preserves_empty_metadata(self) -> None:
+        """Regression: _populate with metadata={} should not convert to None."""
+        store = InMemoryThreadStore()
+        thread = store.create(metadata={})
+        assert thread.metadata == {}  # not None


### PR DESCRIPTION
## Summary

- Add `ThreadStore` protocol (`@runtime_checkable`) defining CRUD + search for thread metadata
- Add `InMemoryThreadStore` with `threading.RLock` guards and deep-copy isolation
- 50 tests covering CRUD, search filtering, thread safety, deep-copy isolation, and protocol conformance

## Key Design Decisions (Oracle-reviewed)

| Decision | Rationale |
|---|---|
| `get` returns `None`; `update`/`delete` raise `KeyError` | Consistent with dict semantics |
| Store generates thread ID via injectable `id_factory` | Testability + UUID default |
| `update()` uses `model_dump → apply → model_validate` | Ensures Pydantic validation on every write |
| `_deep_copy()` uses `model_copy(deep=True)` | Simpler + cheaper than serialize/deserialize |
| `create()` fully atomic under `RLock` | Thread-safe ID generation + duplicate detection |
| `delete()` returns `None` (not `bool`) | `True` carries no info when errors are raised |
| `search()` rejects negative `limit`/`offset` | Prevents surprising Python slice behavior |

## Oracle Post-Implementation Feedback Applied

1. ✅ `update()` → `model_dump` + apply + `model_validate` (not `model_copy(update=)`)
2. ✅ `_deep_copy()` → `thread.model_copy(deep=True)`
3. ✅ `create()` moved entirely inside `RLock`
4. ✅ Duplicate ID detection with `ValueError`
5. ✅ `delete()` → `None` return type
6. ✅ Negative `limit`/`offset` validation
7. ✅ Gap tests: dup ID, negative limit/offset, deep-copy isolation for values/interrupts
8. ✅ Fixed falsy empty-dict bug in test `_populate()` helper

## Test Results

```
212 passed, 99.07% coverage, ruff + mypy clean
```

Closes #37