### PR TITLE
feat: add Azure Blob Storage checkpoint saver (#60)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,9 @@ Repository = "https://github.com/yeongseon/azure-functions-langgraph"
 Issues = "https://github.com/yeongseon/azure-functions-langgraph/issues"
 
 [project.optional-dependencies]
+azure-blob = [
+    "azure-storage-blob>=12.0,<13",
+]
 dev = [
     "bandit==1.9.4",
     "build",

--- a/src/azure_functions_langgraph/checkpointers/__init__.py
+++ b/src/azure_functions_langgraph/checkpointers/__init__.py
@@ -1,0 +1,23 @@
+"""Persistent checkpoint savers for LangGraph graphs."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .azure_blob import (
+        AzureBlobCheckpointSaver,
+    )
+
+
+def __getattr__(name: str) -> object:
+    if name == "AzureBlobCheckpointSaver":
+        from .azure_blob import (
+            AzureBlobCheckpointSaver,
+        )
+
+        return AzureBlobCheckpointSaver
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+__all__ = ["AzureBlobCheckpointSaver"]

--- a/src/azure_functions_langgraph/checkpointers/azure_blob.py
+++ b/src/azure_functions_langgraph/checkpointers/azure_blob.py
@@ -1,0 +1,626 @@
+"""Azure Blob Storage-backed checkpoint saver for LangGraph."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator, Sequence
+import importlib
+import json
+import logging
+import random
+from typing import Any, List, Protocol, cast
+from urllib.parse import quote, unquote
+
+from langchain_core.runnables import RunnableConfig
+from langgraph.checkpoint.base import (
+    WRITES_IDX_MAP,
+    BaseCheckpointSaver,
+    ChannelVersions,
+    Checkpoint,
+    CheckpointMetadata,
+    CheckpointTuple,
+    get_checkpoint_id,
+    get_checkpoint_metadata,
+)
+from langgraph.checkpoint.serde.base import SerializerProtocol
+
+
+class _BlobDownloadProtocol(Protocol):
+    def readall(self) -> bytes: ...
+
+
+class _BlobPropertiesProtocol(Protocol):
+    metadata: dict[str, str] | None
+
+
+class _BlobClientProtocol(Protocol):
+    def upload_blob(self, data: bytes, metadata: dict[str, str], overwrite: bool) -> None: ...
+
+    def download_blob(self) -> _BlobDownloadProtocol: ...
+
+    def get_blob_properties(self) -> _BlobPropertiesProtocol: ...
+
+    def delete_blob(self) -> None: ...
+
+
+class _BlobItemProtocol(Protocol):
+    name: str
+
+
+class _ContainerClientProtocol(Protocol):
+    def get_blob_client(self, blob: str) -> _BlobClientProtocol: ...
+
+    def list_blobs(self, name_starts_with: str = "") -> Sequence[_BlobItemProtocol]: ...
+
+logger = logging.getLogger(__name__)
+
+
+class AzureBlobCheckpointSaver(BaseCheckpointSaver[str]):
+    """Persist LangGraph checkpoints in Azure Blob Storage."""
+
+    def __init__(
+        self,
+        *,
+        container_client: _ContainerClientProtocol,
+        serde: SerializerProtocol | None = None,
+    ) -> None:
+        """Create a saver bound to an Azure Blob container client."""
+        try:
+            azure_blob_module = importlib.import_module("azure.storage.blob")
+        except ImportError as exc:
+            raise ImportError(
+                "AzureBlobCheckpointSaver requires optional dependency "
+                "'azure-storage-blob'. Install with: "
+                "pip install azure-functions-langgraph[azure-blob]"
+            ) from exc
+
+        azure_container_client = getattr(azure_blob_module, "ContainerClient", None)
+        if azure_container_client is None or not isinstance(
+            container_client, azure_container_client
+        ):
+            raise TypeError(
+                "container_client must be an instance of "
+                "azure.storage.blob.ContainerClient"
+            )
+
+        super().__init__(serde=serde)
+        self._container_client: _ContainerClientProtocol = cast(
+            _ContainerClientProtocol,
+            container_client,
+        )
+
+        try:
+            azure_core_exceptions = importlib.import_module("azure.core.exceptions")
+            resource_not_found_error = getattr(
+                azure_core_exceptions, "ResourceNotFoundError", None
+            )
+            if resource_not_found_error is None:
+                raise ImportError(
+                    "azure.core.exceptions.ResourceNotFoundError not found"
+                )
+        except ImportError as exc:
+            raise ImportError(
+                "AzureBlobCheckpointSaver requires 'azure-core'. "
+                "Install with: pip install azure-functions-langgraph[azure-blob]"
+            ) from exc
+        self._not_found_error: type[BaseException] = cast(
+            type[BaseException],
+            resource_not_found_error,
+        )
+    def get_next_version(self, current: str | None, channel: None) -> str:
+        """Return the next monotonic channel version string."""
+        if current is None:
+            current_v = 0
+        elif isinstance(current, int):
+            current_v = current
+        else:
+            current_v = int(current.split(".")[0])
+        next_v = current_v + 1
+        next_h = random.random()
+        return f"{next_v:032}.{next_h:016}"
+
+    def get_tuple(self, config: RunnableConfig) -> CheckpointTuple | None:
+        """Fetch a checkpoint tuple by config or latest checkpoint hint."""
+        thread_id = self._config_thread_id(config)
+        checkpoint_ns = self._config_checkpoint_ns(config)
+        requested_checkpoint_id = get_checkpoint_id(config)
+
+        if requested_checkpoint_id:
+            return self._build_tuple(
+                thread_id=thread_id,
+                checkpoint_ns=checkpoint_ns,
+                checkpoint_id=requested_checkpoint_id,
+                return_config=config,
+            )
+
+        # Optimization: try latest.json hint, but verify it is actually the
+        # latest checkpoint.  If the hint is stale (e.g. concurrent writer),
+        # fall through to the authoritative prefix scan.
+        latest_hint = self._read_latest_checkpoint_id(thread_id, checkpoint_ns)
+        actual_latest = self._find_latest_checkpoint_id(thread_id, checkpoint_ns)
+        if actual_latest is None:
+            return None
+
+        # If the hint matches the scan result we avoid re-scanning, but we
+        # always trust the scan over the hint.
+        resolved_id = actual_latest
+        # When the hint is valid AND matches, we already know the id.
+        if latest_hint is not None and latest_hint == actual_latest:
+            resolved_id = latest_hint
+
+        return self._build_tuple(
+            thread_id=thread_id,
+            checkpoint_ns=checkpoint_ns,
+            checkpoint_id=resolved_id,
+            return_config=self._checkpoint_config(thread_id, checkpoint_ns, resolved_id),
+        )
+
+    def list(
+        self,
+        config: RunnableConfig | None,
+        *,
+        filter: dict[str, Any] | None = None,
+        before: RunnableConfig | None = None,
+        limit: int | None = None,
+    ) -> Iterator[CheckpointTuple]:
+        """List checkpoints matching config and optional metadata filters."""
+        remaining = limit
+        config_checkpoint_ns = self._config_checkpoint_ns(config) if config else None
+        config_checkpoint_id = get_checkpoint_id(config) if config else None
+        before_checkpoint_id = get_checkpoint_id(before) if before else None
+
+        thread_ids = [self._config_thread_id(config)] if config else self._list_thread_ids()
+        for thread_id in thread_ids:
+            checkpoint_namespaces = (
+                [config_checkpoint_ns]
+                if config_checkpoint_ns is not None
+                else self._list_checkpoint_namespaces(thread_id)
+            )
+            for checkpoint_ns in checkpoint_namespaces:
+                checkpoint_ids = self._list_checkpoint_ids(thread_id, checkpoint_ns)
+                for checkpoint_id in checkpoint_ids:
+                    if config_checkpoint_id is not None and checkpoint_id != config_checkpoint_id:
+                        continue
+                    if before_checkpoint_id is not None and checkpoint_id >= before_checkpoint_id:
+                        continue
+
+                    checkpoint_tuple = self._build_tuple(
+                        thread_id=thread_id,
+                        checkpoint_ns=checkpoint_ns,
+                        checkpoint_id=checkpoint_id,
+                        return_config=self._checkpoint_config(
+                            thread_id,
+                            checkpoint_ns,
+                            checkpoint_id,
+                        ),
+                    )
+                    if checkpoint_tuple is None:
+                        continue
+
+                    if filter and not all(
+                        query_value == checkpoint_tuple.metadata.get(query_key)
+                        for query_key, query_value in filter.items()
+                    ):
+                        continue
+
+                    if remaining is not None:
+                        if remaining <= 0:
+                            return
+                        remaining -= 1
+
+                    yield checkpoint_tuple
+
+    def put(
+        self,
+        config: RunnableConfig,
+        checkpoint: Checkpoint,
+        metadata: CheckpointMetadata,
+        new_versions: ChannelVersions,
+    ) -> RunnableConfig:
+        """Store checkpoint state, metadata, channel values, and latest hint."""
+        thread_id = self._config_thread_id(config)
+        checkpoint_ns = self._config_checkpoint_ns(config)
+        checkpoint_id = checkpoint["id"]
+        parent_checkpoint_id = get_checkpoint_id(config)
+
+        # Write order: values → metadata → checkpoint (commit marker) → latest.
+        # checkpoint.bin acts as the commit marker: if it exists, the checkpoint
+        # is valid.  Partial failures before it leave harmless orphans.
+        checkpoint_data: dict[str, Any] = dict(checkpoint)
+        channel_values: dict[str, Any] = checkpoint_data.pop("channel_values", {})
+
+        # 1. Channel value blobs
+        for channel, version in new_versions.items():
+            value_blob_path = self._value_blob_path(thread_id, checkpoint_ns, channel, version)
+            if channel in channel_values:
+                serde_type, payload = self.serde.dumps_typed(channel_values[channel])
+            else:
+                serde_type, payload = "empty", b""
+            self._upload_blob(value_blob_path, payload, {"serde_type": serde_type})
+
+        # 2. Metadata blob (before commit marker)
+        metadata_payload_type, metadata_payload = self.serde.dumps_typed(
+            get_checkpoint_metadata(config, metadata)
+        )
+        self._upload_blob(
+            self._metadata_blob_path(thread_id, checkpoint_ns, checkpoint_id),
+            metadata_payload,
+            {"serde_type": metadata_payload_type},
+        )
+
+        # 3. Checkpoint blob (commit marker — existence = valid checkpoint)
+        checkpoint_serde_type, checkpoint_payload = self.serde.dumps_typed(checkpoint_data)
+        checkpoint_blob_metadata: dict[str, str] = {"serde_type": checkpoint_serde_type}
+        if parent_checkpoint_id is not None:
+            checkpoint_blob_metadata["parent_id"] = quote(parent_checkpoint_id, safe="")
+        self._upload_blob(
+            self._checkpoint_blob_path(thread_id, checkpoint_ns, checkpoint_id),
+            checkpoint_payload,
+            checkpoint_blob_metadata,
+        )
+
+        # 4. Monotonic latest.json hint (best-effort, after commit marker)
+        current_latest = self._read_latest_checkpoint_id(thread_id, checkpoint_ns)
+        if current_latest is None or checkpoint_id >= current_latest:
+            latest_payload = json.dumps(
+                {"checkpoint_id": checkpoint_id},
+                separators=(",", ":"),
+            ).encode()
+            self._upload_blob(
+                self._latest_blob_path(thread_id, checkpoint_ns),
+                latest_payload,
+                {},
+            )
+        return self._checkpoint_config(thread_id, checkpoint_ns, checkpoint_id)
+
+    def put_writes(
+        self,
+        config: RunnableConfig,
+        writes: Sequence[tuple[str, Any]],
+        task_id: str,
+        task_path: str = "",
+    ) -> None:
+        """Store task writes for a checkpoint, preserving MemorySaver semantics."""
+        thread_id = self._config_thread_id(config)
+        checkpoint_ns = self._config_checkpoint_ns(config)
+        checkpoint_id = get_checkpoint_id(config)
+        if checkpoint_id is None:
+            raise ValueError("checkpoint_id is required in config to store writes")
+
+        for index, (channel, value) in enumerate(writes):
+            write_index = WRITES_IDX_MAP.get(channel, index)
+            write_blob_path = self._write_blob_path(
+                thread_id,
+                checkpoint_ns,
+                checkpoint_id,
+                task_id,
+                write_index,
+            )
+
+            if write_index >= 0 and self._blob_exists(write_blob_path):
+                continue
+
+            serde_type, payload = self.serde.dumps_typed(value)
+            self._upload_blob(
+                write_blob_path,
+                payload,
+                {
+                    "serde_type": serde_type,
+                    "channel": quote(channel, safe=""),
+                    "task_id": quote(task_id, safe=""),
+                    "task_path": quote(task_path, safe=""),
+                },
+            )
+
+    def delete_thread(self, thread_id: str) -> None:
+        """Delete all blobs for a thread."""
+        thread_prefix = self._thread_prefix(thread_id)
+        for blob in self._container_client.list_blobs(name_starts_with=thread_prefix):
+            self._container_client.get_blob_client(blob.name).delete_blob()
+
+    def _build_tuple(
+        self,
+        *,
+        thread_id: str,
+        checkpoint_ns: str,
+        checkpoint_id: str,
+        return_config: RunnableConfig,
+    ) -> CheckpointTuple | None:
+        checkpoint_blob_path = self._checkpoint_blob_path(thread_id, checkpoint_ns, checkpoint_id)
+        checkpoint_blob_result = self._download_typed_blob(checkpoint_blob_path)
+        if checkpoint_blob_result is None:
+            return None
+
+        serde_type, payload, checkpoint_blob_metadata = checkpoint_blob_result
+        raw_parent_id = checkpoint_blob_metadata.get("parent_id")
+        parent_checkpoint_id = unquote(raw_parent_id) if raw_parent_id else None
+        checkpoint_data: Checkpoint = self.serde.loads_typed((serde_type, payload))
+        channel_values = self._load_channel_values(
+            thread_id=thread_id,
+            checkpoint_ns=checkpoint_ns,
+            channel_versions=checkpoint_data["channel_versions"],
+        )
+
+        metadata_blob_result = self._download_typed_blob(
+            self._metadata_blob_path(thread_id, checkpoint_ns, checkpoint_id)
+        )
+        if metadata_blob_result is None:
+            return None
+        checkpoint_metadata: CheckpointMetadata = self.serde.loads_typed(
+            (metadata_blob_result[0], metadata_blob_result[1])
+        )
+
+        return CheckpointTuple(
+            config=return_config,
+            checkpoint={**checkpoint_data, "channel_values": channel_values},
+            metadata=checkpoint_metadata,
+            parent_config=(
+                self._checkpoint_config(thread_id, checkpoint_ns, parent_checkpoint_id)
+                if parent_checkpoint_id
+                else None
+            ),
+            pending_writes=self._load_pending_writes(thread_id, checkpoint_ns, checkpoint_id),
+        )
+
+    def _load_channel_values(
+        self,
+        *,
+        thread_id: str,
+        checkpoint_ns: str,
+        channel_versions: ChannelVersions,
+    ) -> dict[str, Any]:
+        values: dict[str, Any] = {}
+        for channel, version in channel_versions.items():
+            typed_blob = self._download_typed_blob(
+                self._value_blob_path(thread_id, checkpoint_ns, channel, version)
+            )
+            if typed_blob is None:
+                continue
+            if typed_blob[0] == "empty":
+                continue
+            values[channel] = self.serde.loads_typed((typed_blob[0], typed_blob[1]))
+        return values
+
+    def _load_pending_writes(
+        self,
+        thread_id: str,
+        checkpoint_ns: str,
+        checkpoint_id: str,
+    ) -> List[tuple[str, str, Any]]:
+        writes_prefix = self._writes_prefix(thread_id, checkpoint_ns, checkpoint_id)
+        loaded: List[tuple[str, int, str, Any]] = []
+
+        for blob in self._container_client.list_blobs(name_starts_with=writes_prefix):
+            # Parse relative to writes_prefix: expect "{task_id}/{idx}.bin"
+            if not blob.name.startswith(writes_prefix):
+                continue
+            relative = blob.name[len(writes_prefix):]
+            rel_parts = relative.split("/")
+            if len(rel_parts) != 2:
+                continue
+
+            task_id = unquote(rel_parts[0])
+            file_name = rel_parts[1]
+            if not file_name.endswith(".bin"):
+                continue
+
+            try:
+                write_index = int(unquote(file_name.removesuffix(".bin")))
+            except ValueError:
+                continue
+            typed_blob_result = self._download_typed_blob(blob.name)
+            if typed_blob_result is None:
+                continue
+
+            # Use metadata from the download result (avoids extra API call)
+            blob_meta = typed_blob_result[2]
+            raw_channel = blob_meta.get("channel")
+            raw_metadata_task_id = blob_meta.get("task_id")
+            if raw_channel is None:
+                continue
+            channel = unquote(raw_channel)
+            resolved_task_id = unquote(raw_metadata_task_id) if raw_metadata_task_id else task_id
+
+            value = self.serde.loads_typed((typed_blob_result[0], typed_blob_result[1]))
+            loaded.append((resolved_task_id, write_index, channel, value))
+
+        loaded.sort(key=lambda item: (item[0], item[1]))
+        return [(task_id, channel, value) for task_id, _idx, channel, value in loaded]
+
+    def _find_latest_checkpoint_id(self, thread_id: str, checkpoint_ns: str) -> str | None:
+        checkpoint_ids = self._list_checkpoint_ids(thread_id, checkpoint_ns)
+        if not checkpoint_ids:
+            return None
+        return checkpoint_ids[0]
+
+    def _list_checkpoint_ids(self, thread_id: str, checkpoint_ns: str) -> List[str]:
+        checkpoints_prefix = self._checkpoints_prefix(thread_id, checkpoint_ns)
+        checkpoint_ids: set[str] = set()
+
+        for blob in self._container_client.list_blobs(name_starts_with=checkpoints_prefix):
+            if not blob.name.endswith("/checkpoint.bin"):
+                continue
+
+            path_parts = blob.name.split("/")
+            if len(path_parts) != 7:
+                continue
+
+            checkpoint_ids.add(unquote(path_parts[5]))
+
+        return sorted(checkpoint_ids, reverse=True)
+
+    def _list_thread_ids(self) -> List[str]:
+        thread_ids: set[str] = set()
+        for blob in self._container_client.list_blobs(name_starts_with="threads/"):
+            path_parts = blob.name.split("/")
+            if len(path_parts) >= 2 and path_parts[0] == "threads":
+                thread_ids.add(unquote(path_parts[1]))
+        return sorted(thread_ids)
+
+    def _list_checkpoint_namespaces(self, thread_id: str) -> List[str]:
+        namespace_prefix = f"{self._thread_prefix(thread_id)}ns/"
+        checkpoint_namespaces: set[str] = set()
+
+        for blob in self._container_client.list_blobs(name_starts_with=namespace_prefix):
+            path_parts = blob.name.split("/")
+            if len(path_parts) >= 4 and path_parts[2] == "ns":
+                checkpoint_namespaces.add(unquote(path_parts[3]))
+
+        return sorted(checkpoint_namespaces)
+
+    def _read_latest_checkpoint_id(self, thread_id: str, checkpoint_ns: str) -> str | None:
+        latest_path = self._latest_blob_path(thread_id, checkpoint_ns)
+        latest_payload = self._download_blob(latest_path)
+        if latest_payload is None:
+            return None
+
+        try:
+            data = json.loads(latest_payload.decode())
+        except (UnicodeDecodeError, json.JSONDecodeError):
+            logger.warning("Ignoring malformed latest.json at %s", latest_path)
+            return None
+
+        if not isinstance(data, dict):
+            return None
+
+        checkpoint_id = data.get("checkpoint_id")
+        if isinstance(checkpoint_id, str):
+            return checkpoint_id
+        return None
+
+    def _checkpoint_config(
+        self, thread_id: str, checkpoint_ns: str, checkpoint_id: str
+    ) -> RunnableConfig:
+        return {
+            "configurable": {
+                "thread_id": thread_id,
+                "checkpoint_ns": checkpoint_ns,
+                "checkpoint_id": checkpoint_id,
+            }
+        }
+
+    def _download_typed_blob(
+        self, blob_path: str
+    ) -> tuple[str, bytes, dict[str, str]] | None:
+        """Download a blob and return ``(serde_type, payload, full_metadata)``."""
+        payload = self._download_blob(blob_path)
+        if payload is None:
+            return None
+
+        metadata = self._blob_metadata(blob_path)
+        serde_type = metadata.get("serde_type")
+        if not serde_type:
+            logger.warning("Blob missing serde_type metadata: %s", blob_path)
+            return None
+
+        return (serde_type, payload, metadata)
+
+    def _blob_metadata(self, blob_path: str) -> dict[str, str]:
+        try:
+            properties = self._container_client.get_blob_client(blob_path).get_blob_properties()
+        except self._not_found_error:
+            return {}
+        metadata = properties.metadata
+        return metadata if metadata is not None else {}
+
+    def _download_blob(self, blob_path: str) -> bytes | None:
+        try:
+            return self._container_client.get_blob_client(blob_path).download_blob().readall()
+        except self._not_found_error:
+            return None
+
+    def _blob_exists(self, blob_path: str) -> bool:
+        try:
+            self._container_client.get_blob_client(blob_path).get_blob_properties()
+        except self._not_found_error:
+            return False
+        return True
+
+    def _upload_blob(self, blob_path: str, payload: bytes, metadata: dict[str, str]) -> None:
+        self._container_client.get_blob_client(blob_path).upload_blob(
+            payload,
+            metadata=metadata,
+            overwrite=True,
+        )
+
+    def _thread_prefix(self, thread_id: str) -> str:
+        return f"threads/{self._escape(thread_id)}/"
+
+    def _namespace_prefix(self, thread_id: str, checkpoint_ns: str) -> str:
+        return f"{self._thread_prefix(thread_id)}ns/{self._escape(checkpoint_ns)}/"
+
+    def _checkpoints_prefix(self, thread_id: str, checkpoint_ns: str) -> str:
+        return f"{self._namespace_prefix(thread_id, checkpoint_ns)}checkpoints/"
+
+    def _checkpoint_base_prefix(
+        self,
+        thread_id: str,
+        checkpoint_ns: str,
+        checkpoint_id: str,
+    ) -> str:
+        return (
+            f"{self._checkpoints_prefix(thread_id, checkpoint_ns)}"
+            f"{self._escape(checkpoint_id)}/"
+        )
+
+    def _checkpoint_blob_path(self, thread_id: str, checkpoint_ns: str, checkpoint_id: str) -> str:
+        return (
+            f"{self._checkpoint_base_prefix(thread_id, checkpoint_ns, checkpoint_id)}"
+            "checkpoint.bin"
+        )
+
+    def _metadata_blob_path(self, thread_id: str, checkpoint_ns: str, checkpoint_id: str) -> str:
+        return (
+            f"{self._checkpoint_base_prefix(thread_id, checkpoint_ns, checkpoint_id)}"
+            "metadata.bin"
+        )
+
+    def _writes_prefix(self, thread_id: str, checkpoint_ns: str, checkpoint_id: str) -> str:
+        return f"{self._checkpoint_base_prefix(thread_id, checkpoint_ns, checkpoint_id)}writes/"
+
+    def _write_blob_path(
+        self,
+        thread_id: str,
+        checkpoint_ns: str,
+        checkpoint_id: str,
+        task_id: str,
+        write_index: int,
+    ) -> str:
+        return (
+            f"{self._writes_prefix(thread_id, checkpoint_ns, checkpoint_id)}"
+            f"{self._escape(task_id)}/{self._escape(str(write_index))}.bin"
+        )
+
+    def _value_blob_path(
+        self,
+        thread_id: str,
+        checkpoint_ns: str,
+        channel: str,
+        version: str | int | float,
+    ) -> str:
+        return (
+            f"{self._namespace_prefix(thread_id, checkpoint_ns)}values/"
+            f"{self._escape(channel)}/{self._escape(str(version))}.bin"
+        )
+
+    def _latest_blob_path(self, thread_id: str, checkpoint_ns: str) -> str:
+        return f"{self._namespace_prefix(thread_id, checkpoint_ns)}latest.json"
+
+    def _config_thread_id(self, config: RunnableConfig) -> str:
+        configurable = config.get("configurable")
+        if not isinstance(configurable, dict):
+            raise ValueError("configurable must be provided in RunnableConfig")
+
+        thread_id = configurable.get("thread_id")
+        if thread_id is None:
+            raise ValueError("thread_id is required in config.configurable")
+        return str(thread_id)
+
+    def _config_checkpoint_ns(self, config: RunnableConfig) -> str:
+        configurable = config.get("configurable")
+        if not isinstance(configurable, dict):
+            raise ValueError("configurable must be provided in RunnableConfig")
+        checkpoint_ns = configurable.get("checkpoint_ns", "")
+        return str(checkpoint_ns)
+
+    def _escape(self, segment: str) -> str:
+        return quote(segment, safe="")

--- a/tests/test_checkpointers_azure_blob.py
+++ b/tests/test_checkpointers_azure_blob.py
@@ -1,0 +1,573 @@
+"""Unit tests for AzureBlobCheckpointSaver."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import importlib
+import json
+import re
+import sys
+import types
+from typing import Any, Iterator, Literal, Protocol, Sequence, cast
+from urllib.parse import quote
+
+from langchain_core.runnables import RunnableConfig
+from langgraph.checkpoint.base import Checkpoint, CheckpointMetadata
+from langgraph.checkpoint.serde.types import ERROR, INTERRUPT
+
+pytest = cast(Any, importlib.import_module("pytest"))
+
+class _CheckpointSaverProtocol(Protocol):
+    def get_next_version(self, current: str | None, channel: None) -> str: ...
+
+    def get_tuple(self, config: RunnableConfig) -> Any: ...
+
+    def list(
+        self,
+        config: RunnableConfig | None,
+        *,
+        filter: dict[str, Any] | None = None,
+        before: RunnableConfig | None = None,
+        limit: int | None = None,
+    ) -> Iterator[Any]: ...
+
+    def put(
+        self,
+        config: RunnableConfig,
+        checkpoint: Checkpoint,
+        metadata: CheckpointMetadata,
+        new_versions: dict[str, str | int | float],
+    ) -> RunnableConfig: ...
+
+    def put_writes(
+        self,
+        config: RunnableConfig,
+        writes: Sequence[tuple[str, Any]],
+        task_id: str,
+        task_path: str = "",
+    ) -> None: ...
+
+    def delete_thread(self, thread_id: str) -> None: ...
+
+
+class FakeResourceNotFoundError(Exception):
+    """Raised when a mock blob is not present."""
+
+
+@dataclass
+class _BlobRecord:
+    data: bytes
+    metadata: dict[str, str]
+
+
+@dataclass
+class _BlobItem:
+    name: str
+
+
+class _MockDownloadStream:
+    def __init__(self, data: bytes) -> None:
+        self._data = data
+
+    def readall(self) -> bytes:
+        return self._data
+
+
+class _MockBlobProperties:
+    def __init__(self, metadata: dict[str, str]) -> None:
+        self.metadata = metadata
+
+
+class MockBlobClient:
+    def __init__(self, container: MockContainerClient, blob_name: str) -> None:
+        self._container = container
+        self._blob_name = blob_name
+
+    def upload_blob(self, data: bytes, metadata: dict[str, str], overwrite: bool) -> None:
+        if not overwrite and self._blob_name in self._container.blobs:
+            raise ValueError("Blob already exists")
+        self._container.blobs[self._blob_name] = _BlobRecord(data=data, metadata=dict(metadata))
+
+    def download_blob(self) -> _MockDownloadStream:
+        record = self._container.blobs.get(self._blob_name)
+        if record is None:
+            raise FakeResourceNotFoundError(self._blob_name)
+        return _MockDownloadStream(record.data)
+
+    def get_blob_properties(self) -> _MockBlobProperties:
+        record = self._container.blobs.get(self._blob_name)
+        if record is None:
+            raise FakeResourceNotFoundError(self._blob_name)
+        return _MockBlobProperties(metadata=dict(record.metadata))
+
+    def delete_blob(self) -> None:
+        if self._blob_name not in self._container.blobs:
+            raise FakeResourceNotFoundError(self._blob_name)
+        del self._container.blobs[self._blob_name]
+
+
+class MockContainerClient:
+    def __init__(self) -> None:
+        self.blobs: dict[str, _BlobRecord] = {}
+
+    def get_blob_client(self, blob: str) -> MockBlobClient:
+        return MockBlobClient(self, blob)
+
+    def list_blobs(self, name_starts_with: str = "") -> list[_BlobItem]:
+        return [
+            _BlobItem(name=name)
+            for name in sorted(self.blobs)
+            if name.startswith(name_starts_with)
+        ]
+
+
+@pytest.fixture(autouse=True)  # type: ignore[untyped-decorator]
+def _install_fake_azure_modules(monkeypatch: Any) -> None:
+    azure_mod = types.ModuleType("azure")
+    azure_storage_mod = types.ModuleType("azure.storage")
+    azure_blob_mod = types.ModuleType("azure.storage.blob")
+    setattr(azure_blob_mod, "ContainerClient", MockContainerClient)
+
+    azure_core_mod = types.ModuleType("azure.core")
+    azure_core_exceptions_mod = types.ModuleType("azure.core.exceptions")
+    setattr(azure_core_exceptions_mod, "ResourceNotFoundError", FakeResourceNotFoundError)
+
+    monkeypatch.setitem(sys.modules, "azure", azure_mod)
+    monkeypatch.setitem(sys.modules, "azure.storage", azure_storage_mod)
+    monkeypatch.setitem(sys.modules, "azure.storage.blob", azure_blob_mod)
+    monkeypatch.setitem(sys.modules, "azure.core", azure_core_mod)
+    monkeypatch.setitem(sys.modules, "azure.core.exceptions", azure_core_exceptions_mod)
+
+
+@pytest.fixture  # type: ignore[untyped-decorator]
+def saver_and_container() -> tuple[_CheckpointSaverProtocol, MockContainerClient]:
+    container = MockContainerClient()
+    module = importlib.import_module("azure_functions_langgraph.checkpointers.azure_blob")
+    saver_cls = getattr(module, "AzureBlobCheckpointSaver")
+    saver = cast(_CheckpointSaverProtocol, saver_cls(container_client=container))
+    return saver, container
+
+
+def _config(
+    thread_id: str = "thread-1",
+    checkpoint_ns: str = "",
+    checkpoint_id: str | None = None,
+) -> RunnableConfig:
+    config: RunnableConfig = {
+        "configurable": {
+            "thread_id": thread_id,
+            "checkpoint_ns": checkpoint_ns,
+        }
+    }
+    if checkpoint_id is not None:
+        config["configurable"]["checkpoint_id"] = checkpoint_id
+    return config
+
+
+def _checkpoint(
+    checkpoint_id: str,
+    *,
+    channel_values: dict[str, Any] | None = None,
+    channel_versions: dict[str, str | int | float] | None = None,
+) -> Checkpoint:
+    return {
+        "v": 1,
+        "id": checkpoint_id,
+        "ts": "2026-01-01T00:00:00Z",
+        "channel_values": channel_values or {},
+        "channel_versions": channel_versions or {},
+        "versions_seen": {},
+        "updated_channels": None,
+    }
+
+
+def _metadata(
+    *,
+    source: Literal["input", "loop", "update", "fork"] = "loop",
+    step: int = 1,
+    run_id: str = "run-1",
+) -> CheckpointMetadata:
+    return {
+        "source": source,
+        "step": step,
+        "run_id": run_id,
+        "parents": {},
+    }
+
+
+def test_path_escaping(
+    saver_and_container: tuple[_CheckpointSaverProtocol, MockContainerClient],
+) -> None:
+    saver, container = saver_and_container
+    cfg = _config(thread_id="thread/a b", checkpoint_ns="ns/x y")
+    checkpoint = _checkpoint(
+        "cp/001",
+        channel_values={"ch/name": "value"},
+        channel_versions={"ch/name": "v/1"},
+    )
+    saver.put(cfg, checkpoint, _metadata(), {"ch/name": "v/1"})
+    saver.put_writes(
+        _config(thread_id="thread/a b", checkpoint_ns="ns/x y", checkpoint_id="cp/001"),
+        [("result/channel", {"ok": True})],
+        task_id="task/1",
+    )
+
+    escaped_thread = quote("thread/a b", safe="")
+    escaped_ns = quote("ns/x y", safe="")
+    escaped_checkpoint = quote("cp/001", safe="")
+    escaped_channel = quote("ch/name", safe="")
+    escaped_version = quote("v/1", safe="")
+    escaped_task_id = quote("task/1", safe="")
+
+    assert (
+        f"threads/{escaped_thread}/ns/{escaped_ns}/checkpoints/"
+        f"{escaped_checkpoint}/checkpoint.bin"
+    ) in container.blobs
+    assert (
+        f"threads/{escaped_thread}/ns/{escaped_ns}/values/"
+        f"{escaped_channel}/{escaped_version}.bin"
+    ) in container.blobs
+    assert (
+        f"threads/{escaped_thread}/ns/{escaped_ns}/checkpoints/{escaped_checkpoint}/"
+        f"writes/{escaped_task_id}/0.bin"
+    ) in container.blobs
+
+
+def test_get_next_version(
+    saver_and_container: tuple[_CheckpointSaverProtocol, MockContainerClient],
+) -> None:
+    saver, _ = saver_and_container
+
+    version_1 = saver.get_next_version(None, None)
+    version_2 = saver.get_next_version(version_1, None)
+
+    assert re.fullmatch(r"\d{32}\.0\.\d+", version_1) is not None
+    assert re.fullmatch(r"\d{32}\.0\.\d+", version_2) is not None
+    assert int(version_2.split(".", maxsplit=1)[0]) == int(version_1.split(".", maxsplit=1)[0]) + 1
+
+
+def test_put_and_get_tuple(
+    saver_and_container: tuple[_CheckpointSaverProtocol, MockContainerClient],
+) -> None:
+    saver, _ = saver_and_container
+    cfg = _config(thread_id="t-1", checkpoint_ns="")
+    checkpoint = _checkpoint(
+        "cp-001",
+        channel_values={"messages": ["hello"]},
+        channel_versions={"messages": "v1"},
+    )
+
+    saved_config = saver.put(cfg, checkpoint, _metadata(), {"messages": "v1"})
+    result = saver.get_tuple(saved_config)
+
+    assert result is not None
+    assert result.config == saved_config
+    assert result.checkpoint["id"] == "cp-001"
+    assert result.checkpoint["channel_values"] == {"messages": ["hello"]}
+    assert result.metadata["run_id"] == "run-1"
+    assert result.parent_config is None
+    assert result.pending_writes == []
+
+
+def test_stale_latest_json_returns_actual_latest(
+    saver_and_container: tuple[_CheckpointSaverProtocol, MockContainerClient],
+) -> None:
+    """When latest.json is stale, get_tuple must return the actual latest checkpoint."""
+    saver, container = saver_and_container
+    cfg = _config(thread_id="t-1", checkpoint_ns="ns")
+
+    saver.put(cfg, _checkpoint("cp-001"), _metadata(step=1), {})
+    saver.put(cfg, _checkpoint("cp-002"), _metadata(step=2), {})
+
+    # Manually set latest.json to the OLDER checkpoint (simulating stale hint)
+    latest_path = "threads/t-1/ns/ns/latest.json"
+    container.get_blob_client(latest_path).upload_blob(
+        json.dumps({"checkpoint_id": "cp-001"}).encode(),
+        metadata={},
+        overwrite=True,
+    )
+
+    result = saver.get_tuple(_config(thread_id="t-1", checkpoint_ns="ns"))
+    assert result is not None
+    # Must return cp-002 (actual latest), NOT cp-001 (stale hint)
+    assert result.checkpoint["id"] == "cp-002"
+
+def test_get_tuple_no_checkpoint_returns_none(
+    saver_and_container: tuple[_CheckpointSaverProtocol, MockContainerClient],
+) -> None:
+    saver, _ = saver_and_container
+    assert saver.get_tuple(_config(thread_id="missing", checkpoint_ns="ns")) is None
+
+
+def test_get_tuple_by_checkpoint_id(
+    saver_and_container: tuple[_CheckpointSaverProtocol, MockContainerClient],
+) -> None:
+    saver, _ = saver_and_container
+    cfg = _config(thread_id="t-1", checkpoint_ns="ns")
+    saver.put(cfg, _checkpoint("cp-001"), _metadata(step=1), {})
+    saver.put(cfg, _checkpoint("cp-002"), _metadata(step=2), {})
+
+    result = saver.get_tuple(_config(thread_id="t-1", checkpoint_ns="ns", checkpoint_id="cp-001"))
+    assert result is not None
+    assert result.checkpoint["id"] == "cp-001"
+
+
+def test_get_tuple_fallback_when_latest_missing(
+    saver_and_container: tuple[_CheckpointSaverProtocol, MockContainerClient],
+) -> None:
+    saver, container = saver_and_container
+    cfg = _config(thread_id="t-1", checkpoint_ns="ns")
+    saver.put(cfg, _checkpoint("cp-001"), _metadata(step=1), {})
+    saver.put(cfg, _checkpoint("cp-002"), _metadata(step=2), {})
+    del container.blobs["threads/t-1/ns/ns/latest.json"]
+
+    result = saver.get_tuple(_config(thread_id="t-1", checkpoint_ns="ns"))
+    assert result is not None
+    assert result.checkpoint["id"] == "cp-002"
+
+
+def test_list_checkpoints(
+    saver_and_container: tuple[_CheckpointSaverProtocol, MockContainerClient],
+) -> None:
+    saver, _ = saver_and_container
+    cfg = _config(thread_id="t-1", checkpoint_ns="ns")
+    saver.put(cfg, _checkpoint("cp-001"), _metadata(step=1), {})
+    saver.put(cfg, _checkpoint("cp-002"), _metadata(step=2), {})
+    saver.put(cfg, _checkpoint("cp-003"), _metadata(step=3), {})
+
+    checkpoints = list(saver.list(_config(thread_id="t-1", checkpoint_ns="ns"), limit=2))
+    assert [item.checkpoint["id"] for item in checkpoints] == ["cp-003", "cp-002"]
+
+
+def test_list_with_before_filter(
+    saver_and_container: tuple[_CheckpointSaverProtocol, MockContainerClient],
+) -> None:
+    saver, _ = saver_and_container
+    cfg = _config(thread_id="t-1", checkpoint_ns="ns")
+    saver.put(cfg, _checkpoint("cp-001"), _metadata(step=1), {})
+    saver.put(cfg, _checkpoint("cp-002"), _metadata(step=2), {})
+    saver.put(cfg, _checkpoint("cp-003"), _metadata(step=3), {})
+
+    checkpoints = list(
+        saver.list(
+            _config(thread_id="t-1", checkpoint_ns="ns"),
+            before=_config(thread_id="t-1", checkpoint_ns="ns", checkpoint_id="cp-003"),
+        )
+    )
+    assert [item.checkpoint["id"] for item in checkpoints] == ["cp-002", "cp-001"]
+
+
+def test_list_with_metadata_filter(
+    saver_and_container: tuple[_CheckpointSaverProtocol, MockContainerClient],
+) -> None:
+    saver, _ = saver_and_container
+    cfg = _config(thread_id="t-1", checkpoint_ns="ns")
+    saver.put(cfg, _checkpoint("cp-001"), _metadata(run_id="run-1"), {})
+    saver.put(cfg, _checkpoint("cp-002"), _metadata(run_id="run-2"), {})
+
+    checkpoints = list(
+        saver.list(_config(thread_id="t-1", checkpoint_ns="ns"), filter={"run_id": "run-2"})
+    )
+    assert [item.checkpoint["id"] for item in checkpoints] == ["cp-002"]
+
+
+def test_put_writes_and_retrieve(
+    saver_and_container: tuple[_CheckpointSaverProtocol, MockContainerClient],
+) -> None:
+    saver, _ = saver_and_container
+    cfg = _config(thread_id="t-1", checkpoint_ns="ns")
+    saver.put(cfg, _checkpoint("cp-001"), _metadata(), {})
+
+    write_config = _config(thread_id="t-1", checkpoint_ns="ns", checkpoint_id="cp-001")
+    saver.put_writes(write_config, [("alpha", 1), ("beta", 2)], task_id="task-1")
+
+    result = saver.get_tuple(write_config)
+    assert result is not None
+    assert result.pending_writes == [("task-1", "alpha", 1), ("task-1", "beta", 2)]
+
+
+def test_put_writes_dedup(
+    saver_and_container: tuple[_CheckpointSaverProtocol, MockContainerClient],
+) -> None:
+    saver, _ = saver_and_container
+    cfg = _config(thread_id="t-1", checkpoint_ns="ns")
+    saver.put(cfg, _checkpoint("cp-001"), _metadata(), {})
+
+    write_config = _config(thread_id="t-1", checkpoint_ns="ns", checkpoint_id="cp-001")
+    writes = [("alpha", 1), ("beta", 2)]
+    saver.put_writes(write_config, writes, task_id="task-1")
+    saver.put_writes(write_config, writes, task_id="task-1")
+
+    result = saver.get_tuple(write_config)
+    assert result is not None
+    assert result.pending_writes == [("task-1", "alpha", 1), ("task-1", "beta", 2)]
+
+
+def test_put_writes_special_types(
+    saver_and_container: tuple[_CheckpointSaverProtocol, MockContainerClient],
+) -> None:
+    saver, container = saver_and_container
+    cfg = _config(thread_id="t-1", checkpoint_ns="ns")
+    saver.put(cfg, _checkpoint("cp-001"), _metadata(), {})
+
+    write_config = _config(thread_id="t-1", checkpoint_ns="ns", checkpoint_id="cp-001")
+    saver.put_writes(write_config, [(ERROR, "err"), (INTERRUPT, "stop")], task_id="task-1")
+
+    blob_names = set(container.blobs)
+    assert "threads/t-1/ns/ns/checkpoints/cp-001/writes/task-1/-1.bin" in blob_names
+    assert "threads/t-1/ns/ns/checkpoints/cp-001/writes/task-1/-3.bin" in blob_names
+
+    result = saver.get_tuple(write_config)
+    assert result is not None
+    assert {(task, channel, value) for task, channel, value in result.pending_writes or []} == {
+        ("task-1", ERROR, "err"),
+        ("task-1", INTERRUPT, "stop"),
+    }
+
+
+def test_delete_thread(
+    saver_and_container: tuple[_CheckpointSaverProtocol, MockContainerClient],
+) -> None:
+    saver, container = saver_and_container
+    saver.put(_config(thread_id="t-1", checkpoint_ns="ns"), _checkpoint("cp-001"), _metadata(), {})
+    saver.put(_config(thread_id="t-2", checkpoint_ns="ns"), _checkpoint("cp-001"), _metadata(), {})
+
+    saver.delete_thread("t-1")
+
+    assert saver.get_tuple(_config(thread_id="t-1", checkpoint_ns="ns")) is None
+    assert saver.get_tuple(_config(thread_id="t-2", checkpoint_ns="ns")) is not None
+    assert all(not name.startswith("threads/t-1/") for name in container.blobs)
+
+
+def test_channel_value_dedup(
+    saver_and_container: tuple[_CheckpointSaverProtocol, MockContainerClient],
+) -> None:
+    saver, container = saver_and_container
+    cfg = _config(thread_id="t-1", checkpoint_ns="ns")
+
+    saver.put(
+        cfg,
+        _checkpoint("cp-001", channel_values={"count": 1}, channel_versions={"count": "v1"}),
+        _metadata(step=1),
+        {"count": "v1"},
+    )
+    saver.put(
+        cfg,
+        _checkpoint("cp-002", channel_values={"count": 1}, channel_versions={"count": "v1"}),
+        _metadata(step=2),
+        {"count": "v1"},
+    )
+
+    value_blobs = [name for name in container.blobs if "/values/count/v1.bin" in name]
+    assert len(value_blobs) == 1
+
+
+def test_empty_checkpoint_ns(
+    saver_and_container: tuple[_CheckpointSaverProtocol, MockContainerClient],
+) -> None:
+    saver, _ = saver_and_container
+    cfg: RunnableConfig = {
+        "configurable": {
+            "thread_id": "thread-default-ns",
+        }
+    }
+
+    saver.put(cfg, _checkpoint("cp-001"), _metadata(), {})
+    result = saver.get_tuple(cfg)
+
+    assert result is not None
+    assert result.config["configurable"]["checkpoint_ns"] == ""
+    assert result.checkpoint["id"] == "cp-001"
+
+
+def test_special_chars_in_ids(
+    saver_and_container: tuple[_CheckpointSaverProtocol, MockContainerClient],
+) -> None:
+    saver, container = saver_and_container
+    cfg = _config(thread_id="thread/한 글 🚀", checkpoint_ns="name/space")
+    checkpoint = _checkpoint(
+        "cp/한글 1",
+        channel_values={"messages": ["ok"]},
+        channel_versions={"messages": "v/1"},
+    )
+
+    saved_config = saver.put(cfg, checkpoint, _metadata(), {"messages": "v/1"})
+    result = saver.get_tuple(saved_config)
+
+    assert result is not None
+    assert result.checkpoint["id"] == "cp/한글 1"
+    assert result.checkpoint["channel_values"] == {"messages": ["ok"]}
+    assert any("%ED%95%9C" in blob_name for blob_name in container.blobs)
+
+
+def test_unicode_parent_id_in_metadata(
+    saver_and_container: tuple[_CheckpointSaverProtocol, MockContainerClient],
+) -> None:
+    """parent_id containing Unicode is safely URL-encoded in blob metadata."""
+    saver, container = saver_and_container
+    parent_cfg = _config(thread_id="t-1", checkpoint_ns="", checkpoint_id="parent/한글")
+    child_checkpoint = _checkpoint("child-001")
+    saver.put(parent_cfg, child_checkpoint, _metadata(), {})
+
+    # Verify the checkpoint blob metadata has URL-encoded parent_id
+    cp_blob_path = "threads/t-1/ns//checkpoints/child-001/checkpoint.bin"
+    record = container.blobs.get(cp_blob_path)
+    assert record is not None
+    assert record.metadata["parent_id"] == quote("parent/한글", safe="")
+
+    # get_tuple should decode it back correctly
+    result = saver.get_tuple(_config(thread_id="t-1", checkpoint_ns="", checkpoint_id="child-001"))
+    assert result is not None
+    assert result.parent_config is not None
+    assert result.parent_config["configurable"]["checkpoint_id"] == "parent/한글"
+
+
+def test_unicode_channel_and_task_id_in_writes(
+    saver_and_container: tuple[_CheckpointSaverProtocol, MockContainerClient],
+) -> None:
+    """channel and task_id containing Unicode are URL-encoded in write blob metadata."""
+    saver, container = saver_and_container
+    cfg = _config(thread_id="t-1", checkpoint_ns="")
+    saver.put(cfg, _checkpoint("cp-001"), _metadata(), {})
+
+    write_cfg = _config(thread_id="t-1", checkpoint_ns="", checkpoint_id="cp-001")
+    saver.put_writes(write_cfg, [("결과/채널", {"ok": True})], task_id="작업/1")
+
+    # Verify metadata values are URL-encoded (ASCII-safe)
+    write_blobs = [
+        (name, rec)
+        for name, rec in container.blobs.items()
+        if "/writes/" in name and name.endswith(".bin")
+    ]
+    assert len(write_blobs) == 1
+    _, write_rec = write_blobs[0]
+    assert write_rec.metadata["channel"] == quote("결과/채널", safe="")
+    assert write_rec.metadata["task_id"] == quote("작업/1", safe="")
+
+    # get_tuple should decode them back correctly
+    result = saver.get_tuple(write_cfg)
+    assert result is not None
+    assert len(result.pending_writes) == 1
+    task_id_out, channel_out, value_out = result.pending_writes[0]
+    assert task_id_out == "작업/1"
+    assert channel_out == "결과/채널"
+    assert value_out == {"ok": True}
+
+
+def test_latest_json_monotonic_write(
+    saver_and_container: tuple[_CheckpointSaverProtocol, MockContainerClient],
+) -> None:
+    """latest.json is only updated when the new checkpoint_id >= the current one."""
+    saver, container = saver_and_container
+    cfg = _config(thread_id="t-1", checkpoint_ns="ns")
+
+    # Write cp-002 first (latest.json = cp-002)
+    saver.put(cfg, _checkpoint("cp-002"), _metadata(step=2), {})
+    latest_path = "threads/t-1/ns/ns/latest.json"
+    latest_data = json.loads(container.blobs[latest_path].data.decode())
+    assert latest_data["checkpoint_id"] == "cp-002"
+
+    # Write cp-001 (older) — latest.json should NOT be downgraded
+    saver.put(cfg, _checkpoint("cp-001"), _metadata(step=1), {})
+    latest_data = json.loads(container.blobs[latest_path].data.decode())
+    assert latest_data["checkpoint_id"] == "cp-002"  # Still cp-002, not cp-001


### PR DESCRIPTION
## Summary

Adds `AzureBlobCheckpointSaver`, a LangGraph `BaseCheckpointSaver[str]` implementation backed by Azure Blob Storage.

Closes #60

## Changes

### New files
- `src/azure_functions_langgraph/checkpointers/__init__.py` — Lazy-loading checkpointers subpackage
- `src/azure_functions_langgraph/checkpointers/azure_blob.py` — Full `AzureBlobCheckpointSaver` implementation (626 lines)
- `tests/test_checkpointers_azure_blob.py` — 20 unit tests with `MockContainerClient` (573 lines)

### Modified files
- `pyproject.toml` — Added `azure-blob = ["azure-storage-blob>=12.0,<13"]` optional extra

## Design

- Hierarchical blob naming: `threads/{thread_id}/ns/{ns}/checkpoints/{checkpoint_id}/checkpoint.bin`
- Separate versioned channel value blobs matching MemorySaver dedup semantics
- `latest.json` monotonic hint pointer — only updated when checkpoint_id >= existing
- `get_tuple` always scans for actual latest (never trusts stale hint)
- Write order: values → metadata.bin → checkpoint.bin (commit marker) → latest.json
- All path segments URL-encoded for ASCII safety
- Azure Blob metadata values URL-encoded (ASCII requirement)
- `_download_typed_blob` returns `(serde_type, payload, full_metadata)` triple — avoids double fetch
- Pending writes parsed relative to `writes_prefix` (not hardcoded path depth)
- Lazy import of `azure.storage.blob` — raises `ImportError` on failure
- `azure-storage-blob` is an optional dependency (not a hard runtime dep)

## Oracle Review

All 7 findings from Oracle post-implementation review have been addressed:
1. ✅ Stale latest.json bug — `get_tuple` scans for actual latest
2. ✅ Azure blob metadata ASCII — URL-encoded with `quote()`/`unquote()`
3. ✅ Write order — values → metadata.bin → checkpoint.bin → latest.json
4. ✅ `_not_found_error` fallback — raises `ImportError` instead of silent fallback
5. ✅ Double metadata fetch — triple return from `_download_typed_blob`
6. ✅ Hardcoded path parsing — uses `writes_prefix`-relative parsing
7. ✅ Stale pointer test + 3 new tests (Unicode parent_id, Unicode channel/task_id, monotonic latest.json)

## Test Results

- **611 tests passing**
- **90.80% coverage** (above 90% threshold)
- **Lint clean** (ruff + mypy)