### PR TITLE
feat: add thread state update and history endpoints (#57, #58)

### DIFF
--- a/src/azure_functions_langgraph/platform/contracts.py
+++ b/src/azure_functions_langgraph/platform/contracts.py
@@ -249,6 +249,34 @@ class ThreadCount(BaseModel):
     metadata: Optional[dict[str, Any]] = None
     status: Optional[ThreadStatus] = None
 
+
+class ThreadStateUpdate(BaseModel):
+    """Request body to update thread state.
+
+    Covers ``POST /threads/{thread_id}/state``.
+    The SDK always sends ``values``; we require it for safety.
+    """
+
+    model_config = ConfigDict(extra="ignore")
+
+    values: Union[dict[str, Any], list[dict[str, Any]]]
+    as_node: Optional[str] = None
+    checkpoint_id: Optional[str] = None
+    checkpoint: Optional[dict[str, Any]] = None
+
+
+class ThreadHistoryRequest(BaseModel):
+    """Request body to query thread state history.
+
+    Covers ``POST /threads/{thread_id}/history``.
+    """
+
+    model_config = ConfigDict(extra="ignore")
+
+    limit: int = Field(default=10, ge=1)
+    before: Optional[Union[str, dict[str, Any]]] = None
+    metadata: Optional[dict[str, Any]] = None
+    checkpoint: Optional[dict[str, Any]] = None
 # ---------------------------------------------------------------------------
 # Public surface
 # ---------------------------------------------------------------------------
@@ -275,4 +303,6 @@ __all__ = [
     "ThreadUpdate",
     "ThreadSearch",
     "ThreadCount",
+    "ThreadStateUpdate",
+    "ThreadHistoryRequest",
 ]

--- a/src/azure_functions_langgraph/platform/routes.py
+++ b/src/azure_functions_langgraph/platform/routes.py
@@ -17,6 +17,8 @@ Routes registered (under ``/api/`` prefix, managed by Azure Functions):
 * ``POST /api/threads/search``
 * ``POST /api/threads/count``
 * ``GET  /api/threads/{thread_id}/state``
+* ``POST /api/threads/{thread_id}/state``
+* ``POST /api/threads/{thread_id}/history``
 * ``POST /api/threads/{thread_id}/runs/wait``
 * ``POST /api/threads/{thread_id}/runs/stream``
 * ``POST /api/runs/wait``  *(threadless)*
@@ -50,15 +52,23 @@ from azure_functions_langgraph.platform.contracts import (
     Assistant,
     AssistantCount,
     AssistantSearch,
+    Checkpoint,
     RunCreate,
     ThreadCount,
     ThreadCreate,
+    ThreadHistoryRequest,
     ThreadSearch,
     ThreadState,
+    ThreadStateUpdate,
     ThreadUpdate,
 )
 from azure_functions_langgraph.platform.stores import ThreadStore
-from azure_functions_langgraph.protocols import StatefulGraph, StreamableGraph
+from azure_functions_langgraph.protocols import (
+    StatefulGraph,
+    StateHistoryGraph,
+    StreamableGraph,
+    UpdatableStateGraph,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -142,6 +152,66 @@ def _get_threadless_graph(graph: Any) -> Any | None:
             exc_info=True,
         )
         return None
+
+
+def _snapshot_to_thread_state(snapshot: Any, thread_id: str) -> ThreadState:
+    """Convert a LangGraph ``StateSnapshot`` to the SDK ``ThreadState`` contract.
+
+    Extracts ``checkpoint_id`` and ``checkpoint_ns`` from the snapshot's
+    ``config["configurable"]`` when available, falling back to bare defaults.
+    """
+    values: dict[str, Any] | list[dict[str, Any]] = (
+        snapshot.values
+        if isinstance(snapshot.values, (dict, list))
+        else {}
+    )
+    next_nodes: list[str] = list(snapshot.next) if hasattr(snapshot, "next") else []
+    metadata = (
+        dict(snapshot.metadata)
+        if hasattr(snapshot, "metadata") and snapshot.metadata is not None
+        else None
+    )
+
+    # Extract checkpoint info from snapshot config when available
+    snap_config = getattr(snapshot, "config", None) or {}
+    snap_configurable = snap_config.get("configurable", {}) if isinstance(snap_config, dict) else {}
+    checkpoint_id = snap_configurable.get("checkpoint_id")
+    checkpoint_ns = snap_configurable.get("checkpoint_ns", "")
+
+    # Parent checkpoint from parent_config
+    parent_config = getattr(snapshot, "parent_config", None) or {}
+    parent_configurable = (
+        parent_config.get("configurable", {})
+        if isinstance(parent_config, dict)
+        else {}
+    )
+    parent_checkpoint_id = parent_configurable.get("checkpoint_id")
+    parent_checkpoint: Checkpoint | None = None
+    if parent_checkpoint_id is not None:
+        parent_checkpoint = Checkpoint(
+            thread_id=thread_id,
+            checkpoint_ns=parent_configurable.get("checkpoint_ns", ""),
+            checkpoint_id=parent_checkpoint_id,
+        )
+
+    # created_at
+    created_at_raw = getattr(snapshot, "created_at", None)
+    created_at = str(created_at_raw) if created_at_raw is not None else None
+
+    return ThreadState(
+        values=values,
+        next=next_nodes,
+        checkpoint=Checkpoint(
+            thread_id=thread_id,
+            checkpoint_ns=checkpoint_ns,
+            checkpoint_id=checkpoint_id,
+        ),
+        metadata=metadata,
+        created_at=created_at,
+        parent_checkpoint=parent_checkpoint,
+        tasks=[],
+        interrupts=[],
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -584,7 +654,7 @@ def register_platform_routes(
             state = ThreadState(
                 values={},
                 next=[],
-                checkpoint={"thread_id": thread_id, "checkpoint_ns": "", "checkpoint_id": None},  # type: ignore[arg-type]
+                checkpoint=Checkpoint(thread_id=thread_id, checkpoint_ns="", checkpoint_id=None),
                 metadata=None,
                 created_at=None,
                 parent_checkpoint=None,
@@ -600,34 +670,266 @@ def register_platform_routes(
             logger.exception("get_state failed for thread %s", thread_id)
             return _platform_error(500, "Internal error retrieving thread state")
 
-        values: dict[str, Any] | list[dict[str, Any]] = (
-            snapshot.values
-            if isinstance(snapshot.values, (dict, list))
-            else {}
-        )
-        next_nodes: list[str] = list(snapshot.next) if hasattr(snapshot, "next") else []
-        metadata = (
-            dict(snapshot.metadata)
-            if hasattr(snapshot, "metadata") and snapshot.metadata is not None
-            else None
-        )
-
-        state = ThreadState(
-            values=values,
-            next=next_nodes,
-            checkpoint={"thread_id": thread_id, "checkpoint_ns": "", "checkpoint_id": None},  # type: ignore[arg-type]
-            metadata=metadata,
-            created_at=None,
-            parent_checkpoint=None,
-            tasks=[],
-            interrupts=[],
-        )
+        state = _snapshot_to_thread_state(snapshot, thread_id)
         return func.HttpResponse(
             body=json.dumps(state.model_dump(mode="json"), default=str),
             mimetype="application/json",
             status_code=200,
         )
 
+    # ── POST /threads/{thread_id}/state (update) ────────────────────
+
+    @app.function_name(name="aflg_platform_threads_state_update")
+    @app.route(
+        route="threads/{thread_id}/state", methods=["POST"], auth_level=auth
+    )
+    def threads_state_update(req: func.HttpRequest) -> func.HttpResponse:
+        thread_id = req.route_params.get("thread_id", "")
+        tid_err = validate_thread_id(thread_id)
+        if tid_err:
+            return _platform_error(400, tid_err)
+
+        # Body size check — reject before parsing
+        raw = req.get_body()
+        size_err = validate_body_size(raw, deps.max_request_body_bytes)
+        if size_err:
+            return _platform_error(400, size_err)
+        try:
+            body: dict[str, Any] = req.get_json()
+        except ValueError:
+            return _platform_error(400, "Invalid JSON body")
+
+        if not isinstance(body, dict):
+            return _platform_error(400, "Request body must be a JSON object")
+
+        try:
+            update_req = ThreadStateUpdate.model_validate(body)
+        except Exception as exc:
+            return _platform_error(422, f"Validation error: {exc}")
+
+        # Thread must exist
+        thread = deps.thread_store.get(thread_id)
+        if thread is None:
+            return _platform_error(404, f"Thread {thread_id!r} not found")
+
+        # Thread must be bound to an assistant (graph)
+        if thread.assistant_id is None:
+            return _platform_error(
+                409,
+                f"Thread {thread_id!r} is not bound to any assistant. "
+                f"Run a graph on this thread first.",
+            )
+
+        reg = deps.registrations.get(thread.assistant_id)
+        if reg is None:
+            return _platform_error(
+                404,
+                f"Assistant {thread.assistant_id!r} not found for thread {thread_id!r}",
+            )
+
+        graph = reg.graph
+        if not isinstance(graph, UpdatableStateGraph):
+            return _platform_error(
+                409,
+                f"Graph {thread.assistant_id!r} does not support state updates",
+            )
+
+        # Build config — merge checkpoint fields if provided
+        configurable: dict[str, Any] = {"thread_id": thread_id}
+        if update_req.checkpoint is not None:
+            # Validate cross-thread checkpoint
+            cp_thread_id = update_req.checkpoint.get("thread_id")
+            if cp_thread_id is not None and cp_thread_id != thread_id:
+                return _platform_error(
+                    422,
+                    f"Checkpoint thread_id {cp_thread_id!r} does not match "
+                    f"path thread_id {thread_id!r}",
+                )
+            cp_id = update_req.checkpoint.get("checkpoint_id")
+            if cp_id is not None:
+                configurable["checkpoint_id"] = cp_id
+            cp_ns = update_req.checkpoint.get("checkpoint_ns")
+            if cp_ns is not None:
+                configurable["checkpoint_ns"] = cp_ns
+        elif update_req.checkpoint_id is not None:
+            configurable["checkpoint_id"] = update_req.checkpoint_id
+        config: dict[str, Any] = {"configurable": configurable}
+
+        try:
+            result = graph.update_state(
+                config, update_req.values, as_node=update_req.as_node
+            )
+        except (KeyError, ValueError) as exc:
+            return _platform_error(
+                404, f"Cannot update state for thread {thread_id!r}: {exc}"
+            )
+        except Exception:
+            logger.exception("update_state failed for thread %s", thread_id)
+            return _platform_error(500, "Internal error updating thread state")
+
+        # Extract checkpoint_id from returned RunnableConfig
+        result_configurable = (
+            result.get("configurable", {}) if isinstance(result, dict) else {}
+        )
+        response_checkpoint = Checkpoint(
+            thread_id=thread_id,
+            checkpoint_ns=result_configurable.get("checkpoint_ns", ""),
+            checkpoint_id=result_configurable.get("checkpoint_id"),
+        )
+        payload = {"checkpoint": response_checkpoint.model_dump(mode="json")}
+        return func.HttpResponse(
+            body=json.dumps(payload, default=str),
+            mimetype="application/json",
+            status_code=200,
+        )
+
+    # ── POST /threads/{thread_id}/history ─────────────────────────────
+
+    @app.function_name(name="aflg_platform_threads_history")
+    @app.route(
+        route="threads/{thread_id}/history", methods=["POST"], auth_level=auth
+    )
+    def threads_history(req: func.HttpRequest) -> func.HttpResponse:
+        thread_id = req.route_params.get("thread_id", "")
+        tid_err = validate_thread_id(thread_id)
+        if tid_err:
+            return _platform_error(400, tid_err)
+
+        # Body size check — reject before parsing
+        raw = req.get_body()
+        size_err = validate_body_size(raw, deps.max_request_body_bytes)
+        if size_err:
+            return _platform_error(400, size_err)
+        if raw and raw.strip() != b"":
+            try:
+                body: dict[str, Any] = req.get_json()
+            except ValueError:
+                return _platform_error(400, "Invalid JSON body")
+
+            if not isinstance(body, dict):
+                return _platform_error(400, "Request body must be a JSON object")
+        else:
+            body = {}
+
+        try:
+            hist_req = ThreadHistoryRequest.model_validate(body)
+        except Exception as exc:
+            return _platform_error(422, f"Validation error: {exc}")
+
+        # Thread must exist
+        thread = deps.thread_store.get(thread_id)
+        if thread is None:
+            return _platform_error(404, f"Thread {thread_id!r} not found")
+
+        # Thread must be bound to an assistant (graph)
+        if thread.assistant_id is None:
+            return _platform_error(
+                409,
+                f"Thread {thread_id!r} is not bound to any assistant. "
+                f"Run a graph on this thread first.",
+            )
+
+        reg = deps.registrations.get(thread.assistant_id)
+        if reg is None:
+            return _platform_error(
+                404,
+                f"Assistant {thread.assistant_id!r} not found for thread {thread_id!r}",
+            )
+
+        graph = reg.graph
+        if not isinstance(graph, StateHistoryGraph):
+            return _platform_error(
+                409,
+                f"Graph {thread.assistant_id!r} does not support state history",
+            )
+
+        # Build config — include checkpoint filter if provided
+        configurable: dict[str, Any] = {"thread_id": thread_id}
+        if hist_req.checkpoint is not None:
+            # Validate cross-thread checkpoint
+            cp_thread_id = hist_req.checkpoint.get("thread_id")
+            if cp_thread_id is not None and cp_thread_id != thread_id:
+                return _platform_error(
+                    422,
+                    f"Checkpoint thread_id {cp_thread_id!r} does not match "
+                    f"path thread_id {thread_id!r}",
+                )
+            cp_id = hist_req.checkpoint.get("checkpoint_id")
+            if cp_id is not None:
+                configurable["checkpoint_id"] = cp_id
+            cp_ns = hist_req.checkpoint.get("checkpoint_ns")
+            if cp_ns is not None:
+                configurable["checkpoint_ns"] = cp_ns
+        config: dict[str, Any] = {"configurable": configurable}
+
+        try:
+            history_iter = graph.get_state_history(config)
+
+            # Apply server-side filtering: before, metadata, limit
+            # Normalize 'before' to a checkpoint_id string for comparison
+            before_id: str | None = None
+            if hist_req.before is not None:
+                if isinstance(hist_req.before, str):
+                    before_id = hist_req.before
+                elif isinstance(hist_req.before, dict):
+                    # Validate cross-thread before checkpoint
+                    before_thread_id = hist_req.before.get("thread_id")
+                    if before_thread_id is not None and before_thread_id != thread_id:
+                        return _platform_error(
+                            422,
+                            f"before checkpoint thread_id {before_thread_id!r} does not match "
+                            f"path thread_id {thread_id!r}",
+                        )
+                    before_id = hist_req.before.get("checkpoint_id")
+
+            results: list[ThreadState] = []
+            found_before = before_id is None  # If no 'before', include from start
+            for snapshot in history_iter:
+                # Extract this snapshot's checkpoint_id
+                snap_config = getattr(snapshot, "config", None) or {}
+                snap_configurable = (
+                    snap_config.get("configurable", {})
+                    if isinstance(snap_config, dict)
+                    else {}
+                )
+                snap_cp_id = snap_configurable.get("checkpoint_id")
+
+                # 'before' filter: skip until we pass the 'before' checkpoint
+                if not found_before:
+                    if snap_cp_id == before_id:
+                        found_before = True
+                    continue  # Skip this one and everything before we find the marker
+
+                # Metadata filter
+                if hist_req.metadata is not None:
+                    snap_metadata = getattr(snapshot, "metadata", None) or {}
+                    if not all(
+                        snap_metadata.get(k) == v
+                        for k, v in hist_req.metadata.items()
+                    ):
+                        continue
+
+                results.append(_snapshot_to_thread_state(snapshot, thread_id))
+                if len(results) >= hist_req.limit:
+                    break
+        except (KeyError, ValueError):
+            # No history / bad config — return empty list
+            return func.HttpResponse(
+                body=json.dumps([]),
+                mimetype="application/json",
+                status_code=200,
+            )
+        except Exception:
+            logger.exception("get_state_history failed for thread %s", thread_id)
+            return _platform_error(500, "Internal error retrieving thread history")
+
+        return func.HttpResponse(
+            body=json.dumps(
+                [s.model_dump(mode="json") for s in results], default=str
+            ),
+            mimetype="application/json",
+            status_code=200,
+        )
     # ── POST /threads/{thread_id}/runs/wait ──────────────────────────
 
     @app.function_name(name="aflg_platform_runs_wait")

--- a/src/azure_functions_langgraph/protocols.py
+++ b/src/azure_functions_langgraph/protocols.py
@@ -36,6 +36,26 @@ class StatefulGraph(Protocol):
 
 
 @runtime_checkable
+class UpdatableStateGraph(Protocol):
+    """Protocol for a graph that supports state updates via a checkpointer."""
+
+    def update_state(
+        self,
+        config: dict[str, Any],
+        values: dict[str, Any] | list[dict[str, Any]] | None,
+        *,
+        as_node: str | None = ...,
+    ) -> Any: ...
+
+
+@runtime_checkable
+class StateHistoryGraph(Protocol):
+    """Protocol for a graph that supports state history retrieval via a checkpointer."""
+
+    def get_state_history(self, config: dict[str, Any]) -> Any: ...
+
+
+@runtime_checkable
 class LangGraphLike(InvocableGraph, StreamableGraph, Protocol):
     """Protocol combining invoke and stream — matches LangGraph's CompiledStateGraph."""
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,11 +16,16 @@ class _FakeStateSnapshot:
         values: dict[str, Any] | None = None,
         next_nodes: tuple[str, ...] = (),
         metadata: dict[str, Any] | None = None,
+        config: dict[str, Any] | None = None,
+        parent_config: dict[str, Any] | None = None,
+        created_at: str | None = None,
     ) -> None:
         self.values = values or {"messages": [{"role": "assistant", "content": "hi"}]}
         self.next = next_nodes
         self.metadata = metadata
-
+        self.config = config
+        self.parent_config = parent_config
+        self.created_at = created_at
 class FakeCompiledGraph:
     """Minimal mock of a LangGraph CompiledStateGraph for testing.
 
@@ -89,6 +94,8 @@ class FakeStatefulGraph:
         stream_results: list[dict[str, Any]] | None = None,
         checkpointer: Any = "memory",
         state_snapshot: _FakeStateSnapshot | None = None,
+        state_history: list[_FakeStateSnapshot] | None = None,
+        update_state_result: dict[str, Any] | None = None,
     ) -> None:
         self._invoke_result = invoke_result or {
             "messages": [{"role": "assistant", "content": "Hello!"}]
@@ -99,6 +106,14 @@ class FakeStatefulGraph:
         ]
         self.checkpointer = checkpointer
         self._state_snapshot = state_snapshot or _FakeStateSnapshot()
+        self._state_history = state_history or []
+        self._update_state_result = update_state_result or {
+            "configurable": {
+                "thread_id": "test-thread",
+                "checkpoint_id": "new-checkpoint-id",
+                "checkpoint_ns": "",
+            }
+        }
 
     def invoke(
         self, input: dict[str, Any], config: dict[str, Any] | None = None
@@ -116,6 +131,19 @@ class FakeStatefulGraph:
     def get_state(self, config: dict[str, Any]) -> _FakeStateSnapshot:
         return self._state_snapshot
 
+    def update_state(
+        self,
+        config: dict[str, Any],
+        values: dict[str, Any] | list[dict[str, Any]] | None,
+        *,
+        as_node: str | None = None,
+    ) -> dict[str, Any]:
+        return self._update_state_result
+
+    def get_state_history(
+        self, config: dict[str, Any]
+    ) -> Iterator[_FakeStateSnapshot]:
+        yield from self._state_history
 
 class FakeFailingStatefulGraph:
     """StatefulGraph that raises on get_state for error path testing."""
@@ -160,6 +188,44 @@ class FakeNotFoundStatefulGraph:
         raise KeyError("thread-xyz")
 
 
+
+class FakeFailingUpdateStateGraph:
+    """StatefulGraph that raises on update_state for error path testing."""
+
+    checkpointer = "memory"
+
+    def invoke(
+        self, input: dict[str, Any], config: dict[str, Any] | None = None
+    ) -> dict[str, Any]:
+        return {"result": "ok"}
+
+    def stream(
+        self,
+        input: dict[str, Any],
+        config: dict[str, Any] | None = None,
+        stream_mode: str = "values",
+    ) -> Iterator[dict[str, Any]]:
+        yield {"data": "chunk"}
+
+    def get_state(self, config: dict[str, Any]) -> _FakeStateSnapshot:
+        return _FakeStateSnapshot()
+
+    def update_state(
+        self,
+        config: dict[str, Any],
+        values: dict[str, Any] | list[dict[str, Any]] | None,
+        *,
+        as_node: str | None = None,
+    ) -> Any:
+        raise RuntimeError("Update state failed")
+
+    def get_state_history(
+        self, config: dict[str, Any]
+    ) -> Iterator[_FakeStateSnapshot]:
+        # Simulate a generator that raises during iteration (real LangGraph behaviour)
+        yield _FakeStateSnapshot()
+        raise RuntimeError("History retrieval failed")
+
 @pytest.fixture
 def fake_graph() -> FakeCompiledGraph:
     return FakeCompiledGraph()
@@ -193,3 +259,8 @@ def fake_failing_stateful_graph() -> FakeFailingStatefulGraph:
 @pytest.fixture
 def fake_not_found_stateful_graph() -> FakeNotFoundStatefulGraph:
     return FakeNotFoundStatefulGraph()
+
+
+@pytest.fixture
+def fake_failing_update_state_graph() -> FakeFailingUpdateStateGraph:
+    return FakeFailingUpdateStateGraph()

--- a/tests/test_platform_routes.py
+++ b/tests/test_platform_routes.py
@@ -1167,6 +1167,44 @@ class TestThreadsStateGet:
         resp = fn(req)
         assert resp.status_code == 409
 
+    def test_state_checkpoint_propagation(self, store: InMemoryThreadStore) -> None:
+        """GET /state returns checkpoint_id from snapshot config (regression)."""
+        from tests.conftest import _FakeStateSnapshot
+        snapshot = _FakeStateSnapshot(
+            values={"count": 42},
+            config={
+                "configurable": {
+                    "thread_id": "t",
+                    "checkpoint_id": "cp-abc",
+                    "checkpoint_ns": "",
+                }
+            },
+            parent_config={
+                "configurable": {
+                    "thread_id": "t",
+                    "checkpoint_id": "cp-prev",
+                    "checkpoint_ns": "",
+                }
+            },
+            created_at="2025-01-01T00:00:00Z",
+        )
+        g = FakeStatefulGraph(state_snapshot=snapshot)
+        app = _build_platform_app(graphs={"agent": g}, store=store)
+        thread = store.create()
+        store.update(thread.thread_id, assistant_id="agent")
+
+        fa = app.function_app
+        fn = _get_fn(fa, "aflg_platform_threads_state_get")
+        req = _get_request(
+            f"/api/threads/{thread.thread_id}/state",
+            thread_id=thread.thread_id,
+        )
+        resp = fn(req)
+        assert resp.status_code == 200
+        data = json.loads(resp.get_body())
+        assert data["checkpoint"]["checkpoint_id"] == "cp-abc"
+        assert data["parent_checkpoint"]["checkpoint_id"] == "cp-prev"
+        assert data["created_at"] == "2025-01-01T00:00:00Z"
 
 # ---------------------------------------------------------------------------
 # Runs/wait endpoint
@@ -2779,3 +2817,760 @@ class TestNaNPayloadInStream:
         updated = store.get(thread.thread_id)
         assert updated is not None
         assert updated.status == "error"
+
+
+# ---------------------------------------------------------------------------
+# POST /threads/{thread_id}/state (update) — Issue #57
+# ---------------------------------------------------------------------------
+
+
+class TestThreadsStateUpdate:
+    """POST /threads/{thread_id}/state — update thread state."""
+
+    def test_update_state_basic(self, store: InMemoryThreadStore) -> None:
+        """Successful state update returns checkpoint response."""
+        g = FakeStatefulGraph()
+        app = _build_platform_app(graphs={"agent": g}, store=store)
+        fa = app.function_app
+        thread = store.create()
+        store.update(thread.thread_id, assistant_id="agent")
+
+        fn = _get_fn(fa, "aflg_platform_threads_state_update")
+        req = _post_request(
+            f"/api/threads/{thread.thread_id}/state",
+            {"values": {"key": "value"}},
+            thread_id=thread.thread_id,
+        )
+        resp = fn(req)
+        assert resp.status_code == 200
+        data = json.loads(resp.get_body())
+        assert "checkpoint" in data
+        cp = data["checkpoint"]
+        assert cp["thread_id"] == thread.thread_id
+        assert "checkpoint_id" in cp
+        assert cp["checkpoint_ns"] == ""
+
+    def test_update_state_with_as_node(self, store: InMemoryThreadStore) -> None:
+        """as_node is forwarded to the graph."""
+        g = FakeStatefulGraph()
+        app = _build_platform_app(graphs={"agent": g}, store=store)
+        fa = app.function_app
+        thread = store.create()
+        store.update(thread.thread_id, assistant_id="agent")
+
+        fn = _get_fn(fa, "aflg_platform_threads_state_update")
+        req = _post_request(
+            f"/api/threads/{thread.thread_id}/state",
+            {"values": {"key": "value"}, "as_node": "greet"},
+            thread_id=thread.thread_id,
+        )
+        resp = fn(req)
+        assert resp.status_code == 200
+
+    def test_update_state_with_checkpoint_id(self, store: InMemoryThreadStore) -> None:
+        """checkpoint_id is merged into config."""
+        g = FakeStatefulGraph()
+        app = _build_platform_app(graphs={"agent": g}, store=store)
+        fa = app.function_app
+        thread = store.create()
+        store.update(thread.thread_id, assistant_id="agent")
+
+        fn = _get_fn(fa, "aflg_platform_threads_state_update")
+        req = _post_request(
+            f"/api/threads/{thread.thread_id}/state",
+            {"values": {"k": "v"}, "checkpoint_id": "cp-123"},
+            thread_id=thread.thread_id,
+        )
+        resp = fn(req)
+        assert resp.status_code == 200
+
+    def test_update_state_with_checkpoint_object(self, store: InMemoryThreadStore) -> None:
+        """checkpoint object merges fields into config."""
+        g = FakeStatefulGraph()
+        app = _build_platform_app(graphs={"agent": g}, store=store)
+        fa = app.function_app
+        thread = store.create()
+        store.update(thread.thread_id, assistant_id="agent")
+        tid = thread.thread_id
+
+        fn = _get_fn(fa, "aflg_platform_threads_state_update")
+        req = _post_request(
+            f"/api/threads/{tid}/state",
+            {"values": {"k": "v"}, "checkpoint": {"thread_id": tid, "checkpoint_id": "cp-x"}},
+            thread_id=tid,
+        )
+        resp = fn(req)
+        assert resp.status_code == 200
+
+    def test_update_state_cross_thread_checkpoint_422(self, store: InMemoryThreadStore) -> None:
+        """checkpoint.thread_id mismatch returns 422."""
+        g = FakeStatefulGraph()
+        app = _build_platform_app(graphs={"agent": g}, store=store)
+        fa = app.function_app
+        thread = store.create()
+        store.update(thread.thread_id, assistant_id="agent")
+
+        fn = _get_fn(fa, "aflg_platform_threads_state_update")
+        req = _post_request(
+            f"/api/threads/{thread.thread_id}/state",
+            {
+                "values": {"k": "v"},
+                "checkpoint": {"thread_id": "other-thread", "checkpoint_id": "cp-x"},
+            },
+            thread_id=thread.thread_id,
+        )
+        resp = fn(req)
+        assert resp.status_code == 422
+        assert "does not match" in json.loads(resp.get_body())["detail"]
+
+    def test_update_state_thread_not_found_404(self, store: InMemoryThreadStore) -> None:
+        """Non-existent thread returns 404."""
+        g = FakeStatefulGraph()
+        app = _build_platform_app(graphs={"agent": g}, store=store)
+        fa = app.function_app
+
+        fn = _get_fn(fa, "aflg_platform_threads_state_update")
+        req = _post_request(
+            "/api/threads/nonexistent/state",
+            {"values": {"k": "v"}},
+            thread_id="nonexistent",
+        )
+        resp = fn(req)
+        assert resp.status_code == 404
+
+    def test_update_state_unbound_thread_409(self, store: InMemoryThreadStore) -> None:
+        """Thread not bound to assistant returns 409."""
+        g = FakeStatefulGraph()
+        app = _build_platform_app(graphs={"agent": g}, store=store)
+        fa = app.function_app
+        thread = store.create()
+
+        fn = _get_fn(fa, "aflg_platform_threads_state_update")
+        req = _post_request(
+            f"/api/threads/{thread.thread_id}/state",
+            {"values": {"k": "v"}},
+            thread_id=thread.thread_id,
+        )
+        resp = fn(req)
+        assert resp.status_code == 409
+
+    def test_update_state_graph_not_updatable_409(self, store: InMemoryThreadStore) -> None:
+        """Graph lacking update_state returns 409."""
+        from tests.conftest import FakeCompiledGraph
+        g = FakeCompiledGraph()  # No update_state method
+        app = _build_platform_app(graphs={"agent": g}, store=store)
+        fa = app.function_app
+        thread = store.create()
+        store.update(thread.thread_id, assistant_id="agent")
+
+        fn = _get_fn(fa, "aflg_platform_threads_state_update")
+        req = _post_request(
+            f"/api/threads/{thread.thread_id}/state",
+            {"values": {"k": "v"}},
+            thread_id=thread.thread_id,
+        )
+        resp = fn(req)
+        assert resp.status_code == 409
+        assert "does not support state updates" in json.loads(resp.get_body())["detail"]
+
+    def test_update_state_graph_raises_500(self, store: InMemoryThreadStore) -> None:
+        """Graph.update_state() raising RuntimeError returns 500."""
+        from tests.conftest import FakeFailingUpdateStateGraph
+        g = FakeFailingUpdateStateGraph()
+        app = _build_platform_app(graphs={"agent": g}, store=store)
+        fa = app.function_app
+        thread = store.create()
+        store.update(thread.thread_id, assistant_id="agent")
+
+        fn = _get_fn(fa, "aflg_platform_threads_state_update")
+        req = _post_request(
+            f"/api/threads/{thread.thread_id}/state",
+            {"values": {"k": "v"}},
+            thread_id=thread.thread_id,
+        )
+        resp = fn(req)
+        assert resp.status_code == 500
+
+    def test_update_state_invalid_json_400(self, store: InMemoryThreadStore) -> None:
+        """Non-JSON body returns 400."""
+        g = FakeStatefulGraph()
+        app = _build_platform_app(graphs={"agent": g}, store=store)
+        fa = app.function_app
+        thread = store.create()
+        store.update(thread.thread_id, assistant_id="agent")
+
+        fn = _get_fn(fa, "aflg_platform_threads_state_update")
+        req = func.HttpRequest(
+            method="POST",
+            url=f"/api/threads/{thread.thread_id}/state",
+            body=b"not json",
+            headers={"Content-Type": "application/json"},
+            route_params={"thread_id": thread.thread_id},
+        )
+        resp = fn(req)
+        assert resp.status_code == 400
+
+    def test_update_state_missing_values_422(self, store: InMemoryThreadStore) -> None:
+        """Missing 'values' field returns 422."""
+        g = FakeStatefulGraph()
+        app = _build_platform_app(graphs={"agent": g}, store=store)
+        fa = app.function_app
+        thread = store.create()
+        store.update(thread.thread_id, assistant_id="agent")
+
+        fn = _get_fn(fa, "aflg_platform_threads_state_update")
+        req = _post_request(
+            f"/api/threads/{thread.thread_id}/state",
+            {"as_node": "greet"},  # no values
+            thread_id=thread.thread_id,
+        )
+        resp = fn(req)
+        assert resp.status_code == 422
+
+    def test_update_state_non_dict_body_400(self, store: InMemoryThreadStore) -> None:
+        """Array body returns 400."""
+        g = FakeStatefulGraph()
+        app = _build_platform_app(graphs={"agent": g}, store=store)
+        fa = app.function_app
+        thread = store.create()
+        store.update(thread.thread_id, assistant_id="agent")
+
+        fn = _get_fn(fa, "aflg_platform_threads_state_update")
+        req = func.HttpRequest(
+            method="POST",
+            url=f"/api/threads/{thread.thread_id}/state",
+            body=json.dumps([1, 2, 3]).encode(),
+            headers={"Content-Type": "application/json"},
+            route_params={"thread_id": thread.thread_id},
+        )
+        resp = fn(req)
+        assert resp.status_code == 400
+
+    def test_update_state_invalid_thread_id_400(self, store: InMemoryThreadStore) -> None:
+        """Empty thread_id returns 400."""
+        g = FakeStatefulGraph()
+        app = _build_platform_app(graphs={"agent": g}, store=store)
+        fa = app.function_app
+
+        fn = _get_fn(fa, "aflg_platform_threads_state_update")
+        req = _post_request(
+            "/api/threads//state",
+            {"values": {"k": "v"}},
+            thread_id="",
+        )
+        resp = fn(req)
+        assert resp.status_code == 400
+
+    def test_update_state_assistant_not_found_404(self, store: InMemoryThreadStore) -> None:
+        """Thread bound to non-existent assistant returns 404."""
+        g = FakeStatefulGraph()
+        app = _build_platform_app(graphs={"agent": g}, store=store)
+        fa = app.function_app
+        thread = store.create()
+        store.update(thread.thread_id, assistant_id="deleted-assistant")
+
+        fn = _get_fn(fa, "aflg_platform_threads_state_update")
+        req = _post_request(
+            f"/api/threads/{thread.thread_id}/state",
+            {"values": {"k": "v"}},
+            thread_id=thread.thread_id,
+        )
+        resp = fn(req)
+        assert resp.status_code == 404
+
+    def test_update_state_values_as_list(self, store: InMemoryThreadStore) -> None:
+        """values as list[dict] is accepted (SDK supports this)."""
+        g = FakeStatefulGraph()
+        app = _build_platform_app(graphs={"agent": g}, store=store)
+        fa = app.function_app
+        thread = store.create()
+        store.update(thread.thread_id, assistant_id="agent")
+
+        fn = _get_fn(fa, "aflg_platform_threads_state_update")
+        req = _post_request(
+            f"/api/threads/{thread.thread_id}/state",
+            {"values": [{"key": "val1"}, {"key": "val2"}]},
+            thread_id=thread.thread_id,
+        )
+        resp = fn(req)
+        assert resp.status_code == 200
+        data = json.loads(resp.get_body())
+        assert "checkpoint" in data
+        assert data["checkpoint"]["thread_id"] == thread.thread_id
+
+# ---------------------------------------------------------------------------
+# POST /threads/{thread_id}/history — Issue #58
+# ---------------------------------------------------------------------------
+
+
+class TestThreadsHistory:
+    """POST /threads/{thread_id}/history — retrieve thread state history."""
+
+    def test_history_empty(self, store: InMemoryThreadStore) -> None:
+        """Thread with no history returns empty list."""
+        g = FakeStatefulGraph(state_history=[])
+        app = _build_platform_app(graphs={"agent": g}, store=store)
+        fa = app.function_app
+        thread = store.create()
+        store.update(thread.thread_id, assistant_id="agent")
+
+        fn = _get_fn(fa, "aflg_platform_threads_history")
+        req = _post_request(
+            f"/api/threads/{thread.thread_id}/history",
+            {},
+            thread_id=thread.thread_id,
+        )
+        resp = fn(req)
+        assert resp.status_code == 200
+        data = json.loads(resp.get_body())
+        assert data == []
+
+    def test_history_returns_snapshots(self, store: InMemoryThreadStore) -> None:
+        """History returns converted ThreadState objects."""
+        from tests.conftest import _FakeStateSnapshot
+        snapshots = [
+            _FakeStateSnapshot(
+                values={"turn": 2},
+                next_nodes=("end",),
+                metadata={"step": 2},
+                config={
+                    "configurable": {
+                        "thread_id": "t",
+                        "checkpoint_id": "cp-2",
+                        "checkpoint_ns": "",
+                    }
+                },
+                parent_config={
+                    "configurable": {
+                        "thread_id": "t",
+                        "checkpoint_id": "cp-1",
+                        "checkpoint_ns": "",
+                    }
+                },
+            ),
+            _FakeStateSnapshot(
+                values={"turn": 1},
+                next_nodes=("count",),
+                metadata={"step": 1},
+                config={
+                    "configurable": {
+                        "thread_id": "t",
+                        "checkpoint_id": "cp-1",
+                        "checkpoint_ns": "",
+                    }
+                },
+            ),
+        ]
+        g = FakeStatefulGraph(state_history=snapshots)
+        app = _build_platform_app(graphs={"agent": g}, store=store)
+        fa = app.function_app
+        thread = store.create()
+        store.update(thread.thread_id, assistant_id="agent")
+
+        fn = _get_fn(fa, "aflg_platform_threads_history")
+        req = _post_request(
+            f"/api/threads/{thread.thread_id}/history",
+            {"limit": 10},
+            thread_id=thread.thread_id,
+        )
+        resp = fn(req)
+        assert resp.status_code == 200
+        data = json.loads(resp.get_body())
+        assert len(data) == 2
+        assert data[0]["values"] == {"turn": 2}
+        assert data[0]["checkpoint"]["checkpoint_id"] == "cp-2"
+        assert data[0]["parent_checkpoint"]["checkpoint_id"] == "cp-1"
+        assert data[1]["values"] == {"turn": 1}
+        assert data[1]["checkpoint"]["checkpoint_id"] == "cp-1"
+
+    def test_history_limit(self, store: InMemoryThreadStore) -> None:
+        """limit parameter caps returned results."""
+        from tests.conftest import _FakeStateSnapshot
+        snapshots = [
+            _FakeStateSnapshot(
+                values={"turn": i},
+                config={
+                    "configurable": {
+                        "thread_id": "t",
+                        "checkpoint_id": f"cp-{i}",
+                        "checkpoint_ns": "",
+                    }
+                },
+            )
+            for i in range(5)
+        ]
+        g = FakeStatefulGraph(state_history=snapshots)
+        app = _build_platform_app(graphs={"agent": g}, store=store)
+        fa = app.function_app
+        thread = store.create()
+        store.update(thread.thread_id, assistant_id="agent")
+
+        fn = _get_fn(fa, "aflg_platform_threads_history")
+        req = _post_request(
+            f"/api/threads/{thread.thread_id}/history",
+            {"limit": 2},
+            thread_id=thread.thread_id,
+        )
+        resp = fn(req)
+        assert resp.status_code == 200
+        data = json.loads(resp.get_body())
+        assert len(data) == 2
+
+    def test_history_before_filter(self, store: InMemoryThreadStore) -> None:
+        """before parameter skips snapshots until the marker checkpoint."""
+        from tests.conftest import _FakeStateSnapshot
+        snapshots = [
+            _FakeStateSnapshot(
+                values={"turn": 3},
+                config={
+                    "configurable": {
+                        "thread_id": "t",
+                        "checkpoint_id": "cp-3",
+                        "checkpoint_ns": "",
+                    }
+                },
+            ),
+            _FakeStateSnapshot(
+                values={"turn": 2},
+                config={
+                    "configurable": {
+                        "thread_id": "t",
+                        "checkpoint_id": "cp-2",
+                        "checkpoint_ns": "",
+                    }
+                },
+            ),
+            _FakeStateSnapshot(
+                values={"turn": 1},
+                config={
+                    "configurable": {
+                        "thread_id": "t",
+                        "checkpoint_id": "cp-1",
+                        "checkpoint_ns": "",
+                    }
+                },
+            ),
+        ]
+        g = FakeStatefulGraph(state_history=snapshots)
+        app = _build_platform_app(graphs={"agent": g}, store=store)
+        fa = app.function_app
+        thread = store.create()
+        store.update(thread.thread_id, assistant_id="agent")
+
+        fn = _get_fn(fa, "aflg_platform_threads_history")
+        # before=cp-3 means: start after cp-3
+        req = _post_request(
+            f"/api/threads/{thread.thread_id}/history",
+            {"limit": 10, "before": "cp-3"},
+            thread_id=thread.thread_id,
+        )
+        resp = fn(req)
+        assert resp.status_code == 200
+        data = json.loads(resp.get_body())
+        assert len(data) == 2
+        assert data[0]["values"] == {"turn": 2}
+        assert data[1]["values"] == {"turn": 1}
+
+    def test_history_before_dict_filter(self, store: InMemoryThreadStore) -> None:
+        """before as dict with checkpoint_id works."""
+        from tests.conftest import _FakeStateSnapshot
+        snapshots = [
+            _FakeStateSnapshot(
+                values={"turn": 3},
+                config={
+                    "configurable": {
+                        "thread_id": "t",
+                        "checkpoint_id": "cp-3",
+                        "checkpoint_ns": "",
+                    }
+                },
+            ),
+            _FakeStateSnapshot(
+                values={"turn": 2},
+                config={
+                    "configurable": {
+                        "thread_id": "t",
+                        "checkpoint_id": "cp-2",
+                        "checkpoint_ns": "",
+                    }
+                },
+            ),
+        ]
+        g = FakeStatefulGraph(state_history=snapshots)
+        app = _build_platform_app(graphs={"agent": g}, store=store)
+        fa = app.function_app
+        thread = store.create()
+        store.update(thread.thread_id, assistant_id="agent")
+
+        fn = _get_fn(fa, "aflg_platform_threads_history")
+        req = _post_request(
+            f"/api/threads/{thread.thread_id}/history",
+            {"limit": 10, "before": {"checkpoint_id": "cp-3"}},
+            thread_id=thread.thread_id,
+        )
+        resp = fn(req)
+        assert resp.status_code == 200
+        data = json.loads(resp.get_body())
+        assert len(data) == 1
+        assert data[0]["values"] == {"turn": 2}
+
+    def test_history_metadata_filter(self, store: InMemoryThreadStore) -> None:
+        """metadata filter narrows results."""
+        from tests.conftest import _FakeStateSnapshot
+        snapshots = [
+            _FakeStateSnapshot(
+                values={"turn": 2},
+                metadata={"source": "input"},
+                config={
+                    "configurable": {
+                        "thread_id": "t",
+                        "checkpoint_id": "cp-2",
+                        "checkpoint_ns": "",
+                    }
+                },
+            ),
+            _FakeStateSnapshot(
+                values={"turn": 1},
+                metadata={"source": "loop"},
+                config={
+                    "configurable": {
+                        "thread_id": "t",
+                        "checkpoint_id": "cp-1",
+                        "checkpoint_ns": "",
+                    }
+                },
+            ),
+        ]
+        g = FakeStatefulGraph(state_history=snapshots)
+        app = _build_platform_app(graphs={"agent": g}, store=store)
+        fa = app.function_app
+        thread = store.create()
+        store.update(thread.thread_id, assistant_id="agent")
+
+        fn = _get_fn(fa, "aflg_platform_threads_history")
+        req = _post_request(
+            f"/api/threads/{thread.thread_id}/history",
+            {"metadata": {"source": "input"}},
+            thread_id=thread.thread_id,
+        )
+        resp = fn(req)
+        assert resp.status_code == 200
+        data = json.loads(resp.get_body())
+        assert len(data) == 1
+        assert data[0]["values"] == {"turn": 2}
+
+    def test_history_thread_not_found_404(self, store: InMemoryThreadStore) -> None:
+        """Non-existent thread returns 404."""
+        g = FakeStatefulGraph()
+        app = _build_platform_app(graphs={"agent": g}, store=store)
+        fa = app.function_app
+
+        fn = _get_fn(fa, "aflg_platform_threads_history")
+        req = _post_request(
+            "/api/threads/nonexistent/history",
+            {},
+            thread_id="nonexistent",
+        )
+        resp = fn(req)
+        assert resp.status_code == 404
+
+    def test_history_unbound_thread_409(self, store: InMemoryThreadStore) -> None:
+        """Thread not bound to assistant returns 409."""
+        g = FakeStatefulGraph()
+        app = _build_platform_app(graphs={"agent": g}, store=store)
+        fa = app.function_app
+        thread = store.create()
+
+        fn = _get_fn(fa, "aflg_platform_threads_history")
+        req = _post_request(
+            f"/api/threads/{thread.thread_id}/history",
+            {},
+            thread_id=thread.thread_id,
+        )
+        resp = fn(req)
+        assert resp.status_code == 409
+
+    def test_history_graph_not_capable_409(self, store: InMemoryThreadStore) -> None:
+        """Graph without get_state_history returns 409."""
+        g = FakeCompiledGraph()  # No get_state_history
+        app = _build_platform_app(graphs={"agent": g}, store=store)
+        fa = app.function_app
+        thread = store.create()
+        store.update(thread.thread_id, assistant_id="agent")
+
+        fn = _get_fn(fa, "aflg_platform_threads_history")
+        req = _post_request(
+            f"/api/threads/{thread.thread_id}/history",
+            {},
+            thread_id=thread.thread_id,
+        )
+        resp = fn(req)
+        assert resp.status_code == 409
+        assert "does not support state history" in json.loads(resp.get_body())["detail"]
+
+    def test_history_graph_raises_500(self, store: InMemoryThreadStore) -> None:
+        """Graph.get_state_history() raising RuntimeError returns 500."""
+        from tests.conftest import FakeFailingUpdateStateGraph
+        g = FakeFailingUpdateStateGraph()
+        app = _build_platform_app(graphs={"agent": g}, store=store)
+        fa = app.function_app
+        thread = store.create()
+        store.update(thread.thread_id, assistant_id="agent")
+
+        fn = _get_fn(fa, "aflg_platform_threads_history")
+        req = _post_request(
+            f"/api/threads/{thread.thread_id}/history",
+            {},
+            thread_id=thread.thread_id,
+        )
+        resp = fn(req)
+        assert resp.status_code == 500
+
+    def test_history_empty_body_defaults(self, store: InMemoryThreadStore) -> None:
+        """Empty body uses default limit=10."""
+        g = FakeStatefulGraph(state_history=[])
+        app = _build_platform_app(graphs={"agent": g}, store=store)
+        fa = app.function_app
+        thread = store.create()
+        store.update(thread.thread_id, assistant_id="agent")
+
+        fn = _get_fn(fa, "aflg_platform_threads_history")
+        req = func.HttpRequest(
+            method="POST",
+            url=f"/api/threads/{thread.thread_id}/history",
+            body=b"",
+            headers={},
+            route_params={"thread_id": thread.thread_id},
+        )
+        resp = fn(req)
+        assert resp.status_code == 200
+        assert json.loads(resp.get_body()) == []
+
+    def test_history_invalid_json_400(self, store: InMemoryThreadStore) -> None:
+        """Non-JSON body returns 400."""
+        g = FakeStatefulGraph()
+        app = _build_platform_app(graphs={"agent": g}, store=store)
+        fa = app.function_app
+        thread = store.create()
+        store.update(thread.thread_id, assistant_id="agent")
+
+        fn = _get_fn(fa, "aflg_platform_threads_history")
+        req = func.HttpRequest(
+            method="POST",
+            url=f"/api/threads/{thread.thread_id}/history",
+            body=b"not json",
+            headers={"Content-Type": "application/json"},
+            route_params={"thread_id": thread.thread_id},
+        )
+        resp = fn(req)
+        assert resp.status_code == 400
+
+    def test_history_cross_thread_checkpoint_422(self, store: InMemoryThreadStore) -> None:
+        """checkpoint.thread_id mismatch returns 422."""
+        g = FakeStatefulGraph()
+        app = _build_platform_app(graphs={"agent": g}, store=store)
+        fa = app.function_app
+        thread = store.create()
+        store.update(thread.thread_id, assistant_id="agent")
+
+        fn = _get_fn(fa, "aflg_platform_threads_history")
+        req = _post_request(
+            f"/api/threads/{thread.thread_id}/history",
+            {"checkpoint": {"thread_id": "other-thread", "checkpoint_id": "cp-1"}},
+            thread_id=thread.thread_id,
+        )
+        resp = fn(req)
+        assert resp.status_code == 422
+        assert "does not match" in json.loads(resp.get_body())["detail"]
+
+    def test_history_invalid_thread_id_400(self, store: InMemoryThreadStore) -> None:
+        """Empty thread_id returns 400."""
+        g = FakeStatefulGraph()
+        app = _build_platform_app(graphs={"agent": g}, store=store)
+        fa = app.function_app
+
+        fn = _get_fn(fa, "aflg_platform_threads_history")
+        req = _post_request(
+            "/api/threads//history",
+            {},
+            thread_id="",
+        )
+        resp = fn(req)
+        assert resp.status_code == 400
+
+    def test_history_assistant_not_found_404(self, store: InMemoryThreadStore) -> None:
+        """Thread bound to deleted assistant returns 404."""
+        g = FakeStatefulGraph()
+        app = _build_platform_app(graphs={"agent": g}, store=store)
+        fa = app.function_app
+        thread = store.create()
+        store.update(thread.thread_id, assistant_id="deleted-assistant")
+
+        fn = _get_fn(fa, "aflg_platform_threads_history")
+        req = _post_request(
+            f"/api/threads/{thread.thread_id}/history",
+            {},
+            thread_id=thread.thread_id,
+        )
+        resp = fn(req)
+        assert resp.status_code == 404
+
+    def test_history_nonexistent_before_returns_empty(self, store: InMemoryThreadStore) -> None:
+        """before referencing a non-existent checkpoint returns empty list."""
+        from tests.conftest import _FakeStateSnapshot
+        snapshots = [
+            _FakeStateSnapshot(
+                values={"turn": 2},
+                config={
+                    "configurable": {
+                        "thread_id": "t",
+                        "checkpoint_id": "cp-2",
+                        "checkpoint_ns": "",
+                    }
+                },
+            ),
+            _FakeStateSnapshot(
+                values={"turn": 1},
+                config={
+                    "configurable": {
+                        "thread_id": "t",
+                        "checkpoint_id": "cp-1",
+                        "checkpoint_ns": "",
+                    }
+                },
+            ),
+        ]
+        g = FakeStatefulGraph(state_history=snapshots)
+        app = _build_platform_app(graphs={"agent": g}, store=store)
+        fa = app.function_app
+        thread = store.create()
+        store.update(thread.thread_id, assistant_id="agent")
+
+        fn = _get_fn(fa, "aflg_platform_threads_history")
+        req = _post_request(
+            f"/api/threads/{thread.thread_id}/history",
+            {"before": "nonexistent-cp-id"},
+            thread_id=thread.thread_id,
+        )
+        resp = fn(req)
+        assert resp.status_code == 200
+        data = json.loads(resp.get_body())
+        assert data == []
+
+    def test_history_before_dict_cross_thread_422(self, store: InMemoryThreadStore) -> None:
+        """before dict with mismatched thread_id returns 422."""
+        g = FakeStatefulGraph()
+        app = _build_platform_app(graphs={"agent": g}, store=store)
+        fa = app.function_app
+        thread = store.create()
+        store.update(thread.thread_id, assistant_id="agent")
+
+        fn = _get_fn(fa, "aflg_platform_threads_history")
+        req = _post_request(
+            f"/api/threads/{thread.thread_id}/history",
+            {"before": {"thread_id": "other-thread", "checkpoint_id": "cp-1"}},
+            thread_id=thread.thread_id,
+        )
+        resp = fn(req)
+        assert resp.status_code == 422
+        assert "does not match" in json.loads(resp.get_body())["detail"]

--- a/tests/test_sdk_compat.py
+++ b/tests/test_sdk_compat.py
@@ -126,6 +126,18 @@ _ROUTE_TABLE: list[tuple[str, re.Pattern[str], str, list[str]]] = [
     ),
     (
         "POST",
+        re.compile(r"^/threads/(?P<thread_id>[^/]+)/state$"),
+        "aflg_platform_threads_state_update",
+        ["thread_id"],
+    ),
+    (
+        "POST",
+        re.compile(r"^/threads/(?P<thread_id>[^/]+)/history$"),
+        "aflg_platform_threads_history",
+        ["thread_id"],
+    ),
+    (
+        "POST",
         re.compile(r"^/runs/wait$"),
         "aflg_platform_runs_wait_threadless",
         [],
@@ -460,6 +472,103 @@ class TestSdkThreads:
         client.threads.create(metadata={"env": "prod"})
         client.threads.create(metadata={"env": "dev"})
         assert client.threads.count(metadata={"env": "prod"}) == 1
+
+    def test_update_state(self) -> None:
+        """threads.update_state() updates checkpoint and returns new checkpoint info."""
+        _, client = _make_app()
+        thread = client.threads.create()
+        tid = thread["thread_id"]
+
+        # Run the graph to create a checkpoint
+        client.runs.wait(
+            tid,
+            "agent",
+            input={"user_text": "Alice", "history": [], "turn_count": 0},
+        )
+
+        # Update state with new values
+        resp = client.threads.update_state(
+            tid,
+            values={"last_reply": "Overridden"},
+            as_node="count",
+        )
+
+        # SDK returns ThreadUpdateStateResponse with checkpoint info
+        assert "checkpoint" in resp
+        cp = resp["checkpoint"]
+        assert cp["thread_id"] == tid
+        assert "checkpoint_id" in cp
+        assert "checkpoint_ns" in cp
+
+        # Verify state was updated via get_state
+        state = client.threads.get_state(tid)
+        values = state["values"]
+        assert isinstance(values, dict)
+        assert values["last_reply"] == "Overridden"
+
+    def test_update_state_unbound_409(self) -> None:
+        """threads.update_state() on unbound thread returns 409."""
+        _, client = _make_app()
+        thread = client.threads.create()
+
+        with pytest.raises(ConflictError):
+            client.threads.update_state(
+                thread["thread_id"],
+                values={"key": "val"},
+            )
+
+    def test_get_history(self) -> None:
+        """threads.get_history() returns state snapshots after runs."""
+        _, client = _make_app()
+        thread = client.threads.create()
+        tid = thread["thread_id"]
+
+        # Run graph twice to create multiple checkpoints
+        client.runs.wait(
+            tid,
+            "agent",
+            input={"user_text": "A", "history": [], "turn_count": 0},
+        )
+        client.runs.wait(
+            tid,
+            "agent",
+            input={"user_text": "B"},
+        )
+
+        history = client.threads.get_history(tid)
+        assert isinstance(history, list)
+        # Each node produces a checkpoint; 2 runs × 2 nodes = 4+
+        assert len(history) >= 2
+
+        # History is newest-first
+        for entry in history:
+            assert "values" in entry
+            assert "checkpoint" in entry
+
+    def test_get_history_with_limit(self) -> None:
+        """threads.get_history(limit=N) caps results."""
+        _, client = _make_app()
+        thread = client.threads.create()
+        tid = thread["thread_id"]
+
+        # Run graph to generate checkpoints
+        client.runs.wait(
+            tid,
+            "agent",
+            input={"user_text": "X", "history": [], "turn_count": 0},
+        )
+
+        history = client.threads.get_history(tid, limit=2)
+        assert isinstance(history, list)
+        assert len(history) <= 2
+
+    def test_get_history_unbound_409(self) -> None:
+        """threads.get_history() on unbound thread returns 409."""
+        _, client = _make_app()
+        thread = client.threads.create()
+
+        with pytest.raises(ConflictError):
+            client.threads.get_history(thread["thread_id"])
 # ---------------------------------------------------------------------------
 # Tests — Runs
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Add `POST /threads/{thread_id}/state` handler for updating thread state via checkpointer
- Add `POST /threads/{thread_id}/history` handler for retrieving state history snapshots
- Refactor `GET /threads/{thread_id}/state` to use shared `_snapshot_to_thread_state()` helper

## Details

### State Update (`POST /threads/{thread_id}/state`)
- `UpdatableStateGraph` protocol — 409 if graph lacks `update_state()`
- Cross-thread checkpoint validation — 422 if checkpoint.thread_id != path thread_id
- Checkpoint config normalization — merges `checkpoint_id` or `checkpoint` dict fields
- Returns `{"checkpoint": {"thread_id": ..., "checkpoint_ns": ..., "checkpoint_id": ...}}`

### History (`POST /threads/{thread_id}/history`)
- `StateHistoryGraph` protocol — 409 if graph lacks `get_state_history()`
- Server-side filtering: `before` (exclusive cursor), `metadata` (subset match), `limit`
- `before.thread_id` cross-thread validation — 422 if mismatch
- Generator-safe error handling — wraps full iteration in try/except (per Oracle review)
- Accepts empty body with sensible defaults (limit=10)

### Shared Helper
- `_snapshot_to_thread_state()` extracts checkpoint_id, checkpoint_ns, parent_checkpoint, created_at from StateSnapshot
- Used by both GET /state and POST /history for consistent ThreadState serialization

## Test Results
- **591 tests pass** (was 553 before)
- **93.57% coverage** (min 90%)
- **Lint + mypy clean**
- 5 SDK compat tests, 13 state update unit tests, 14 history unit tests, 4 additional edge-case tests (Oracle feedback)

## Oracle Review
- Design review: Approved (session `ses_2a4daf2f1ffeXAFcrzs182KwnE`)
- Post-implementation review: Approved with feedback applied:
  1. ✅ Fixed generator-safe error handling (wrap full iteration in try/except)
  2. ✅ Added `before.thread_id` cross-thread validation
  3. ✅ Added test for `values` as `list[dict]`
  4. ✅ Added GET /state checkpoint propagation regression test
  5. ✅ Added test for nonexistent `before` checkpoint

Closes #57, closes #58