### PR TITLE
feat: Platform API compat route layer

### DIFF
--- a/src/azure_functions_langgraph/app.py
+++ b/src/azure_functions_langgraph/app.py
@@ -68,8 +68,10 @@ class LangGraphApp:
 
     auth_level: func.AuthLevel = func.AuthLevel.ANONYMOUS
     max_stream_response_bytes: int = 1024 * 1024
+    platform_compat: bool = False
     _registrations: dict[str, _GraphRegistration] = field(default_factory=dict)
     _function_app: Optional[func.FunctionApp] = field(default=None, init=False, repr=False)
+    _thread_store: Any = field(default=None, init=False, repr=False)
 
     def __post_init__(self) -> None:
         if self.auth_level == func.AuthLevel.ANONYMOUS and os.environ.get(
@@ -79,6 +81,10 @@ class LangGraphApp:
                 "LangGraphApp is configured with anonymous HTTP auth. "
                 "Use FUNCTION or ADMIN auth levels for production deployments."
             )
+        if self.platform_compat and self._thread_store is None:
+            from azure_functions_langgraph.platform.stores import InMemoryThreadStore
+
+            self._thread_store = InMemoryThreadStore()
 
     def register(
         self,
@@ -124,6 +130,20 @@ class LangGraphApp:
             self._function_app = self._build_function_app()
         return self._function_app
 
+    @property
+    def thread_store(self) -> Any:
+        """Return the thread store, or ``None`` if platform compat is disabled."""
+        return self._thread_store
+
+    @thread_store.setter
+    def thread_store(self, store: Any) -> None:
+        """Set a custom thread store implementation.
+
+        Must be called before accessing :attr:`function_app`.
+        """
+        self._thread_store = store
+        self._function_app = None  # invalidate cached routes
+
     # ------------------------------------------------------------------
     # Internal route builders
     # ------------------------------------------------------------------
@@ -167,6 +187,21 @@ class LangGraphApp:
             self._register_stream_route(app, reg)
             if isinstance(reg.graph, StatefulGraph):
                 self._register_state_route(app, reg)
+
+        # Platform API compatibility routes
+        if self.platform_compat:
+            from azure_functions_langgraph.platform.routes import (
+                PlatformRouteDeps,
+                register_platform_routes,
+            )
+
+            deps = PlatformRouteDeps(
+                registrations=self._registrations,
+                thread_store=self._thread_store,
+                auth_level=self.auth_level,
+                max_stream_response_bytes=self.max_stream_response_bytes,
+            )
+            register_platform_routes(app, deps)
 
         return app
 

--- a/src/azure_functions_langgraph/platform/contracts.py
+++ b/src/azure_functions_langgraph/platform/contracts.py
@@ -89,6 +89,7 @@ class Thread(BaseModel):
     metadata: Json = None
     status: ThreadStatus = "idle"
     values: Json = None
+    assistant_id: Optional[str] = None
     interrupts: dict[str, list[Interrupt]] = Field(default_factory=dict)
 
 
@@ -167,6 +168,8 @@ class RunCreate(BaseModel):
     on_completion: Optional[str] = None
     after_seconds: Optional[float] = None
     if_not_exists: Optional[str] = None
+    command: Optional[dict[str, Any]] = None
+    feedback_keys: Optional[list[str]] = None
 
 
 class ThreadCreate(BaseModel):

--- a/src/azure_functions_langgraph/platform/routes.py
+++ b/src/azure_functions_langgraph/platform/routes.py
@@ -1,0 +1,608 @@
+"""Platform API–compatible route registration.
+
+Registers Azure Functions HTTP routes that mirror the LangGraph Platform
+REST API (``langgraph-sdk ~0.1``).  When enabled via
+``LangGraphApp(platform_compat=True)``, the official ``langgraph-sdk``
+Python client can communicate with Azure Functions–hosted graphs.
+
+Routes registered (under ``/api/`` prefix, managed by Azure Functions):
+
+* ``POST /api/assistants/search``
+* ``GET  /api/assistants/{assistant_id}``
+* ``POST /api/threads``
+* ``GET  /api/threads/{thread_id}``
+* ``GET  /api/threads/{thread_id}/state``
+* ``POST /api/threads/{thread_id}/runs/wait``
+* ``POST /api/threads/{thread_id}/runs/stream``
+
+.. versionadded:: 0.3.0
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import json
+import logging
+from typing import Any
+import uuid
+
+import azure.functions as func
+
+from azure_functions_langgraph.platform.contracts import (
+    Assistant,
+    AssistantSearch,
+    RunCreate,
+    ThreadCreate,
+    ThreadState,
+)
+from azure_functions_langgraph.platform.stores import ThreadStore
+from azure_functions_langgraph.protocols import StatefulGraph, StreamableGraph
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Error helper — Platform-specific JSON error responses
+# ---------------------------------------------------------------------------
+
+
+def _platform_error(status_code: int, detail: str) -> func.HttpResponse:
+    """Return a JSON error matching LangGraph Platform conventions."""
+    body = json.dumps({"detail": detail})
+    return func.HttpResponse(
+        body=body,
+        mimetype="application/json",
+        status_code=status_code,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Unsupported-feature preflight check
+# ---------------------------------------------------------------------------
+
+_UNSUPPORTED_FIELDS: dict[str, str] = {
+    "interrupt_before": "Interrupt-before is not supported in this release.",
+    "interrupt_after": "Interrupt-after is not supported in this release.",
+    "webhook": "Webhook callbacks are not supported in this release.",
+    "on_completion": "on_completion callbacks are not supported in this release.",
+    "after_seconds": "Delayed runs are not supported in this release.",
+    "if_not_exists": "if_not_exists is not supported in this release.",
+    "checkpoint_id": "Checkpoint resumption is not supported in this release.",
+    "command": "Command-based resumption is not supported in this release.",
+    "feedback_keys": "Feedback keys are not supported in this release.",
+}
+
+
+def _preflight_run_create(run: RunCreate) -> func.HttpResponse | None:
+    """Return a 501 response if *run* uses unsupported features, else ``None``."""
+    for field_name, message in _UNSUPPORTED_FIELDS.items():
+        value = getattr(run, field_name, None)
+        if value is not None:
+            return _platform_error(501, message)
+    if run.multitask_strategy is not None and run.multitask_strategy != "reject":
+        return _platform_error(
+            501,
+            f"Multitask strategy {run.multitask_strategy!r} is not supported; "
+            f"only 'reject' is available.",
+        )
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Registration deps — narrow interface, NOT the whole LangGraphApp
+# ---------------------------------------------------------------------------
+
+
+class PlatformRouteDeps:
+    """Holds all dependencies the platform routes need.
+
+    Constructed by ``LangGraphApp._build_function_app()`` when
+    ``platform_compat`` is enabled.
+    """
+
+    __slots__ = ("registrations", "thread_store", "auth_level", "max_stream_response_bytes")
+
+    def __init__(
+        self,
+        *,
+        registrations: dict[str, Any],
+        thread_store: ThreadStore,
+        auth_level: func.AuthLevel,
+        max_stream_response_bytes: int,
+    ) -> None:
+        self.registrations = registrations
+        self.thread_store = thread_store
+        self.auth_level = auth_level
+        self.max_stream_response_bytes = max_stream_response_bytes
+
+
+# ---------------------------------------------------------------------------
+# Assistant helpers
+# ---------------------------------------------------------------------------
+
+# Module-level timestamp for stable assistant responses within a process.
+# Re-computed only on import / process restart.
+_PROCESS_START = datetime.now(timezone.utc)
+
+
+def _registration_to_assistant(name: str, reg: Any) -> Assistant:
+    """Build an ``Assistant`` response from an internal ``_GraphRegistration``."""
+    return Assistant(
+        assistant_id=name,
+        graph_id=name,
+        config={},
+        created_at=_PROCESS_START,
+        metadata=None,
+        version=1,
+        name=name,
+        description=getattr(reg, "description", None),
+        updated_at=_PROCESS_START,
+        context={},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Route registration
+# ---------------------------------------------------------------------------
+
+
+def register_platform_routes(
+    app: func.FunctionApp,
+    deps: PlatformRouteDeps,
+) -> None:
+    """Register all LangGraph Platform–compatible routes on *app*.
+
+    Parameters
+    ----------
+    app:
+        The Azure ``FunctionApp`` to register routes on.
+    deps:
+        Narrow dependency bag containing registrations, thread store,
+        auth level, and max stream bytes.
+    """
+
+    auth = deps.auth_level
+
+    # ── POST /assistants/search ──────────────────────────────────────
+
+    @app.function_name(name="aflg_platform_assistants_search")
+    @app.route(route="assistants/search", methods=["POST"], auth_level=auth)
+    def assistants_search(req: func.HttpRequest) -> func.HttpResponse:
+        raw = req.get_body()
+        if not raw or raw.strip() == b"":
+            body: dict[str, Any] = {}
+        else:
+            try:
+                body = req.get_json()
+            except ValueError:
+                return _platform_error(400, "Invalid JSON body")
+
+        try:
+            search = AssistantSearch.model_validate(body)
+        except Exception as exc:
+            return _platform_error(422, f"Validation error: {exc}")
+
+        results: list[Assistant] = []
+        for name, reg in deps.registrations.items():
+            if search.graph_id is not None and name != search.graph_id:
+                continue
+            if search.metadata is not None:
+                # Assistants don't have user metadata — skip filter
+                continue
+            results.append(_registration_to_assistant(name, reg))
+
+        # Apply offset/limit
+        page = results[search.offset : search.offset + search.limit]
+        return func.HttpResponse(
+            body=json.dumps([a.model_dump(mode="json") for a in page], default=str),
+            mimetype="application/json",
+            status_code=200,
+        )
+
+    # ── GET /assistants/{assistant_id} ───────────────────────────────
+
+    @app.function_name(name="aflg_platform_assistants_get")
+    @app.route(route="assistants/{assistant_id}", methods=["GET"], auth_level=auth)
+    def assistants_get(req: func.HttpRequest) -> func.HttpResponse:
+        assistant_id = req.route_params.get("assistant_id", "")
+        reg = deps.registrations.get(assistant_id)
+        if reg is None:
+            return _platform_error(404, f"Assistant {assistant_id!r} not found")
+        assistant = _registration_to_assistant(assistant_id, reg)
+        return func.HttpResponse(
+            body=json.dumps(assistant.model_dump(mode="json"), default=str),
+            mimetype="application/json",
+            status_code=200,
+        )
+
+    # ── POST /threads ────────────────────────────────────────────────
+
+    @app.function_name(name="aflg_platform_threads_create")
+    @app.route(route="threads", methods=["POST"], auth_level=auth)
+    def threads_create(req: func.HttpRequest) -> func.HttpResponse:
+        raw = req.get_body()
+        if not raw or raw.strip() == b"":
+            body: dict[str, Any] = {}
+        else:
+            try:
+                body = req.get_json()
+            except ValueError:
+                return _platform_error(400, "Invalid JSON body")
+
+        try:
+            create_req = ThreadCreate.model_validate(body)
+        except Exception as exc:
+            return _platform_error(422, f"Validation error: {exc}")
+
+        thread = deps.thread_store.create(metadata=create_req.metadata)
+        return func.HttpResponse(
+            body=json.dumps(thread.model_dump(mode="json"), default=str),
+            mimetype="application/json",
+            status_code=200,
+        )
+
+    # ── GET /threads/{thread_id} ─────────────────────────────────────
+
+    @app.function_name(name="aflg_platform_threads_get")
+    @app.route(route="threads/{thread_id}", methods=["GET"], auth_level=auth)
+    def threads_get(req: func.HttpRequest) -> func.HttpResponse:
+        thread_id = req.route_params.get("thread_id", "")
+        thread = deps.thread_store.get(thread_id)
+        if thread is None:
+            return _platform_error(404, f"Thread {thread_id!r} not found")
+        return func.HttpResponse(
+            body=json.dumps(thread.model_dump(mode="json"), default=str),
+            mimetype="application/json",
+            status_code=200,
+        )
+
+    # ── GET /threads/{thread_id}/state ───────────────────────────────
+
+    @app.function_name(name="aflg_platform_threads_state_get")
+    @app.route(
+        route="threads/{thread_id}/state", methods=["GET"], auth_level=auth
+    )
+    def threads_state_get(req: func.HttpRequest) -> func.HttpResponse:
+        thread_id = req.route_params.get("thread_id", "")
+        thread = deps.thread_store.get(thread_id)
+        if thread is None:
+            return _platform_error(404, f"Thread {thread_id!r} not found")
+
+        # Thread must be bound to an assistant (graph) to have state
+        if thread.assistant_id is None:
+            return _platform_error(
+                409,
+                f"Thread {thread_id!r} is not bound to any assistant. "
+                f"Run a graph on this thread first.",
+            )
+
+        reg = deps.registrations.get(thread.assistant_id)
+        if reg is None:
+            return _platform_error(
+                404,
+                f"Assistant {thread.assistant_id!r} not found for thread {thread_id!r}",
+            )
+
+        graph = reg.graph
+        if not isinstance(graph, StatefulGraph):
+            return _platform_error(
+                409,
+                f"Graph {thread.assistant_id!r} does not support state retrieval",
+            )
+
+        config: dict[str, Any] = {"configurable": {"thread_id": thread_id}}
+        try:
+            snapshot = graph.get_state(config)
+        except (KeyError, ValueError):
+            # No checkpoint yet — return empty state
+            state = ThreadState(
+                values={},
+                next=[],
+                checkpoint={"thread_id": thread_id, "checkpoint_ns": "", "checkpoint_id": None},  # type: ignore[arg-type]
+                metadata=None,
+                created_at=None,
+                parent_checkpoint=None,
+                tasks=[],
+                interrupts=[],
+            )
+            return func.HttpResponse(
+                body=json.dumps(state.model_dump(mode="json"), default=str),
+                mimetype="application/json",
+                status_code=200,
+            )
+        except Exception:
+            logger.exception("get_state failed for thread %s", thread_id)
+            return _platform_error(500, "Internal error retrieving thread state")
+
+        values: dict[str, Any] | list[dict[str, Any]] = (
+            snapshot.values
+            if isinstance(snapshot.values, (dict, list))
+            else {}
+        )
+        next_nodes: list[str] = list(snapshot.next) if hasattr(snapshot, "next") else []
+        metadata = (
+            dict(snapshot.metadata)
+            if hasattr(snapshot, "metadata") and snapshot.metadata is not None
+            else None
+        )
+
+        state = ThreadState(
+            values=values,
+            next=next_nodes,
+            checkpoint={"thread_id": thread_id, "checkpoint_ns": "", "checkpoint_id": None},  # type: ignore[arg-type]
+            metadata=metadata,
+            created_at=None,
+            parent_checkpoint=None,
+            tasks=[],
+            interrupts=[],
+        )
+        return func.HttpResponse(
+            body=json.dumps(state.model_dump(mode="json"), default=str),
+            mimetype="application/json",
+            status_code=200,
+        )
+
+    # ── POST /threads/{thread_id}/runs/wait ──────────────────────────
+
+    @app.function_name(name="aflg_platform_runs_wait")
+    @app.route(
+        route="threads/{thread_id}/runs/wait", methods=["POST"], auth_level=auth
+    )
+    def runs_wait(req: func.HttpRequest) -> func.HttpResponse:
+        thread_id = req.route_params.get("thread_id", "")
+
+        # Thread must exist
+        thread = deps.thread_store.get(thread_id)
+        if thread is None:
+            return _platform_error(404, f"Thread {thread_id!r} not found")
+
+        # Parse request
+        try:
+            body = req.get_json()
+        except ValueError:
+            return _platform_error(400, "Invalid JSON body")
+
+        try:
+            run_req = RunCreate.model_validate(body)
+        except Exception as exc:
+            return _platform_error(422, f"Validation error: {exc}")
+
+        # Preflight: reject unsupported features
+        preflight = _preflight_run_create(run_req)
+        if preflight is not None:
+            return preflight
+
+        # Resolve assistant → graph registration
+        reg = deps.registrations.get(run_req.assistant_id)
+        if reg is None:
+            return _platform_error(
+                404, f"Assistant {run_req.assistant_id!r} not found"
+            )
+
+        # Thread-assistant binding: set on first run, immutable after.
+        # NOTE: There is an inherent TOCTOU race between the read above and
+        # the update below.  For the InMemoryThreadStore single-process case
+        # this is acceptable; a durable backend should use compare-and-swap.
+        if thread.assistant_id is None:
+            deps.thread_store.update(thread_id, assistant_id=run_req.assistant_id)
+        elif thread.assistant_id != run_req.assistant_id:
+            return _platform_error(
+                409,
+                f"Thread {thread_id!r} is bound to assistant "
+                f"{thread.assistant_id!r}, cannot run with "
+                f"{run_req.assistant_id!r}",
+            )
+
+        # Reject if thread is busy (multitask_strategy=reject is the only
+        # supported strategy; concurrent runs are not allowed).
+        if thread.status == "busy":
+            return _platform_error(
+                409,
+                f"Thread {thread_id!r} is already busy. "
+                f"Concurrent runs are not supported (multitask_strategy=reject).",
+            )
+
+        # Mark thread busy
+        deps.thread_store.update(thread_id, status="busy")
+
+        # Build config
+        config: dict[str, Any] = {"configurable": {"thread_id": thread_id}}
+        if run_req.config:
+            user_config = dict(run_req.config)
+            user_configurable = user_config.pop("configurable", {})
+            config["configurable"].update(user_configurable)
+            config.update(user_config)
+
+        # Execute graph synchronously
+        graph_input = run_req.input or {}
+        try:
+            result = reg.graph.invoke(graph_input, config=config)
+        except Exception:
+            logger.exception(
+                "Graph %s invoke failed for thread %s",
+                run_req.assistant_id,
+                thread_id,
+            )
+            deps.thread_store.update(thread_id, status="error")
+            return _platform_error(500, "Graph execution failed")
+
+        # Update thread state
+        output = result if isinstance(result, dict) else {"result": result}
+        deps.thread_store.update(thread_id, status="idle", values=output)
+
+        # SDK runs/wait returns final state values (dict), NOT a Run object.
+        # Include Content-Location header so the SDK can extract run metadata.
+        run_id = str(uuid.uuid4())
+        return func.HttpResponse(
+            body=json.dumps(output, default=str),
+            mimetype="application/json",
+            status_code=200,
+            headers={"Content-Location": f"/api/threads/{thread_id}/runs/{run_id}"},
+        )
+
+    # ── POST /threads/{thread_id}/runs/stream ────────────────────────
+
+    @app.function_name(name="aflg_platform_runs_stream")
+    @app.route(
+        route="threads/{thread_id}/runs/stream",
+        methods=["POST"],
+        auth_level=auth,
+    )
+    def runs_stream(req: func.HttpRequest) -> func.HttpResponse:
+        thread_id = req.route_params.get("thread_id", "")
+
+        # Thread must exist
+        thread = deps.thread_store.get(thread_id)
+        if thread is None:
+            return _platform_error(404, f"Thread {thread_id!r} not found")
+
+        # Parse request
+        try:
+            body = req.get_json()
+        except ValueError:
+            return _platform_error(400, "Invalid JSON body")
+
+        try:
+            run_req = RunCreate.model_validate(body)
+        except Exception as exc:
+            return _platform_error(422, f"Validation error: {exc}")
+
+        # Preflight: reject unsupported features
+        preflight = _preflight_run_create(run_req)
+        if preflight is not None:
+            return preflight
+
+        # Resolve assistant → graph
+        reg = deps.registrations.get(run_req.assistant_id)
+        if reg is None:
+            return _platform_error(
+                404, f"Assistant {run_req.assistant_id!r} not found"
+            )
+
+        # Graph must support streaming
+        if not isinstance(reg.graph, StreamableGraph):
+            return _platform_error(
+                501,
+                f"Graph {run_req.assistant_id!r} does not support streaming",
+            )
+
+        # Thread-assistant binding (see TOCTOU note in runs_wait).
+        if thread.assistant_id is None:
+            deps.thread_store.update(thread_id, assistant_id=run_req.assistant_id)
+        elif thread.assistant_id != run_req.assistant_id:
+            return _platform_error(
+                409,
+                f"Thread {thread_id!r} is bound to assistant "
+                f"{thread.assistant_id!r}, cannot run with "
+                f"{run_req.assistant_id!r}",
+            )
+
+        # Reject if thread is busy (multitask_strategy=reject).
+        if thread.status == "busy":
+            return _platform_error(
+                409,
+                f"Thread {thread_id!r} is already busy. "
+                f"Concurrent runs are not supported (multitask_strategy=reject).",
+            )
+
+        # Mark thread busy
+        deps.thread_store.update(thread_id, status="busy")
+
+        # Build config
+        config: dict[str, Any] = {"configurable": {"thread_id": thread_id}}
+        if run_req.config:
+            user_config = dict(run_req.config)
+            user_configurable = user_config.pop("configurable", {})
+            config["configurable"].update(user_configurable)
+            config.update(user_config)
+
+        # Resolve stream_mode
+        stream_mode = run_req.stream_mode
+        if isinstance(stream_mode, list):
+            stream_mode = stream_mode[0] if stream_mode else "values"
+
+        # Synthetic run ID for metadata event
+        run_id = str(uuid.uuid4())
+
+        graph_input = run_req.input or {}
+        chunks: list[str] = []
+        buffered_bytes = 0
+        max_bytes = deps.max_stream_response_bytes
+
+        # Metadata event (first SSE event per SDK protocol)
+        meta_data = json.dumps({"run_id": run_id})
+        chunks.append(f"event: metadata\ndata: {meta_data}\n\n")
+
+        try:
+            for event in reg.graph.stream(
+                graph_input,
+                config=config,
+                stream_mode=stream_mode,
+            ):
+                serialized = json.dumps(
+                    event if isinstance(event, dict) else {"data": str(event)},
+                    default=str,
+                )
+                chunk = f"event: {stream_mode}\ndata: {serialized}\n\n"
+                chunk_bytes = len(chunk.encode())
+                if buffered_bytes + chunk_bytes > max_bytes:
+                    error_payload = json.dumps(
+                        {
+                            "error": (
+                                "stream response exceeded max buffered size "
+                                f"({max_bytes} bytes)"
+                            )
+                        }
+                    )
+                    chunks.append(f"event: error\ndata: {error_payload}\n\n")
+                    break
+                chunks.append(chunk)
+                buffered_bytes += chunk_bytes
+        except Exception:
+            logger.exception(
+                "Graph %s stream failed for thread %s",
+                run_req.assistant_id,
+                thread_id,
+            )
+            deps.thread_store.update(thread_id, status="error")
+            error_payload = json.dumps({"error": "stream processing failed"})
+            chunks.append(f"event: error\ndata: {error_payload}\n\n")
+            # End event after error
+            chunks.append("event: end\ndata: null\n\n")
+            return func.HttpResponse(
+                body="".join(chunks),
+                mimetype="text/event-stream",
+                status_code=200,
+                headers={
+                    "Cache-Control": "no-cache",
+                    "X-Accel-Buffering": "no",
+                    "Content-Location": f"/api/threads/{thread_id}/runs/{run_id}",
+                },
+            )
+
+        # End event
+        chunks.append("event: end\ndata: null\n\n")
+
+        # Update thread state to idle after successful stream
+        deps.thread_store.update(thread_id, status="idle")
+
+        return func.HttpResponse(
+            body="".join(chunks),
+            mimetype="text/event-stream",
+            status_code=200,
+            headers={
+                "Cache-Control": "no-cache",
+                "X-Accel-Buffering": "no",
+                "Content-Location": f"/api/threads/{thread_id}/runs/{run_id}",
+            },
+        )
+
+
+# ---------------------------------------------------------------------------
+# Public surface
+# ---------------------------------------------------------------------------
+
+__all__ = [
+    "PlatformRouteDeps",
+    "register_platform_routes",
+]

--- a/src/azure_functions_langgraph/platform/stores.py
+++ b/src/azure_functions_langgraph/platform/stores.py
@@ -57,6 +57,7 @@ class ThreadStore(Protocol):
         status: ThreadStatus | None = None,
         values: dict[str, Any] | None = None,
         interrupts: dict[str, list[Interrupt]] | None = None,
+        assistant_id: str | None = None,
     ) -> Thread:
         """Partially update a thread.
 
@@ -165,6 +166,7 @@ class InMemoryThreadStore:
         status: ThreadStatus | None = None,
         values: dict[str, Any] | None = None,
         interrupts: dict[str, list[Interrupt]] | None = None,
+        assistant_id: str | None = None,
     ) -> Thread:
         """Partially update a thread.  Raises ``KeyError`` if not found."""
         with self._lock:
