### PR TITLE
test: integration tests with real LangGraph graphs (#41)

### DIFF
--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,0 +1,454 @@
+"""Integration tests using real LangGraph StateGraph + InMemorySaver.
+
+These tests drive real compiled graphs through the native HTTP handler layer
+(``/api/graphs/{name}/invoke``, ``stream``, ``state``).  All node logic is
+deterministic — no LLM calls.
+
+Issue: #41
+"""
+
+from __future__ import annotations
+
+import json
+import operator
+from typing import Annotated, Any, TypedDict
+
+import azure.functions as func
+from langgraph.checkpoint.memory import MemorySaver
+from langgraph.graph import END, START, StateGraph
+
+from azure_functions_langgraph.app import LangGraphApp
+
+# ---------------------------------------------------------------------------
+# Graph state & deterministic nodes
+# ---------------------------------------------------------------------------
+
+
+class ChatState(TypedDict, total=False):
+    user_text: str
+    history: Annotated[list[str], operator.add]
+    turn_count: int
+    last_reply: str
+
+
+def greet(state: ChatState) -> dict[str, Any]:
+    """First node — build a greeting from *user_text*."""
+    text = state.get("user_text", "")
+    reply = f"Hello, {text}!" if text else "Hello!"
+    return {"history": [reply], "last_reply": reply}
+
+
+def count(state: ChatState) -> dict[str, Any]:
+    """Second node — increment *turn_count*."""
+    return {"turn_count": (state.get("turn_count") or 0) + 1}
+
+
+def _build_graph(*, checkpointer: Any = None) -> Any:
+    """Compile a two-node deterministic graph.
+
+    ``greet`` → ``count`` with optional *checkpointer* for persistence.
+    """
+    builder = StateGraph(ChatState)
+    builder.add_node("greet", greet)
+    builder.add_node("count", count)
+    builder.add_edge(START, "greet")
+    builder.add_edge("greet", "count")
+    builder.add_edge("count", END)
+    return builder.compile(checkpointer=checkpointer)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_app(graph: Any, *, name: str = "agent") -> LangGraphApp:
+    """Build a LangGraphApp with a single registered graph."""
+    app = LangGraphApp()
+    app.register(graph=graph, name=name)
+    return app
+
+
+def _get_fn(fa: func.FunctionApp, fn_name: str) -> Any:
+    """Retrieve a registered function handler by name."""
+    fa.functions_bindings = {}
+    for fn in fa.get_functions():
+        if fn.get_function_name() == fn_name:
+            return fn.get_user_function()
+    raise AssertionError(f"Function {fn_name!r} not found")
+
+
+def _post(url: str, body: dict[str, Any], **route_params: str) -> func.HttpRequest:
+    return func.HttpRequest(
+        method="POST",
+        url=url,
+        body=json.dumps(body).encode(),
+        headers={"Content-Type": "application/json"},
+        route_params=route_params,
+    )
+
+
+def _get(url: str, **route_params: str) -> func.HttpRequest:
+    return func.HttpRequest(
+        method="GET",
+        url=url,
+        body=b"",
+        route_params=route_params,
+    )
+
+
+def _parse_sse_frames(body: str) -> list[dict[str, Any]]:
+    """Parse SSE body into structured frames.
+
+    Each frame is ``{"event": ..., "data": ...}`` where *data* is the
+    parsed JSON payload (or ``None`` when the data line is empty/absent).
+    Frames are delimited by blank lines per the SSE specification.
+    """
+    frames: list[dict[str, Any]] = []
+    current_event: str | None = None
+    data_lines: list[str] = []
+    for line in body.splitlines():
+        if line.startswith("event: "):
+            current_event = line.removeprefix("event: ")
+        elif line.startswith("data: "):
+            data_lines.append(line.removeprefix("data: "))
+        elif line == "":
+            if current_event is not None or data_lines:
+                raw = "\n".join(data_lines)
+                try:
+                    payload = json.loads(raw) if raw.strip() else None
+                except json.JSONDecodeError:
+                    payload = raw
+                frames.append({"event": current_event, "data": payload})
+                current_event = None
+                data_lines = []
+    # Flush last frame if no trailing blank line
+    if current_event is not None or data_lines:
+        raw = "\n".join(data_lines)
+        try:
+            payload = json.loads(raw) if raw.strip() else None
+        except json.JSONDecodeError:
+            payload = raw
+        frames.append({"event": current_event, "data": payload})
+    return frames
+
+
+# ---------------------------------------------------------------------------
+# Tests — Native routes with real LangGraph graphs
+# ---------------------------------------------------------------------------
+
+
+class TestNativeInvoke:
+    """Invoke endpoint with real compiled graph."""
+
+    def test_single_turn_invoke(self) -> None:
+        """Single invoke returns expected state from deterministic nodes."""
+        saver = MemorySaver()
+        graph = _build_graph(checkpointer=saver)
+        app = _make_app(graph)
+        handler = _get_fn(app.function_app, "aflg_agent_invoke")
+
+        req = _post(
+            "/api/graphs/agent/invoke",
+            {
+                "input": {"user_text": "Alice", "history": [], "turn_count": 0},
+                "config": {"configurable": {"thread_id": "t1"}},
+            },
+        )
+        resp = handler(req)
+        assert resp.status_code == 200
+        data = json.loads(resp.get_body())
+        output = data["output"]
+
+        assert output["last_reply"] == "Hello, Alice!"
+        assert "Hello, Alice!" in output["history"]
+        assert output["turn_count"] == 1
+
+    def test_multi_turn_invoke_accumulates_state(self) -> None:
+        """Two sequential invokes on the same thread accumulate history."""
+        saver = MemorySaver()
+        graph = _build_graph(checkpointer=saver)
+        app = _make_app(graph)
+        handler = _get_fn(app.function_app, "aflg_agent_invoke")
+
+        # Turn 1
+        req1 = _post(
+            "/api/graphs/agent/invoke",
+            {
+                "input": {"user_text": "Alice", "history": [], "turn_count": 0},
+                "config": {"configurable": {"thread_id": "t-multi"}},
+            },
+        )
+        resp1 = handler(req1)
+        assert resp1.status_code == 200
+        out1 = json.loads(resp1.get_body())["output"]
+        assert out1["turn_count"] == 1
+
+        # Turn 2 — same thread_id, state accumulates via reducer
+        req2 = _post(
+            "/api/graphs/agent/invoke",
+            {
+                "input": {"user_text": "Bob"},
+                "config": {"configurable": {"thread_id": "t-multi"}},
+            },
+        )
+        resp2 = handler(req2)
+        assert resp2.status_code == 200
+        out2 = json.loads(resp2.get_body())["output"]
+
+        assert out2["turn_count"] == 2
+        assert out2["history"] == ["Hello, Alice!", "Hello, Bob!"]
+        assert out2["last_reply"] == "Hello, Bob!"
+
+    def test_different_threads_are_isolated(self) -> None:
+        """Different thread_ids maintain independent state."""
+        saver = MemorySaver()
+        graph = _build_graph(checkpointer=saver)
+        app = _make_app(graph)
+        handler = _get_fn(app.function_app, "aflg_agent_invoke")
+
+        for tid, name in [("iso-a", "Alpha"), ("iso-b", "Beta")]:
+            req = _post(
+                "/api/graphs/agent/invoke",
+                {
+                    "input": {"user_text": name, "history": [], "turn_count": 0},
+                    "config": {"configurable": {"thread_id": tid}},
+                },
+            )
+            resp = handler(req)
+            assert resp.status_code == 200
+            out = json.loads(resp.get_body())["output"]
+            assert out["turn_count"] == 1
+            assert out["history"] == [f"Hello, {name}!"]
+
+
+class TestNativeStream:
+    """Stream endpoint with real compiled graph."""
+
+    def test_stream_values_mode(self) -> None:
+        """stream_mode='values' yields intermediate + final state snapshots."""
+        saver = MemorySaver()
+        graph = _build_graph(checkpointer=saver)
+        app = _make_app(graph)
+        handler = _get_fn(app.function_app, "aflg_agent_stream")
+
+        req = _post(
+            "/api/graphs/agent/stream",
+            {
+                "input": {"user_text": "Eve", "history": [], "turn_count": 0},
+                "config": {"configurable": {"thread_id": "stream-v"}},
+                "stream_mode": "values",
+            },
+        )
+        resp = handler(req)
+        assert resp.status_code == 200
+        assert resp.mimetype == "text/event-stream"
+
+        # Parse SSE frames using proper frame-based parser
+        body = resp.get_body().decode()
+        frames = _parse_sse_frames(body)
+
+        # Filter to data-bearing frames (skip empty payloads)
+        data_frames = [f for f in frames if f["data"] and isinstance(f["data"], dict)]
+
+        # At least 2 data events (intermediate snapshots + final)
+        assert len(data_frames) >= 2
+        # Final event should have the completed state
+        final = data_frames[-1]["data"]
+        assert final["turn_count"] == 1
+        assert final["history"] == ["Hello, Eve!"]
+        assert final["last_reply"] == "Hello, Eve!"
+
+    def test_stream_updates_mode(self) -> None:
+        """stream_mode='updates' yields per-node update dicts."""
+        saver = MemorySaver()
+        graph = _build_graph(checkpointer=saver)
+        app = _make_app(graph)
+        handler = _get_fn(app.function_app, "aflg_agent_stream")
+
+        req = _post(
+            "/api/graphs/agent/stream",
+            {
+                "input": {"user_text": "Frank", "history": [], "turn_count": 0},
+                "config": {"configurable": {"thread_id": "stream-u"}},
+                "stream_mode": "updates",
+            },
+        )
+        resp = handler(req)
+        assert resp.status_code == 200
+
+        body = resp.get_body().decode()
+        frames = _parse_sse_frames(body)
+
+        # Filter to data-bearing frames
+        data_frames = [f for f in frames if f["data"] and isinstance(f["data"], dict)]
+
+        # updates mode yields node-keyed dicts: {"greet": {...}}, {"count": {...}}
+        node_names = set()
+        for frame in data_frames:
+            node_names.update(frame["data"].keys())
+        assert "greet" in node_names
+        assert "count" in node_names
+
+        # Verify payload content — greet node should produce greeting
+        greet_frames = [f for f in data_frames if "greet" in f["data"]]
+        assert len(greet_frames) >= 1
+        greet_payload = greet_frames[0]["data"]["greet"]
+        assert greet_payload["last_reply"] == "Hello, Frank!"
+        assert greet_payload["history"] == ["Hello, Frank!"]
+
+
+class TestNativeState:
+    """State endpoint with real compiled graph."""
+
+    def test_state_after_invoke(self) -> None:
+        """GET /state returns persisted thread state after invoke."""
+        saver = MemorySaver()
+        graph = _build_graph(checkpointer=saver)
+        app = _make_app(graph)
+        fa = app.function_app
+
+        invoke_fn = _get_fn(fa, "aflg_agent_invoke")
+        state_fn = _get_fn(fa, "aflg_agent_state")
+
+        # Invoke first
+        req = _post(
+            "/api/graphs/agent/invoke",
+            {
+                "input": {"user_text": "Grace", "history": [], "turn_count": 0},
+                "config": {"configurable": {"thread_id": "state-t1"}},
+            },
+        )
+        resp = invoke_fn(req)
+        assert resp.status_code == 200
+
+        # GET state
+        state_req = _get(
+            "/api/graphs/agent/threads/state-t1/state",
+            thread_id="state-t1",
+        )
+        state_resp = state_fn(state_req)
+        assert state_resp.status_code == 200
+        state_data = json.loads(state_resp.get_body())
+
+        assert state_data["values"]["turn_count"] == 1
+        assert state_data["values"]["history"] == ["Hello, Grace!"]
+        assert state_data["values"]["last_reply"] == "Hello, Grace!"
+        assert state_data["next"] == []
+
+    def test_state_cross_check_with_direct_get_state(self) -> None:
+        """HTTP state endpoint matches direct graph.get_state() on stable fields."""
+        saver = MemorySaver()
+        graph = _build_graph(checkpointer=saver)
+        app = _make_app(graph)
+        fa = app.function_app
+
+        invoke_fn = _get_fn(fa, "aflg_agent_invoke")
+        state_fn = _get_fn(fa, "aflg_agent_state")
+
+        # Invoke
+        req = _post(
+            "/api/graphs/agent/invoke",
+            {
+                "input": {"user_text": "Ivy", "history": [], "turn_count": 0},
+                "config": {"configurable": {"thread_id": "xcheck-1"}},
+            },
+        )
+        invoke_fn(req)
+
+        # HTTP state
+        state_req = _get(
+            "/api/graphs/agent/threads/xcheck-1/state",
+            thread_id="xcheck-1",
+        )
+        http_resp = state_fn(state_req)
+        http_state = json.loads(http_resp.get_body())
+
+        # Direct get_state
+        config = {"configurable": {"thread_id": "xcheck-1"}}
+        snapshot = graph.get_state(config)
+
+        # Cross-check stable fields
+        assert http_state["values"] == snapshot.values
+        assert http_state["next"] == list(snapshot.next)
+
+
+class TestNativeErrors:
+    """Error paths with real compiled graphs."""
+
+    def test_state_unknown_thread_returns_empty(self) -> None:
+        """GET /state for nonexistent thread returns 200 with empty values.
+
+        Real MemorySaver returns an empty StateSnapshot (values={}, next=())
+        for threads that have never been written — this is NOT a 404.
+        """
+        saver = MemorySaver()
+        graph = _build_graph(checkpointer=saver)
+        app = _make_app(graph)
+        state_fn = _get_fn(app.function_app, "aflg_agent_state")
+
+        req = _get(
+            "/api/graphs/agent/threads/nonexistent/state",
+            thread_id="nonexistent",
+        )
+        resp = state_fn(req)
+        assert resp.status_code == 200
+        data = json.loads(resp.get_body())
+        assert data["values"] == {}
+        assert data["next"] == []
+
+    def test_state_no_checkpointer_returns_404(self) -> None:
+        """Graph without checkpointer → get_state raises ValueError → 404."""
+        graph = _build_graph(checkpointer=None)
+        # Real compiled graphs always have get_state(), so state route IS registered.
+        # But get_state() raises ValueError('No checkpointer set').
+        app = _make_app(graph)
+        state_fn = _get_fn(app.function_app, "aflg_agent_state")
+
+        req = _get(
+            "/api/graphs/agent/threads/no-cp/state",
+            thread_id="no-cp",
+        )
+        resp = state_fn(req)
+        # ValueError is caught by handle_state → 404 (thread not found)
+        assert resp.status_code == 404
+
+
+class TestNativeStreamState:
+    """Verify that stream also persists checkpointed state."""
+
+    def test_stream_persists_state(self) -> None:
+        """After streaming, GET /state returns the final persisted state."""
+        saver = MemorySaver()
+        graph = _build_graph(checkpointer=saver)
+        app = _make_app(graph)
+        fa = app.function_app
+
+        stream_fn = _get_fn(fa, "aflg_agent_stream")
+        state_fn = _get_fn(fa, "aflg_agent_state")
+
+        # Stream first
+        req = _post(
+            "/api/graphs/agent/stream",
+            {
+                "input": {"user_text": "Streamer", "history": [], "turn_count": 0},
+                "config": {"configurable": {"thread_id": "stream-persist"}},
+                "stream_mode": "values",
+            },
+        )
+        stream_resp = stream_fn(req)
+        assert stream_resp.status_code == 200
+
+        # GET state — should be persisted by checkpointer
+        state_req = _get(
+            "/api/graphs/agent/threads/stream-persist/state",
+            thread_id="stream-persist",
+        )
+        state_resp = state_fn(state_req)
+        assert state_resp.status_code == 200
+        state_data = json.loads(state_resp.get_body())
+
+        assert state_data["values"]["turn_count"] == 1
+        assert state_data["values"]["history"] == ["Hello, Streamer!"]
+        assert state_data["values"]["last_reply"] == "Hello, Streamer!"
+        assert state_data["next"] == []

--- a/tests/test_integration_platform.py
+++ b/tests/test_integration_platform.py
@@ -1,0 +1,333 @@
+"""Integration tests — Platform API routes with real LangGraph graphs.
+
+These tests drive real compiled graphs through the Platform API–compatible
+route layer (``/api/threads/{thread_id}/runs/wait``, ``runs/stream``,
+``threads/{thread_id}/state``).
+
+Issue: #41
+"""
+
+from __future__ import annotations
+
+import json
+import operator
+from typing import Annotated, Any, TypedDict
+
+import azure.functions as func
+from langgraph.checkpoint.memory import MemorySaver
+from langgraph.graph import END, START, StateGraph
+
+from azure_functions_langgraph.app import LangGraphApp
+from azure_functions_langgraph.platform.stores import InMemoryThreadStore
+
+# ---------------------------------------------------------------------------
+# Graph state & deterministic nodes (same schema as test_integration.py)
+# ---------------------------------------------------------------------------
+
+
+class ChatState(TypedDict, total=False):
+    user_text: str
+    history: Annotated[list[str], operator.add]
+    turn_count: int
+    last_reply: str
+
+
+def greet(state: ChatState) -> dict[str, Any]:
+    text = state.get("user_text", "")
+    reply = f"Hello, {text}!" if text else "Hello!"
+    return {"history": [reply], "last_reply": reply}
+
+
+def count(state: ChatState) -> dict[str, Any]:
+    return {"turn_count": (state.get("turn_count") or 0) + 1}
+
+
+def _build_graph(*, checkpointer: Any = None) -> Any:
+    builder = StateGraph(ChatState)
+    builder.add_node("greet", greet)
+    builder.add_node("count", count)
+    builder.add_edge(START, "greet")
+    builder.add_edge("greet", "count")
+    builder.add_edge("count", END)
+    return builder.compile(checkpointer=checkpointer)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_platform_app(
+    graph: Any,
+    *,
+    store: InMemoryThreadStore | None = None,
+    name: str = "agent",
+) -> LangGraphApp:
+    """Build a LangGraphApp with platform_compat=True."""
+    app = LangGraphApp(platform_compat=True)
+    if store is not None:
+        app._thread_store = store
+    app.register(graph=graph, name=name)
+    return app
+
+
+def _get_fn(fa: func.FunctionApp, fn_name: str) -> Any:
+    fa.functions_bindings = {}
+    for fn in fa.get_functions():
+        if fn.get_function_name() == fn_name:
+            return fn.get_user_function()
+    raise AssertionError(f"Function {fn_name!r} not found")
+
+
+def _post(url: str, body: dict[str, Any], **route_params: str) -> func.HttpRequest:
+    return func.HttpRequest(
+        method="POST",
+        url=url,
+        body=json.dumps(body).encode(),
+        headers={"Content-Type": "application/json"},
+        route_params=route_params,
+    )
+
+
+def _get(url: str, **route_params: str) -> func.HttpRequest:
+    return func.HttpRequest(
+        method="GET",
+        url=url,
+        body=b"",
+        route_params=route_params,
+    )
+
+
+def _parse_sse_frames(body: str) -> list[dict[str, Any]]:
+    """Parse SSE body into structured frames.
+
+    Each frame is ``{"event": ..., "data": ...}`` where *data* is the
+    parsed JSON payload (or ``None`` when the data line is empty/absent).
+    Frames are delimited by blank lines per the SSE specification.
+    """
+    frames: list[dict[str, Any]] = []
+    current_event: str | None = None
+    data_lines: list[str] = []
+    for line in body.splitlines():
+        if line.startswith("event: "):
+            current_event = line.removeprefix("event: ")
+        elif line.startswith("data: "):
+            data_lines.append(line.removeprefix("data: "))
+        elif line == "":
+            if current_event is not None or data_lines:
+                raw = "\n".join(data_lines)
+                try:
+                    payload = json.loads(raw) if raw.strip() else None
+                except json.JSONDecodeError:
+                    payload = raw
+                frames.append({"event": current_event, "data": payload})
+                current_event = None
+                data_lines = []
+    # Flush last frame if no trailing blank line
+    if current_event is not None or data_lines:
+        raw = "\n".join(data_lines)
+        try:
+            payload = json.loads(raw) if raw.strip() else None
+        except json.JSONDecodeError:
+            payload = raw
+        frames.append({"event": current_event, "data": payload})
+    return frames
+
+
+# ---------------------------------------------------------------------------
+# Tests — Platform routes with real LangGraph graphs
+# ---------------------------------------------------------------------------
+
+
+class TestPlatformInvoke:
+    """runs/wait endpoint with real compiled graph."""
+
+    def test_invoke_via_platform(self) -> None:
+        """POST /threads/{tid}/runs/wait invokes real graph and returns state."""
+        saver = MemorySaver()
+        graph = _build_graph(checkpointer=saver)
+        store = InMemoryThreadStore(id_factory=lambda: "pt-1")
+        app = _make_platform_app(graph, store=store)
+        fa = app.function_app
+
+        # Create thread
+        create_fn = _get_fn(fa, "aflg_platform_threads_create")
+        resp = create_fn(_post("/api/threads", {}))
+        assert resp.status_code == 200
+        thread = json.loads(resp.get_body())
+        tid = thread["thread_id"]
+
+        # runs/wait
+        wait_fn = _get_fn(fa, "aflg_platform_runs_wait")
+        req = _post(
+            f"/api/threads/{tid}/runs/wait",
+            {
+                "assistant_id": "agent",
+                "input": {"user_text": "Platform", "history": [], "turn_count": 0},
+            },
+            thread_id=tid,
+        )
+        resp = wait_fn(req)
+        assert resp.status_code == 200
+
+        output = json.loads(resp.get_body())
+        assert output["last_reply"] == "Hello, Platform!"
+        assert output["turn_count"] == 1
+        assert "Hello, Platform!" in output["history"]
+
+    def test_multi_turn_via_platform(self) -> None:
+        """Two runs/wait on same thread accumulate state."""
+        saver = MemorySaver()
+        graph = _build_graph(checkpointer=saver)
+        store = InMemoryThreadStore(id_factory=lambda: "pt-mt")
+        app = _make_platform_app(graph, store=store)
+        fa = app.function_app
+
+        # Create thread
+        create_fn = _get_fn(fa, "aflg_platform_threads_create")
+        resp = create_fn(_post("/api/threads", {}))
+        tid = json.loads(resp.get_body())["thread_id"]
+
+        wait_fn = _get_fn(fa, "aflg_platform_runs_wait")
+
+        # Turn 1
+        req1 = _post(
+            f"/api/threads/{tid}/runs/wait",
+            {
+                "assistant_id": "agent",
+                "input": {"user_text": "Turn1", "history": [], "turn_count": 0},
+            },
+            thread_id=tid,
+        )
+        out1 = json.loads(wait_fn(req1).get_body())
+        assert out1["turn_count"] == 1
+
+        # Turn 2
+        req2 = _post(
+            f"/api/threads/{tid}/runs/wait",
+            {
+                "assistant_id": "agent",
+                "input": {"user_text": "Turn2"},
+            },
+            thread_id=tid,
+        )
+        out2 = json.loads(wait_fn(req2).get_body())
+        assert out2["turn_count"] == 2
+        assert "Hello, Turn1!" in out2["history"]
+        assert out2["history"] == ["Hello, Turn1!", "Hello, Turn2!"]
+        assert out2["last_reply"] == "Hello, Turn2!"
+
+
+class TestPlatformStream:
+    """runs/stream endpoint with real compiled graph."""
+
+    def test_stream_via_platform(self) -> None:
+        """POST /threads/{tid}/runs/stream returns valid SSE events."""
+        saver = MemorySaver()
+        graph = _build_graph(checkpointer=saver)
+        store = InMemoryThreadStore(id_factory=lambda: "ps-1")
+        app = _make_platform_app(graph, store=store)
+        fa = app.function_app
+
+        # Create thread
+        create_fn = _get_fn(fa, "aflg_platform_threads_create")
+        resp = create_fn(_post("/api/threads", {}))
+        tid = json.loads(resp.get_body())["thread_id"]
+
+        # runs/stream
+        stream_fn = _get_fn(fa, "aflg_platform_runs_stream")
+        req = _post(
+            f"/api/threads/{tid}/runs/stream",
+            {
+                "assistant_id": "agent",
+                "input": {"user_text": "Stream", "history": [], "turn_count": 0},
+                "stream_mode": "values",
+            },
+            thread_id=tid,
+        )
+        resp = stream_fn(req)
+        assert resp.status_code == 200
+        assert resp.mimetype == "text/event-stream"
+
+        body = resp.get_body().decode()
+        frames = _parse_sse_frames(body)
+
+        # Verify event types using proper frame parser
+        event_types = [f["event"] for f in frames if f["event"]]
+        assert "metadata" in event_types
+        assert "values" in event_types
+        assert "end" in event_types
+
+        # MUST-FIX: Assert payload content, not just event-type presence
+        values_frames = [
+            f for f in frames
+            if f["event"] == "values" and f["data"] and isinstance(f["data"], dict)
+        ]
+        assert len(values_frames) >= 1
+        # At least one values event should contain the final state
+        final_values = values_frames[-1]["data"]
+        assert final_values["turn_count"] == 1
+        assert final_values["history"] == ["Hello, Stream!"]
+        assert final_values["last_reply"] == "Hello, Stream!"
+
+
+class TestPlatformState:
+    """State endpoint with real compiled graph via platform routes."""
+
+    def test_state_after_platform_invoke(self) -> None:
+        """GET /threads/{tid}/state returns real persisted state."""
+        saver = MemorySaver()
+        graph = _build_graph(checkpointer=saver)
+        store = InMemoryThreadStore(id_factory=lambda: "pst-1")
+        app = _make_platform_app(graph, store=store)
+        fa = app.function_app
+
+        # Create thread
+        create_fn = _get_fn(fa, "aflg_platform_threads_create")
+        resp = create_fn(_post("/api/threads", {}))
+        tid = json.loads(resp.get_body())["thread_id"]
+
+        # Invoke to populate state
+        wait_fn = _get_fn(fa, "aflg_platform_runs_wait")
+        req = _post(
+            f"/api/threads/{tid}/runs/wait",
+            {
+                "assistant_id": "agent",
+                "input": {"user_text": "StateCheck", "history": [], "turn_count": 0},
+            },
+            thread_id=tid,
+        )
+        wait_fn(req)
+
+        # GET state
+        state_fn = _get_fn(fa, "aflg_platform_threads_state_get")
+        state_req = _get(
+            f"/api/threads/{tid}/state",
+            thread_id=tid,
+        )
+        state_resp = state_fn(state_req)
+        assert state_resp.status_code == 200
+
+        state_data = json.loads(state_resp.get_body())
+        assert state_data["values"]["turn_count"] == 1
+        assert "Hello, StateCheck!" in state_data["values"]["history"]
+        assert state_data["values"]["last_reply"] == "Hello, StateCheck!"
+
+    def test_state_unbound_thread_returns_409(self) -> None:
+        """GET /state on a thread that has never run returns 409."""
+        saver = MemorySaver()
+        graph = _build_graph(checkpointer=saver)
+        store = InMemoryThreadStore(id_factory=lambda: "pst-unbound")
+        app = _make_platform_app(graph, store=store)
+        fa = app.function_app
+
+        # Create thread but don't run anything
+        create_fn = _get_fn(fa, "aflg_platform_threads_create")
+        resp = create_fn(_post("/api/threads", {}))
+        tid = json.loads(resp.get_body())["thread_id"]
+
+        # GET state on unbound thread
+        state_fn = _get_fn(fa, "aflg_platform_threads_state_get")
+        state_req = _get(f"/api/threads/{tid}/state", thread_id=tid)
+        state_resp = state_fn(state_req)
+        assert state_resp.status_code == 409


### PR DESCRIPTION
## Summary

Closes #41

Add **15 integration tests** (10 native + 5 platform) that exercise real `StateGraph.compile()` + `InMemorySaver` through the HTTP handler layers. All tests use deterministic node functions — no LLM calls.

## Test Coverage

### Native route tests (`test_integration.py`) — 10 tests

| Test | Validates |
|---|---|
| `test_single_turn_invoke` | Basic invoke returns correct state |
| `test_multi_turn_invoke_accumulates_state` | Same thread accumulates history via reducer |
| `test_different_threads_are_isolated` | Different thread_ids maintain independent state |
| `test_stream_values_mode` | stream mode=values yields state snapshots with correct payload |
| `test_stream_updates_mode` | stream mode=updates yields per-node dicts with correct payload |
| `test_stream_persists_state` | State is persisted to checkpointer after streaming |
| `test_state_after_invoke` | GET /state returns persisted thread state |
| `test_state_cross_check_with_direct_get_state` | HTTP endpoint matches `graph.get_state()` |
| `test_state_unknown_thread_returns_empty` | MemorySaver returns empty snapshot (200), not 404 |
| `test_state_no_checkpointer_returns_404` | No checkpointer → ValueError → 404 |

### Platform route tests (`test_integration_platform.py`) — 5 tests

| Test | Validates |
|---|---|
| `test_invoke_via_platform` | runs/wait invokes real graph |
| `test_multi_turn_via_platform` | Two runs/wait accumulate state |
| `test_stream_via_platform` | runs/stream returns valid SSE with correct payload |
| `test_state_after_platform_invoke` | GET /threads/{tid}/state returns real state |
| `test_state_unbound_thread_returns_409` | Unbound thread returns 409 |

## Key implementation details

- **Real graphs**: `ChatState` TypedDict with `Annotated[list[str], operator.add]` reducer, two-node graph (greet → count)
- **Proper SSE parsing**: Frame-based parser that groups by blank lines, reads `event:` + `data:` lines per SSE spec
- **Payload assertions**: All stream tests verify actual data content, not just event-type presence (per Oracle review)
- **Fresh MemorySaver per test**: No cross-test state leakage

## Verification

- ✅ 410 tests pass (395 existing + 15 new)
- ✅ 96.27% coverage (threshold: 90%)
- ✅ Lint clean (ruff + mypy)
- ✅ Oracle post-implementation review applied