@@ -183,6 +185,8 @@ class InMemoryThreadStore:
                 data["values"] = values
             if interrupts is not None:
                 data["interrupts"] = interrupts
+            if assistant_id is not None:
+                data["assistant_id"] = assistant_id
 
             updated = Thread.model_validate(data)
             self._threads[thread_id] = updated

--- a/tests/test_platform_routes.py
+++ b/tests/test_platform_routes.py
@@ -1,0 +1,1136 @@
+"""Tests for Platform API–compatible route layer (issue #38)."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Iterator
+
+import azure.functions as func
+import pytest
+
+from azure_functions_langgraph.app import LangGraphApp
+from azure_functions_langgraph.platform.routes import (
+    PlatformRouteDeps,
+    _platform_error,
+)
+from azure_functions_langgraph.platform.stores import InMemoryThreadStore
+from tests.conftest import (
+    FakeCompiledGraph,
+    FakeInvokeOnlyGraph,
+    FakeStatefulGraph,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def store() -> InMemoryThreadStore:
+    """Thread store with deterministic IDs."""
+    counter = iter(range(1000))
+    return InMemoryThreadStore(id_factory=lambda: f"thread-{next(counter)}")
+
+
+@pytest.fixture()
+def graph() -> FakeCompiledGraph:
+    return FakeCompiledGraph()
+
+
+@pytest.fixture()
+def stateful_graph() -> FakeStatefulGraph:
+    return FakeStatefulGraph()
+
+
+def _build_platform_app(
+    *,
+    graphs: dict[str, Any] | None = None,
+    store: InMemoryThreadStore | None = None,
+) -> LangGraphApp:
+    """Build a LangGraphApp with platform_compat=True and register graphs."""
+    app = LangGraphApp(platform_compat=True)
+    if store is not None:
+        app._thread_store = store
+    if graphs:
+        for name, g in graphs.items():
+            app.register(graph=g, name=name)
+    return app
+
+
+def _get_fn(fa: func.FunctionApp, fn_name: str) -> Any:
+    """Get a registered function handler by name from a FunctionApp."""
+    fa.functions_bindings = {}
+    for fn in fa.get_functions():
+        if fn.get_function_name() == fn_name:
+            return fn.get_user_function()
+    raise AssertionError(f"Function {fn_name!r} not found")
+
+
+def _post_request(
+    url: str,
+    body: dict[str, Any] | None = None,
+    **route_params: str,
+) -> func.HttpRequest:
+    """Build a POST request with JSON body."""
+    return func.HttpRequest(
+        method="POST",
+        url=url,
+        body=json.dumps(body or {}).encode(),
+        headers={"Content-Type": "application/json"},
+        route_params=route_params,
+    )
+
+
+def _get_request(url: str, **route_params: str) -> func.HttpRequest:
+    """Build a GET request."""
+    return func.HttpRequest(
+        method="GET",
+        url=url,
+        body=b"",
+        route_params=route_params,
+    )
+
+
+# ---------------------------------------------------------------------------
+# LangGraphApp integration — platform_compat flag
+# ---------------------------------------------------------------------------
+
+
+class TestPlatformCompatFlag:
+    def test_platform_routes_registered_when_enabled(self, graph: FakeCompiledGraph) -> None:
+        app = _build_platform_app(graphs={"agent": graph})
+        fa = app.function_app
+
+        fa.functions_bindings = {}
+        fn_names = [f.get_function_name() for f in fa.get_functions()]
+
+        # All 7 platform route names must be present
+        expected = {
+            "aflg_platform_assistants_search",
+            "aflg_platform_assistants_get",
+            "aflg_platform_threads_create",
+            "aflg_platform_threads_get",
+            "aflg_platform_threads_state_get",
+            "aflg_platform_runs_wait",
+            "aflg_platform_runs_stream",
+        }
+        assert expected.issubset(set(fn_names))
+
+    def test_platform_routes_not_registered_when_disabled(self, graph: FakeCompiledGraph) -> None:
+        app = LangGraphApp(platform_compat=False)
+        app.register(graph=graph, name="agent")
+        fa = app.function_app
+
+        fa.functions_bindings = {}
+        fn_names = [f.get_function_name() for f in fa.get_functions()]
+
+        assert "aflg_platform_assistants_search" not in fn_names
+
+    def test_auto_creates_thread_store(self) -> None:
+        app = LangGraphApp(platform_compat=True)
+        assert app.thread_store is not None
+        assert isinstance(app.thread_store, InMemoryThreadStore)
+
+    def test_no_thread_store_when_disabled(self) -> None:
+        app = LangGraphApp(platform_compat=False)
+        assert app.thread_store is None
+
+    def test_custom_thread_store(self, store: InMemoryThreadStore) -> None:
+        app = LangGraphApp(platform_compat=True)
+        app.thread_store = store
+        assert app.thread_store is store
+
+
+# ---------------------------------------------------------------------------
+# Assistants endpoints
+# ---------------------------------------------------------------------------
+
+
+class TestAssistantsSearch:
+    def test_search_returns_all(self, graph: FakeCompiledGraph, store: InMemoryThreadStore) -> None:
+        app = _build_platform_app(graphs={"agent": graph}, store=store)
+        fa = app.function_app
+        fn = _get_fn(fa, "aflg_platform_assistants_search")
+
+        req = _post_request("/api/assistants/search")
+        resp = fn(req)
+        assert resp.status_code == 200
+        data = json.loads(resp.get_body())
+        assert len(data) == 1
+        assert data[0]["assistant_id"] == "agent"
+        assert data[0]["graph_id"] == "agent"
+
+    def test_search_multiple_graphs(self, store: InMemoryThreadStore) -> None:
+        g1 = FakeCompiledGraph()
+        g2 = FakeCompiledGraph()
+        app = _build_platform_app(graphs={"alpha": g1, "beta": g2}, store=store)
+        fa = app.function_app
+        fn = _get_fn(fa, "aflg_platform_assistants_search")
+
+        req = _post_request("/api/assistants/search")
+        resp = fn(req)
+        data = json.loads(resp.get_body())
+        assert len(data) == 2
+        names = {a["assistant_id"] for a in data}
+        assert names == {"alpha", "beta"}
+
+    def test_search_filter_by_graph_id(self, store: InMemoryThreadStore) -> None:
+        g1 = FakeCompiledGraph()
+        g2 = FakeCompiledGraph()
+        app = _build_platform_app(graphs={"alpha": g1, "beta": g2}, store=store)
+        fa = app.function_app
+        fn = _get_fn(fa, "aflg_platform_assistants_search")
+
+        req = _post_request("/api/assistants/search", {"graph_id": "alpha"})
+        resp = fn(req)
+        data = json.loads(resp.get_body())
+        assert len(data) == 1
+        assert data[0]["assistant_id"] == "alpha"
+
+    def test_search_with_limit(self, store: InMemoryThreadStore) -> None:
+        graphs = {f"g{i}": FakeCompiledGraph() for i in range(5)}
+        app = _build_platform_app(graphs=graphs, store=store)
+        fa = app.function_app
+        fn = _get_fn(fa, "aflg_platform_assistants_search")
+
+        req = _post_request("/api/assistants/search", {"limit": 2})
+        resp = fn(req)
+        data = json.loads(resp.get_body())
+        assert len(data) == 2
+
+    def test_search_with_offset(self, store: InMemoryThreadStore) -> None:
+        graphs = {f"g{i}": FakeCompiledGraph() for i in range(5)}
+        app = _build_platform_app(graphs=graphs, store=store)
+        fa = app.function_app
+        fn = _get_fn(fa, "aflg_platform_assistants_search")
+
+        req = _post_request("/api/assistants/search", {"limit": 2, "offset": 3})
+        resp = fn(req)
+        data = json.loads(resp.get_body())
+        assert len(data) == 2
+
+    def test_search_empty_body(self, graph: FakeCompiledGraph, store: InMemoryThreadStore) -> None:
+        """POST with no body should still work (defaults)."""
+        app = _build_platform_app(graphs={"agent": graph}, store=store)
+        fa = app.function_app
+        fn = _get_fn(fa, "aflg_platform_assistants_search")
+
+        req = func.HttpRequest(
+            method="POST",
+            url="/api/assistants/search",
+            body=b"",
+            headers={},
+        )
+        resp = fn(req)
+        assert resp.status_code == 200
+
+
+class TestAssistantsGet:
+    def test_get_existing(self, graph: FakeCompiledGraph, store: InMemoryThreadStore) -> None:
+        app = _build_platform_app(graphs={"agent": graph}, store=store)
+        fa = app.function_app
+        fn = _get_fn(fa, "aflg_platform_assistants_get")
+
+        req = _get_request("/api/assistants/agent", assistant_id="agent")
+        resp = fn(req)
+        assert resp.status_code == 200
+        data = json.loads(resp.get_body())
+        assert data["assistant_id"] == "agent"
+        assert data["name"] == "agent"
+
+    def test_get_not_found(self, graph: FakeCompiledGraph, store: InMemoryThreadStore) -> None:
+        app = _build_platform_app(graphs={"agent": graph}, store=store)
+        fa = app.function_app
+        fn = _get_fn(fa, "aflg_platform_assistants_get")
+
+        req = _get_request("/api/assistants/missing", assistant_id="missing")
+        resp = fn(req)
+        assert resp.status_code == 404
+        data = json.loads(resp.get_body())
+        assert "not found" in data["detail"]
+
+
+# ---------------------------------------------------------------------------
+# Threads endpoints
+# ---------------------------------------------------------------------------
+
+
+class TestThreadsCreate:
+    def test_create_thread(self, graph: FakeCompiledGraph, store: InMemoryThreadStore) -> None:
+        app = _build_platform_app(graphs={"agent": graph}, store=store)
+        fa = app.function_app
+        fn = _get_fn(fa, "aflg_platform_threads_create")
+
+        req = _post_request("/api/threads", {})
+        resp = fn(req)
+        assert resp.status_code == 200
+        data = json.loads(resp.get_body())
+        assert data["thread_id"] == "thread-0"
+        assert data["status"] == "idle"
+
+    def test_create_thread_with_metadata(
+        self, graph: FakeCompiledGraph, store: InMemoryThreadStore,
+    ) -> None:
+        app = _build_platform_app(graphs={"agent": graph}, store=store)
+        fa = app.function_app
+        fn = _get_fn(fa, "aflg_platform_threads_create")
+
+        req = _post_request("/api/threads", {"metadata": {"key": "value"}})
+        resp = fn(req)
+        assert resp.status_code == 200
+        data = json.loads(resp.get_body())
+        assert data["metadata"]["key"] == "value"
+
+    def test_create_thread_empty_body(
+        self, graph: FakeCompiledGraph, store: InMemoryThreadStore,
+    ) -> None:
+        app = _build_platform_app(graphs={"agent": graph}, store=store)
+        fa = app.function_app
+        fn = _get_fn(fa, "aflg_platform_threads_create")
+
+        req = func.HttpRequest(
+            method="POST",
+            url="/api/threads",
+            body=b"",
+            headers={},
+        )
+        resp = fn(req)
+        assert resp.status_code == 200
+
+
+class TestThreadsGet:
+    def test_get_existing_thread(
+        self, graph: FakeCompiledGraph, store: InMemoryThreadStore,
+    ) -> None:
+        app = _build_platform_app(graphs={"agent": graph}, store=store)
+        fa = app.function_app
+
+        # Create thread first
+        create_fn = _get_fn(fa, "aflg_platform_threads_create")
+        resp = create_fn(_post_request("/api/threads", {}))
+        thread_id = json.loads(resp.get_body())["thread_id"]
+
+        # Get thread
+        fa.functions_bindings = {}
+        get_fn = _get_fn(fa, "aflg_platform_threads_get")
+        req = _get_request(f"/api/threads/{thread_id}", thread_id=thread_id)
+        resp = get_fn(req)
+        assert resp.status_code == 200
+        data = json.loads(resp.get_body())
+        assert data["thread_id"] == thread_id
+
+    def test_get_not_found(self, graph: FakeCompiledGraph, store: InMemoryThreadStore) -> None:
+        app = _build_platform_app(graphs={"agent": graph}, store=store)
+        fa = app.function_app
+        fn = _get_fn(fa, "aflg_platform_threads_get")
+
+        req = _get_request("/api/threads/missing", thread_id="missing")
+        resp = fn(req)
+        assert resp.status_code == 404
+        data = json.loads(resp.get_body())
+        assert "not found" in data["detail"]
+
+
+# ---------------------------------------------------------------------------
+# Thread state endpoint
+# ---------------------------------------------------------------------------
+
+
+class TestThreadsStateGet:
+    def test_thread_not_found(self, graph: FakeCompiledGraph, store: InMemoryThreadStore) -> None:
+        app = _build_platform_app(graphs={"agent": graph}, store=store)
+        fa = app.function_app
+        fn = _get_fn(fa, "aflg_platform_threads_state_get")
+
+        req = _get_request("/api/threads/missing/state", thread_id="missing")
+        resp = fn(req)
+        assert resp.status_code == 404
+
+    def test_thread_not_bound_to_assistant(
+        self, graph: FakeCompiledGraph, store: InMemoryThreadStore
+    ) -> None:
+        app = _build_platform_app(graphs={"agent": graph}, store=store)
+        fa = app.function_app
+
+        # Create a thread (not bound)
+        create_fn = _get_fn(fa, "aflg_platform_threads_create")
+        resp = create_fn(_post_request("/api/threads", {}))
+        thread_id = json.loads(resp.get_body())["thread_id"]
+
+        # Get state — should 409 because not bound
+        fa.functions_bindings = {}
+        state_fn = _get_fn(fa, "aflg_platform_threads_state_get")
+        req = _get_request(f"/api/threads/{thread_id}/state", thread_id=thread_id)
+        resp = state_fn(req)
+        assert resp.status_code == 409
+        data = json.loads(resp.get_body())
+        assert "not bound" in data["detail"]
+
+    def test_state_with_stateful_graph(
+        self, store: InMemoryThreadStore
+    ) -> None:
+        sg = FakeStatefulGraph()
+        app = _build_platform_app(graphs={"agent": sg}, store=store)
+        fa = app.function_app
+
+        # Create thread and bind via a run
+        create_fn = _get_fn(fa, "aflg_platform_threads_create")
+        resp = create_fn(_post_request("/api/threads", {}))
+        thread_id = json.loads(resp.get_body())["thread_id"]
+
+        # Run to bind assistant
+        fa.functions_bindings = {}
+        wait_fn = _get_fn(fa, "aflg_platform_runs_wait")
+        req = _post_request(
+            f"/api/threads/{thread_id}/runs/wait",
+            {"assistant_id": "agent", "input": {"messages": []}},
+            thread_id=thread_id,
+        )
+        wait_fn(req)
+
+        # Now get state
+        fa.functions_bindings = {}
+        state_fn = _get_fn(fa, "aflg_platform_threads_state_get")
+        req = _get_request(f"/api/threads/{thread_id}/state", thread_id=thread_id)
+        resp = state_fn(req)
+        assert resp.status_code == 200
+        data = json.loads(resp.get_body())
+        assert "values" in data
+        assert "next" in data
+
+    def test_state_assistant_not_found(self, store: InMemoryThreadStore) -> None:
+        """If thread's assistant_id references a graph that no longer exists."""
+        sg = FakeStatefulGraph()
+        app = _build_platform_app(graphs={"agent": sg}, store=store)
+
+        # Create and bind thread manually
+        thread = store.create()
+        store.update(thread.thread_id, assistant_id="vanished")
+
+        fa = app.function_app
+        fn = _get_fn(fa, "aflg_platform_threads_state_get")
+        req = _get_request(
+            f"/api/threads/{thread.thread_id}/state",
+            thread_id=thread.thread_id,
+        )
+        resp = fn(req)
+        assert resp.status_code == 404
+        data = json.loads(resp.get_body())
+        assert "vanished" in data["detail"]
+
+    def test_state_graph_not_stateful(self, store: InMemoryThreadStore) -> None:
+        """Graph bound to thread doesn't support get_state."""
+        g = FakeCompiledGraph()  # has invoke/stream but NOT get_state
+        app = _build_platform_app(graphs={"agent": g}, store=store)
+
+        thread = store.create()
+        store.update(thread.thread_id, assistant_id="agent")
+
+        fa = app.function_app
+        fn = _get_fn(fa, "aflg_platform_threads_state_get")
+        req = _get_request(
+            f"/api/threads/{thread.thread_id}/state",
+            thread_id=thread.thread_id,
+        )
+        resp = fn(req)
+        assert resp.status_code == 409
+
+
+# ---------------------------------------------------------------------------
+# Runs/wait endpoint
+# ---------------------------------------------------------------------------
+
+
+class TestRunsWait:
+    def test_invoke_success(self, store: InMemoryThreadStore) -> None:
+        g = FakeCompiledGraph()
+        app = _build_platform_app(graphs={"agent": g}, store=store)
+        fa = app.function_app
+
+        # Create thread
+        create_fn = _get_fn(fa, "aflg_platform_threads_create")
+        resp = create_fn(_post_request("/api/threads", {}))
+        thread_id = json.loads(resp.get_body())["thread_id"]
+
+        # Run
+        fa.functions_bindings = {}
+        wait_fn = _get_fn(fa, "aflg_platform_runs_wait")
+        req = _post_request(
+            f"/api/threads/{thread_id}/runs/wait",
+            {"assistant_id": "agent", "input": {"messages": [{"role": "human", "content": "hi"}]}},
+            thread_id=thread_id,
+        )
+        resp = wait_fn(req)
+        assert resp.status_code == 200
+        data = json.loads(resp.get_body())
+        # SDK returns final state values (dict)
+        assert isinstance(data, dict)
+        assert "messages" in data
+
+    def test_thread_becomes_idle_after_run(self, store: InMemoryThreadStore) -> None:
+        g = FakeCompiledGraph()
+        app = _build_platform_app(graphs={"agent": g}, store=store)
+        fa = app.function_app
+
+        create_fn = _get_fn(fa, "aflg_platform_threads_create")
+        resp = create_fn(_post_request("/api/threads", {}))
+        thread_id = json.loads(resp.get_body())["thread_id"]
+
+        fa.functions_bindings = {}
+        wait_fn = _get_fn(fa, "aflg_platform_runs_wait")
+        req = _post_request(
+            f"/api/threads/{thread_id}/runs/wait",
+            {"assistant_id": "agent", "input": {}},
+            thread_id=thread_id,
+        )
+        wait_fn(req)
+
+        thread = store.get(thread_id)
+        assert thread is not None
+        assert thread.status == "idle"
+        assert thread.assistant_id == "agent"
+
+    def test_thread_not_found(self, store: InMemoryThreadStore) -> None:
+        g = FakeCompiledGraph()
+        app = _build_platform_app(graphs={"agent": g}, store=store)
+        fa = app.function_app
+        fn = _get_fn(fa, "aflg_platform_runs_wait")
+
+        req = _post_request(
+            "/api/threads/missing/runs/wait",
+            {"assistant_id": "agent", "input": {}},
+            thread_id="missing",
+        )
+        resp = fn(req)
+        assert resp.status_code == 404
+
+    def test_assistant_not_found(self, store: InMemoryThreadStore) -> None:
+        g = FakeCompiledGraph()
+        app = _build_platform_app(graphs={"agent": g}, store=store)
+        fa = app.function_app
+
+        thread = store.create()
+
+        fn = _get_fn(fa, "aflg_platform_runs_wait")
+        req = _post_request(
+            f"/api/threads/{thread.thread_id}/runs/wait",
+            {"assistant_id": "nonexistent", "input": {}},
+            thread_id=thread.thread_id,
+        )
+        resp = fn(req)
+        assert resp.status_code == 404
+        data = json.loads(resp.get_body())
+        assert "nonexistent" in data["detail"]
+
+    def test_thread_assistant_binding_immutable(self, store: InMemoryThreadStore) -> None:
+        """Once a thread is bound to an assistant, running with a different one is 409."""
+        g1 = FakeCompiledGraph()
+        g2 = FakeCompiledGraph()
+        app = _build_platform_app(graphs={"alpha": g1, "beta": g2}, store=store)
+        fa = app.function_app
+
+        # Create thread and bind to 'alpha'
+        thread = store.create()
+        store.update(thread.thread_id, assistant_id="alpha")
+
+        fn = _get_fn(fa, "aflg_platform_runs_wait")
+        req = _post_request(
+            f"/api/threads/{thread.thread_id}/runs/wait",
+            {"assistant_id": "beta", "input": {}},
+            thread_id=thread.thread_id,
+        )
+        resp = fn(req)
+        assert resp.status_code == 409
+        data = json.loads(resp.get_body())
+        assert "bound to assistant" in data["detail"]
+
+    def test_invalid_json_body(self, store: InMemoryThreadStore) -> None:
+        g = FakeCompiledGraph()
+        app = _build_platform_app(graphs={"agent": g}, store=store)
+        fa = app.function_app
+
+        thread = store.create()
+        fn = _get_fn(fa, "aflg_platform_runs_wait")
+        req = func.HttpRequest(
+            method="POST",
+            url=f"/api/threads/{thread.thread_id}/runs/wait",
+            body=b"not json",
+            headers={"Content-Type": "application/json"},
+            route_params={"thread_id": thread.thread_id},
+        )
+        resp = fn(req)
+        assert resp.status_code == 400
+
+    def test_validation_error(self, store: InMemoryThreadStore) -> None:
+        g = FakeCompiledGraph()
+        app = _build_platform_app(graphs={"agent": g}, store=store)
+        fa = app.function_app
+
+        thread = store.create()
+        fn = _get_fn(fa, "aflg_platform_runs_wait")
+        # Missing required assistant_id
+        req = _post_request(
+            f"/api/threads/{thread.thread_id}/runs/wait",
+            {"input": {}},
+            thread_id=thread.thread_id,
+        )
+        resp = fn(req)
+        assert resp.status_code == 422
+
+    def test_graph_execution_failure(self, store: InMemoryThreadStore) -> None:
+        class FailingGraph:
+            def invoke(self, input: dict[str, Any], config: dict[str, Any] | None = None) -> Any:
+                raise RuntimeError("boom")
+
+            def stream(
+                self,
+                input: dict[str, Any],
+                config: dict[str, Any] | None = None,
+                stream_mode: str = "values",
+            ) -> Iterator[Any]:
+                yield {}
+
+        app = _build_platform_app(graphs={"agent": FailingGraph()}, store=store)
+        fa = app.function_app
+
+        thread = store.create()
+
+        fn = _get_fn(fa, "aflg_platform_runs_wait")
+        req = _post_request(
+            f"/api/threads/{thread.thread_id}/runs/wait",
+            {"assistant_id": "agent", "input": {}},
+            thread_id=thread.thread_id,
+        )
+        resp = fn(req)
+        assert resp.status_code == 500
+
+        # Thread should be in error state
+        updated = store.get(thread.thread_id)
+        assert updated is not None
+        assert updated.status == "error"
+
+    def test_with_user_config(self, store: InMemoryThreadStore) -> None:
+        g = FakeCompiledGraph()
+        app = _build_platform_app(graphs={"agent": g}, store=store)
+        fa = app.function_app
+
+        thread = store.create()
+        fn = _get_fn(fa, "aflg_platform_runs_wait")
+        req = _post_request(
+            f"/api/threads/{thread.thread_id}/runs/wait",
+            {
+                "assistant_id": "agent",
+                "input": {},
+                "config": {"configurable": {"extra_key": "val"}},
+            },
+            thread_id=thread.thread_id,
+        )
+        resp = fn(req)
+        assert resp.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# Runs/stream endpoint
+# ---------------------------------------------------------------------------
+
+
+class TestRunsStream:
+    def test_stream_success(self, store: InMemoryThreadStore) -> None:
+        g = FakeCompiledGraph()
+        app = _build_platform_app(graphs={"agent": g}, store=store)
+        fa = app.function_app
+
+        thread = store.create()
+
+        fn = _get_fn(fa, "aflg_platform_runs_stream")
+        req = _post_request(
+            f"/api/threads/{thread.thread_id}/runs/stream",
+            {"assistant_id": "agent", "input": {}},
+            thread_id=thread.thread_id,
+        )
+        resp = fn(req)
+        assert resp.status_code == 200
+        body = resp.get_body().decode()
+
+        # Should have metadata event, data events, and end event
+        assert "event: metadata" in body
+        assert "run_id" in body
+        assert "event: values" in body
+        assert "event: end" in body
+
+    def test_stream_thread_not_found(self, store: InMemoryThreadStore) -> None:
+        g = FakeCompiledGraph()
+        app = _build_platform_app(graphs={"agent": g}, store=store)
+        fa = app.function_app
+        fn = _get_fn(fa, "aflg_platform_runs_stream")
+
+        req = _post_request(
+            "/api/threads/missing/runs/stream",
+            {"assistant_id": "agent", "input": {}},
+            thread_id="missing",
+        )
+        resp = fn(req)
+        assert resp.status_code == 404
+
+    def test_stream_assistant_not_found(self, store: InMemoryThreadStore) -> None:
+        g = FakeCompiledGraph()
+        app = _build_platform_app(graphs={"agent": g}, store=store)
+        fa = app.function_app
+
+        thread = store.create()
+
+        fn = _get_fn(fa, "aflg_platform_runs_stream")
+        req = _post_request(
+            f"/api/threads/{thread.thread_id}/runs/stream",
+            {"assistant_id": "nonexistent", "input": {}},
+            thread_id=thread.thread_id,
+        )
+        resp = fn(req)
+        assert resp.status_code == 404
+
+    def test_stream_not_streamable(self, store: InMemoryThreadStore) -> None:
+        """Graph that doesn't support streaming should return 501."""
+        g = FakeInvokeOnlyGraph()
+        app = _build_platform_app(graphs={"agent": g}, store=store)
+        fa = app.function_app
+
+        thread = store.create()
+
+        fn = _get_fn(fa, "aflg_platform_runs_stream")
+        req = _post_request(
+            f"/api/threads/{thread.thread_id}/runs/stream",
+            {"assistant_id": "agent", "input": {}},
+            thread_id=thread.thread_id,
+        )
+        resp = fn(req)
+        assert resp.status_code == 501
+
+    def test_stream_thread_binding_mismatch(self, store: InMemoryThreadStore) -> None:
+        g1 = FakeCompiledGraph()
+        g2 = FakeCompiledGraph()
+        app = _build_platform_app(graphs={"alpha": g1, "beta": g2}, store=store)
+        fa = app.function_app
+
+        thread = store.create()
+        store.update(thread.thread_id, assistant_id="alpha")
+
+        fn = _get_fn(fa, "aflg_platform_runs_stream")
+        req = _post_request(
+            f"/api/threads/{thread.thread_id}/runs/stream",
+            {"assistant_id": "beta", "input": {}},
+            thread_id=thread.thread_id,
+        )
+        resp = fn(req)
+        assert resp.status_code == 409
+
+    def test_stream_thread_becomes_idle(self, store: InMemoryThreadStore) -> None:
+        g = FakeCompiledGraph()
+        app = _build_platform_app(graphs={"agent": g}, store=store)
+        fa = app.function_app
+
+        thread = store.create()
+
+        fn = _get_fn(fa, "aflg_platform_runs_stream")
+        req = _post_request(
+            f"/api/threads/{thread.thread_id}/runs/stream",
+            {"assistant_id": "agent", "input": {}},
+            thread_id=thread.thread_id,
+        )
+        fn(req)
+
+        updated = store.get(thread.thread_id)
+        assert updated is not None
+        assert updated.status == "idle"
+        assert updated.assistant_id == "agent"
+
+    def test_stream_failure_sets_error_state(self, store: InMemoryThreadStore) -> None:
+        class FailingStreamGraph:
+            def invoke(self, input: dict[str, Any], config: dict[str, Any] | None = None) -> Any:
+                return {}
+
+            def stream(
+                self,
+                input: dict[str, Any],
+                config: dict[str, Any] | None = None,
+                stream_mode: str = "values",
+            ) -> Iterator[Any]:
+                raise RuntimeError("stream boom")
+
+        app = _build_platform_app(graphs={"agent": FailingStreamGraph()}, store=store)
+        fa = app.function_app
+
+        thread = store.create()
+
+        fn = _get_fn(fa, "aflg_platform_runs_stream")
+        req = _post_request(
+            f"/api/threads/{thread.thread_id}/runs/stream",
+            {"assistant_id": "agent", "input": {}},
+            thread_id=thread.thread_id,
+        )
+        resp = fn(req)
+        assert resp.status_code == 200  # SSE always 200
+        body = resp.get_body().decode()
+        assert "event: error" in body
+        assert "event: end" in body
+
+        updated = store.get(thread.thread_id)
+        assert updated is not None
+        assert updated.status == "error"
+
+    def test_stream_invalid_json(self, store: InMemoryThreadStore) -> None:
+        g = FakeCompiledGraph()
+        app = _build_platform_app(graphs={"agent": g}, store=store)
+        fa = app.function_app
+
+        thread = store.create()
+        fn = _get_fn(fa, "aflg_platform_runs_stream")
+        req = func.HttpRequest(
+            method="POST",
+            url=f"/api/threads/{thread.thread_id}/runs/stream",
+            body=b"not json",
+            headers={"Content-Type": "application/json"},
+            route_params={"thread_id": thread.thread_id},
+        )
+        resp = fn(req)
+        assert resp.status_code == 400
+
+    def test_stream_max_bytes_exceeded(self, store: InMemoryThreadStore) -> None:
+        """Stream should stop when max buffered bytes exceeded."""
+
+        class BigStreamGraph:
+            def invoke(self, input: dict[str, Any], config: dict[str, Any] | None = None) -> Any:
+                return {}
+
+            def stream(
+                self,
+                input: dict[str, Any],
+                config: dict[str, Any] | None = None,
+                stream_mode: str = "values",
+            ) -> Iterator[dict[str, Any]]:
+                for i in range(1000):
+                    yield {"data": "x" * 1000}
+
+        app = LangGraphApp(platform_compat=True, max_stream_response_bytes=500)
+        app._thread_store = store
+        app.register(graph=BigStreamGraph(), name="agent")
+        fa = app.function_app
+
+        thread = store.create()
+
+        fn = _get_fn(fa, "aflg_platform_runs_stream")
+        req = _post_request(
+            f"/api/threads/{thread.thread_id}/runs/stream",
+            {"assistant_id": "agent", "input": {}},
+            thread_id=thread.thread_id,
+        )
+        resp = fn(req)
+        body = resp.get_body().decode()
+        assert "event: error" in body
+        assert "max buffered size" in body
+
+
+# ---------------------------------------------------------------------------
+# Preflight validation (501 for unsupported features)
+# ---------------------------------------------------------------------------
+
+
+class TestPreflightValidation:
+    @pytest.mark.parametrize(
+        "field,value",
+        [
+            ("interrupt_before", ["node_a"]),
+            ("interrupt_after", ["node_b"]),
+            ("webhook", "https://example.com"),
+            ("on_completion", "callback"),
+            ("after_seconds", 10.0),
+            ("if_not_exists", "create"),
+            ("checkpoint_id", "cp-123"),
+        ],
+    )
+    def test_unsupported_field_returns_501(
+        self, store: InMemoryThreadStore, field: str, value: Any
+    ) -> None:
+        g = FakeCompiledGraph()
+        app = _build_platform_app(graphs={"agent": g}, store=store)
+        fa = app.function_app
+
+        thread = store.create()
+
+        fn = _get_fn(fa, "aflg_platform_runs_wait")
+        body = {"assistant_id": "agent", "input": {}, field: value}
+        req = _post_request(
+            f"/api/threads/{thread.thread_id}/runs/wait",
+            body,
+            thread_id=thread.thread_id,
+        )
+        resp = fn(req)
+        assert resp.status_code == 501
+
+    def test_multitask_reject_allowed(self, store: InMemoryThreadStore) -> None:
+        g = FakeCompiledGraph()
+        app = _build_platform_app(graphs={"agent": g}, store=store)
+        fa = app.function_app
+
+        thread = store.create()
+        fn = _get_fn(fa, "aflg_platform_runs_wait")
+        req = _post_request(
+            f"/api/threads/{thread.thread_id}/runs/wait",
+            {"assistant_id": "agent", "input": {}, "multitask_strategy": "reject"},
+            thread_id=thread.thread_id,
+        )
+        resp = fn(req)
+        assert resp.status_code == 200
+
+    def test_multitask_non_reject_returns_501(self, store: InMemoryThreadStore) -> None:
+        g = FakeCompiledGraph()
+        app = _build_platform_app(graphs={"agent": g}, store=store)
+        fa = app.function_app
+
+        thread = store.create()
+        fn = _get_fn(fa, "aflg_platform_runs_wait")
+        req = _post_request(
+            f"/api/threads/{thread.thread_id}/runs/wait",
+            {"assistant_id": "agent", "input": {}, "multitask_strategy": "enqueue"},
+            thread_id=thread.thread_id,
+        )
+        resp = fn(req)
+        assert resp.status_code == 501
+
+    @pytest.mark.parametrize(
+        "field,value",
+        [
+            ("interrupt_before", ["*"]),
+            ("webhook", "https://hooks.example.com/callback"),
+        ],
+    )
+    def test_unsupported_field_in_stream_returns_501(
+        self, store: InMemoryThreadStore, field: str, value: Any
+    ) -> None:
+        g = FakeCompiledGraph()
+        app = _build_platform_app(graphs={"agent": g}, store=store)
+        fa = app.function_app
+
+        thread = store.create()
+
+        fn = _get_fn(fa, "aflg_platform_runs_stream")
+        body = {"assistant_id": "agent", "input": {}, field: value}
+        req = _post_request(
+            f"/api/threads/{thread.thread_id}/runs/stream",
+            body,
+            thread_id=thread.thread_id,
+        )
+        resp = fn(req)
+        assert resp.status_code == 501
+
+
+# ---------------------------------------------------------------------------
+# Platform error helper
+# ---------------------------------------------------------------------------
+
+
+class TestPlatformError:
+    def test_error_format(self) -> None:
+        resp = _platform_error(418, "I'm a teapot")
+        assert resp.status_code == 418
+        data = json.loads(resp.get_body())
+        assert data["detail"] == "I'm a teapot"
+        assert resp.mimetype == "application/json"
+
+
+# ---------------------------------------------------------------------------
+# PlatformRouteDeps
+# ---------------------------------------------------------------------------
+
+
+class TestPlatformRouteDeps:
+    def test_construction(self, store: InMemoryThreadStore) -> None:
+        deps = PlatformRouteDeps(
+            registrations={},
+            thread_store=store,
+            auth_level=func.AuthLevel.ANONYMOUS,
+            max_stream_response_bytes=1024,
+        )
+        assert deps.registrations == {}
+        assert deps.thread_store is store
+        assert deps.auth_level == func.AuthLevel.ANONYMOUS
+        assert deps.max_stream_response_bytes == 1024
+
+
+# ---------------------------------------------------------------------------
+# Oracle review fixes — additional tests
+# ---------------------------------------------------------------------------
+
+
+class TestBusyThreadReject:
+    """Threads marked 'busy' must return 409 on new run attempts."""
+
+    def test_runs_wait_busy_thread_returns_409(self, store: InMemoryThreadStore) -> None:
+        g = FakeCompiledGraph()
+        app = _build_platform_app(graphs={"agent": g}, store=store)
+        fa = app.function_app
+
+        thread = store.create()
+        store.update(thread.thread_id, status="busy", assistant_id="agent")
+
+        fn = _get_fn(fa, "aflg_platform_runs_wait")
+        req = _post_request(
+            f"/api/threads/{thread.thread_id}/runs/wait",
+            {"assistant_id": "agent", "input": {}},
+            thread_id=thread.thread_id,
+        )
+        resp = fn(req)
+        assert resp.status_code == 409
+        data = json.loads(resp.get_body())
+        assert "busy" in data["detail"]
+
+    def test_runs_stream_busy_thread_returns_409(self, store: InMemoryThreadStore) -> None:
+        g = FakeCompiledGraph()
+        app = _build_platform_app(graphs={"agent": g}, store=store)
+        fa = app.function_app
+
+        thread = store.create()
+        store.update(thread.thread_id, status="busy", assistant_id="agent")
+
+        fn = _get_fn(fa, "aflg_platform_runs_stream")
+        req = _post_request(
+            f"/api/threads/{thread.thread_id}/runs/stream",
+            {"assistant_id": "agent", "input": {}},
+            thread_id=thread.thread_id,
+        )
+        resp = fn(req)
+        assert resp.status_code == 409
+        data = json.loads(resp.get_body())
+        assert "busy" in data["detail"]
+
+    def test_idle_thread_can_run(self, store: InMemoryThreadStore) -> None:
+        g = FakeCompiledGraph()
+        app = _build_platform_app(graphs={"agent": g}, store=store)
+        fa = app.function_app
+
+        thread = store.create()
+        # Thread is idle by default
+
+        fn = _get_fn(fa, "aflg_platform_runs_wait")
+        req = _post_request(
+            f"/api/threads/{thread.thread_id}/runs/wait",
+            {"assistant_id": "agent", "input": {}},
+            thread_id=thread.thread_id,
+        )
+        resp = fn(req)
+        assert resp.status_code == 200
+
+
+class TestAssistantsSearchInvalidJson:
+    """Invalid JSON in assistants_search should return 400."""
+
+    def test_invalid_json_returns_400(
+        self, graph: FakeCompiledGraph, store: InMemoryThreadStore,
+    ) -> None:
+        app = _build_platform_app(graphs={"agent": graph}, store=store)
+        fa = app.function_app
+        fn = _get_fn(fa, "aflg_platform_assistants_search")
+
+        req = func.HttpRequest(
+            method="POST",
+            url="/api/assistants/search",
+            body=b"not valid json",
+            headers={"Content-Type": "application/json"},
+        )
+        resp = fn(req)
+        assert resp.status_code == 400
+        data = json.loads(resp.get_body())
+        assert "Invalid JSON" in data["detail"]
+
+
+class TestContentLocationHeader:
+    """Runs endpoints must include Content-Location header."""
+
+    def test_runs_wait_has_content_location(self, store: InMemoryThreadStore) -> None:
+        g = FakeCompiledGraph()
+        app = _build_platform_app(graphs={"agent": g}, store=store)
+        fa = app.function_app
+
+        thread = store.create()
+
+        fn = _get_fn(fa, "aflg_platform_runs_wait")
+        req = _post_request(
+            f"/api/threads/{thread.thread_id}/runs/wait",
+            {"assistant_id": "agent", "input": {}},
+            thread_id=thread.thread_id,
+        )
+        resp = fn(req)
+        assert resp.status_code == 200
+        headers = dict(resp.headers)
+        assert "Content-Location" in headers
+        assert f"/api/threads/{thread.thread_id}/runs/" in headers["Content-Location"]
+
+    def test_runs_stream_has_content_location(self, store: InMemoryThreadStore) -> None:
+        g = FakeCompiledGraph()
+        app = _build_platform_app(graphs={"agent": g}, store=store)
+        fa = app.function_app
+
+        thread = store.create()
+
+        fn = _get_fn(fa, "aflg_platform_runs_stream")
+        req = _post_request(
+            f"/api/threads/{thread.thread_id}/runs/stream",
+            {"assistant_id": "agent", "input": {}},
+            thread_id=thread.thread_id,
+        )
+        resp = fn(req)
+        assert resp.status_code == 200
+        headers = dict(resp.headers)
+        assert "Content-Location" in headers
+        assert f"/api/threads/{thread.thread_id}/runs/" in headers["Content-Location"]
+
+
+class TestAdditionalPreflightFields:
+    """command and feedback_keys should return 501."""
+
+    @pytest.mark.parametrize(
+        "field,value",
+        [
+            ("command", {"resume": "value"}),
+            ("feedback_keys", ["key1", "key2"]),
+        ],
+    )
+    def test_unsupported_new_fields_return_501(
+        self, store: InMemoryThreadStore, field: str, value: Any
+    ) -> None:
+        g = FakeCompiledGraph()
+        app = _build_platform_app(graphs={"agent": g}, store=store)
+        fa = app.function_app
+
+        thread = store.create()
+
+        fn = _get_fn(fa, "aflg_platform_runs_wait")
+        body = {"assistant_id": "agent", "input": {}, field: value}
+        req = _post_request(
+            f"/api/threads/{thread.thread_id}/runs/wait",
+            body,
+            thread_id=thread.thread_id,
+        )
+        resp = fn(req)
+        assert resp.status_code == 501
+
+
+class TestStableAssistantTimestamps:
+    """Assistant timestamps should be stable across calls."""
+
+    def test_timestamps_are_stable(
+        self, graph: FakeCompiledGraph, store: InMemoryThreadStore,
+    ) -> None:
+        app = _build_platform_app(graphs={"agent": graph}, store=store)
+        fa = app.function_app
+        fn = _get_fn(fa, "aflg_platform_assistants_get")
+
+        req1 = _get_request("/api/assistants/agent", assistant_id="agent")
+        resp1 = fn(req1)
+        data1 = json.loads(resp1.get_body())
+
+        req2 = _get_request("/api/assistants/agent", assistant_id="agent")
+        resp2 = fn(req2)
+        data2 = json.loads(resp2.get_body())
+
+        assert data1["created_at"] == data2["created_at"]
+        assert data1["updated_at"] == data2["updated_at"]


### PR DESCRIPTION
## Summary
- Adds 7 LangGraph Platform API-compatible HTTP routes for `langgraph-sdk` client compatibility
- Thread-assistant binding with busy-thread rejection (409)
- Content-Location headers for SDK run metadata extraction
- Preflight validation for unsupported features (501)
- 63 new tests (275 total), 96.75% coverage, lint clean

## Routes Added
| SDK Method | HTTP | Route |
|---|---|---|
| `assistants.search()` | POST | `/assistants/search` |
| `assistants.get(id)` | GET | `/assistants/{assistant_id}` |
| `threads.create()` | POST | `/threads` |
| `threads.get(id)` | GET | `/threads/{thread_id}` |
| `threads.get_state(id)` | GET | `/threads/{thread_id}/state` |
| `runs.wait(tid, aid)` | POST | `/threads/{thread_id}/runs/wait` |
| `runs.stream(tid, aid)` | POST | `/threads/{thread_id}/runs/stream` |

## Oracle Review Findings Addressed
1. **Busy-thread check**: 409 when thread status is "busy" (multitask_strategy=reject)
2. **Invalid JSON handling**: Return 400 for malformed JSON; empty body defaults to `{}`
3. **List values support**: `snapshot.values` handles both `dict` and `list[dict]`
4. **Stable timestamps**: Module-level `_PROCESS_START` instead of per-request `datetime.now()`
5. **Content-Location header**: Added to runs/wait and runs/stream responses
6. **Additional preflight fields**: `command` and `feedback_keys` now return 501
7. **TOCTOU race documented**: Comment noting acceptable for InMemory, needs CAS for durable backends

Closes #38