### PR TITLE
docs: standardize architecture docs with Mermaid diagrams, Sources, and See Also

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -10,24 +10,36 @@
 
 ## Architecture
 
-```
-User Code                     azure-functions-langgraph           Azure Functions
-─────────────────────────────────────────────────────────────────────────────────
-StateGraph → compile()  →  LangGraphApp.register(graph)  →  FunctionApp with routes
-                            ├─ POST /graphs/{name}/invoke  →  graph.invoke(input, config)
-                            ├─ POST /graphs/{name}/stream  →  graph.stream(input, config)
-                            ├─ GET /graphs/{name}/threads/{id}/state → graph.get_state(config)
-                            ├─ GET /health                 →  list registered graphs
-                            ├─ GET /openapi.json           →  auto-generated spec
-                            │
-                            │  platform_compat=True adds:
-                            ├─ POST /assistants/search     →  list registered graphs as assistants
-                            ├─ POST /threads               →  thread lifecycle (CRUD, search)
-                            ├─ POST /threads/{id}/runs/wait →  graph.invoke via SDK client
-                            ├─ POST /runs/wait             →  threadless run (ephemeral thread)
-                            ├─ GET /threads/{id}/state     →  graph.get_state(config)
-                            ├─ POST /threads/{id}/state    →  graph.update_state(config, values)
-                            └─ POST /threads/{id}/history   →  graph.get_state_history(config)
+```mermaid
+flowchart TB
+    subgraph App ["App / Core"]
+        UC["User Code\nStateGraph → compile()"] --> REG["LangGraphApp.register(graph)"]
+        REG --> FA["Azure FunctionApp"]
+    end
+
+    subgraph Native ["Native Routes"]
+        FA --> INV["POST /graphs/{name}/invoke"]
+        FA --> STR["POST /graphs/{name}/stream"]
+        FA --> GST["GET /graphs/{name}/threads/{id}/state"]
+        FA --> HLT["GET /health"]
+        FA --> OAI["GET /openapi.json"]
+    end
+
+    subgraph Platform ["Platform-Compatible Routes (platform_compat=True, subset shown)"]
+        FA --> AST["POST /assistants/search"]
+        FA --> THR["POST /threads (CRUD, search)"]
+        FA --> RUN["POST /threads/{id}/runs/wait"]
+        FA --> RUNS["POST /threads/{id}/runs/stream"]
+        FA --> TLR["POST /runs/wait (threadless)"]
+        FA --> TLS["POST /runs/stream (threadless)"]
+        FA --> UST["POST /threads/{id}/state"]
+        FA --> HST["POST /threads/{id}/history"]
+    end
+
+    subgraph Storage ["Persistent Storage (optional)"]
+        CKP["Checkpoint Store\n(AzureBlobCheckpointSaver)"]
+        THS["Thread Store\n(AzureTableThreadStore)"]
+    end
 ```
 
 ## Key Decisions
@@ -43,8 +55,8 @@ Azure Functions doesn't natively support true SSE streaming (no chunked transfer
 
 Future versions may use Durable Functions fan-out or WebSocket support to enable true streaming.
 
-### 3. Thread ID in request body config (not URL path)
-Following LangGraph conventions, `thread_id` is passed in `config.configurable.thread_id`, not as a URL path parameter. This keeps the API surface minimal and compatible with LangGraph's native client patterns.
+### 3. Thread ID in request body config (native routes)
+For native routes (`/graphs/{name}/invoke`, etc.), `thread_id` is passed in `config.configurable.thread_id`, not as a URL path parameter. This keeps the native API surface minimal and compatible with LangGraph's client patterns. Platform-compatible routes use path parameters (`/threads/{thread_id}/...`) to match the LangGraph Platform REST API.
 
 ### 4. No Durable Functions dependency (v0.1)
 The v0.1 release is HTTP-only. This keeps the dependency footprint small and the mental model simple. Durable Functions can be added later for timeout extension and fan-out patterns.
@@ -127,3 +139,21 @@ src/azure_functions_langgraph/
 - No real LLM calls in any tests
 - 645 tests, 91%+ coverage as of v0.4.0
 - Coverage threshold enforced at 90% (`fail_under = 90`)
+
+
+## Sources
+
+- [Azure Functions Python developer reference](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-python)
+- [Azure Functions HTTP trigger](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-http-webhook-trigger)
+- [Supported languages in Azure Functions](https://learn.microsoft.com/en-us/azure/azure-functions/supported-languages)
+- [Azure Blob Storage documentation](https://learn.microsoft.com/en-us/azure/storage/blobs/)
+- [Azure Table Storage documentation](https://learn.microsoft.com/en-us/azure/storage/tables/)
+- [LangGraph documentation](https://langchain-ai.github.io/langgraph/)
+
+## See Also
+
+- [azure-functions-validation — Architecture](https://github.com/yeongseon/azure-functions-validation) — Request/response validation pipeline
+- [azure-functions-openapi — Architecture](https://github.com/yeongseon/azure-functions-openapi) — OpenAPI spec generation
+- [azure-functions-logging — Architecture](https://github.com/yeongseon/azure-functions-logging) — Structured logging with contextvars
+- [azure-functions-doctor — Architecture](https://github.com/yeongseon/azure-functions-doctor) — Pre-deploy diagnostic CLI
+- [azure-functions-scaffold — Architecture](https://github.com/yeongseon/azure-functions-scaffold) — Project scaffolding CLI

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -5,19 +5,49 @@
 `azure-functions-langgraph` is a thin deployment adapter. It bridges LangGraph compiled graphs and Azure Functions HTTP endpoints without adding intermediate abstractions.
 
 ```mermaid
-flowchart LR
-    A[User Code] --> B[StateGraph.compile]
-    B --> C[CompiledStateGraph]
-    C --> D[LangGraphApp.register]
-    D --> E[Azure FunctionApp]
-    E --> F["POST /graphs/{name}/invoke"]
-    E --> G["POST /graphs/{name}/stream"]
-    E --> H[GET /health]
-    E --> I["GET /graphs/{name}/threads/{id}/state"]
-    E --> J[GET /openapi.json]
+flowchart TB
+    subgraph User ["User Code"]
+        SG["StateGraph → compile()"] --> CSG["CompiledStateGraph"]
+    end
+
+    subgraph Core ["LangGraphApp"]
+        CSG --> REG["register(graph)"]
+        REG --> FA["Azure FunctionApp"]
+    end
+
+    subgraph Native ["Native Routes"]
+        FA --> INV["POST /graphs/{name}/invoke"]
+        FA --> STR["POST /graphs/{name}/stream"]
+        FA --> GST["GET /graphs/{name}/threads/{id}/state"]
+        FA --> HLT["GET /health"]
+        FA --> OAI["GET /openapi.json"]
+    end
+
+    subgraph Platform ["Platform-Compatible Routes"]
+        FA --> THR["Thread CRUD + search"]
+        FA --> RUN["POST /threads/{id}/runs/wait|stream"]
+        FA --> TLR["POST /runs/wait|stream (threadless)"]
+        FA --> AST["POST /assistants/search"]
+        FA --> PST["State: get / update / history"]
+    end
+
+    subgraph Storage ["Persistent Storage (optional)"]
+        CKP["Checkpoint Store"]
+        THS["Thread Store"]
+    end
 ```
 
-## Request flow
+Platform-compatible routes are registered when `platform_compat=True`, enabling the official `langgraph-sdk` Python client to communicate with Azure Functions–hosted graphs.
+
+## Design Objectives
+
+- **Thin adapter, not a framework** — wrap LangGraph, don't replace it. All graph logic stays in LangGraph.
+- **Zero boilerplate** — `register()` + `function_app` is the entire API surface.
+- **LangGraph conventions first** — input/output contracts follow LangGraph's patterns (messages, config, stream_mode).
+- **Azure Functions native** — use the v2 programming model directly, no intermediate web framework.
+- **Checkpointer agnostic** — users bring their own checkpointer; config is passed through.
+
+## High-Level Flow
 
 ### Invoke
 
@@ -25,17 +55,19 @@ flowchart LR
 sequenceDiagram
     participant Client
     participant AzureFunctions
-    participant LangGraphApp
+    participant Handlers as _handlers.py
+    participant Validation as _validation.py
     participant Graph
 
     Client->>AzureFunctions: POST /api/graphs/agent/invoke
-    AzureFunctions->>LangGraphApp: _handle_invoke(req, reg)
-    LangGraphApp->>LangGraphApp: Parse JSON body
-    LangGraphApp->>LangGraphApp: Validate with InvokeRequest
-    LangGraphApp->>Graph: graph.invoke(input, config=config)
-    Graph-->>LangGraphApp: result dict
-    LangGraphApp->>LangGraphApp: Wrap in InvokeResponse
-    LangGraphApp-->>AzureFunctions: HttpResponse (200, JSON)
+    AzureFunctions->>Handlers: handle_invoke(req, reg)
+    Handlers->>Validation: validate_body_size, validate_input_structure
+    Validation-->>Handlers: ok
+    Handlers->>Handlers: Parse JSON body → InvokeRequest
+    Handlers->>Graph: graph.invoke(input, config=config)
+    Graph-->>Handlers: result dict
+    Handlers->>Handlers: Wrap in InvokeResponse
+    Handlers-->>AzureFunctions: HttpResponse (200, JSON)
     AzureFunctions-->>Client: JSON response
 ```
 
@@ -45,103 +77,240 @@ sequenceDiagram
 sequenceDiagram
     participant Client
     participant AzureFunctions
-    participant LangGraphApp
+    participant Handlers as _handlers.py
     participant Graph
 
     Client->>AzureFunctions: POST /api/graphs/agent/stream
-    AzureFunctions->>LangGraphApp: _handle_stream(req, reg)
-    LangGraphApp->>LangGraphApp: Parse JSON body
-    LangGraphApp->>LangGraphApp: Validate with StreamRequest
-    LangGraphApp->>Graph: graph.stream(input, config, stream_mode)
+    AzureFunctions->>Handlers: handle_stream(req, reg)
+    Handlers->>Handlers: validate_body_size, validate_input_structure
+    Handlers->>Handlers: Parse JSON body → StreamRequest
     loop Collect chunks
-        Graph-->>LangGraphApp: event dict
-        LangGraphApp->>LangGraphApp: Serialize to SSE format
+        Graph-->>Handlers: event dict
+        Handlers->>Handlers: Serialize to SSE format
     end
-    LangGraphApp->>LangGraphApp: Append "event: end"
-    LangGraphApp-->>AzureFunctions: HttpResponse (200, text/event-stream)
+    Handlers->>Handlers: Append "event: end"
+    Handlers-->>AzureFunctions: HttpResponse (200, text/event-stream)
     AzureFunctions-->>Client: Buffered SSE response
 ```
 
-## Module structure
+### Platform: Thread Run (SDK-compatible)
 
+```mermaid
+sequenceDiagram
+    participant SDK as langgraph-sdk Client
+    participant AzureFunctions
+    participant Routes as platform/routes.py
+    participant Store as ThreadStore
+    participant Graph
+
+    SDK->>AzureFunctions: POST /api/threads/{id}/runs/wait
+    AzureFunctions->>Routes: runs_wait(req)
+    Routes->>Routes: Validate thread_id, body, assistant_id
+    Routes->>Store: get thread by ID
+    Store-->>Routes: Thread record
+    Routes->>Routes: Optional assistant bind (first run on thread)
+    Routes->>Store: update thread status → busy
+    Routes->>Graph: graph.invoke(input, config)
+    Graph-->>Routes: result dict
+    Routes->>Store: update thread status → idle (or error on failure)
+    Routes-->>AzureFunctions: HttpResponse (200, JSON Run)
+    AzureFunctions-->>SDK: JSON response
 ```
-src/azure_functions_langgraph/
-├── __init__.py       # Package init, lazy LangGraphApp import, __version__
-├── app.py            # LangGraphApp class, route registration, request handlers
-├── contracts.py      # Pydantic request/response models
-├── protocols.py      # Protocol interfaces (InvocableGraph, StreamableGraph, StatefulGraph, LangGraphLike)
-└── py.typed          # PEP 561 marker for typed package
+
+## Module Boundaries (key import edges)
+
+```mermaid
+flowchart TD
+    INIT["__init__.py\nLazy re-exports + __version__"]
+    APP["app.py\nLangGraphApp + route wiring"]
+    HDL["_handlers.py\nNative route handlers"]
+    VAL["_validation.py\nTransport-agnostic validators"]
+    CON["contracts.py\nPydantic request/response models"]
+    PRO["protocols.py\nProtocol interfaces"]
+
+    subgraph platform ["platform/"]
+        PRTE["routes.py\nSDK-compatible handlers"]
+        PCON["contracts.py\nPlatform API models"]
+        PSTR["stores.py\nThreadStore protocol + InMemoryThreadStore"]
+        PSSE["_sse.py\nSSE event formatting"]
+    end
+
+    subgraph checkpointers ["checkpointers/"]
+        ABLOB["azure_blob.py\nAzureBlobCheckpointSaver"]
+    end
+
+    subgraph stores ["stores/"]
+        ATABLE["azure_table.py\nAzureTableThreadStore"]
+    end
+
+    INIT -.-> APP
+    INIT -.-> CON
+    INIT -.-> PRO
+    APP --> HDL
+    APP --> VAL
+    APP --> CON
+    APP --> PRO
+    APP --> PRTE
+    APP --> PSTR
+    HDL --> VAL
+    HDL --> CON
+    HDL --> PRO
+    PRTE --> PCON
+    PRTE --> PSTR
+    PRTE --> PSSE
+    PRTE --> VAL
+    PRTE --> PRO
+    ATABLE --> PCON
+    ATABLE --> PSTR
+    PSTR --> PCON
 ```
 
 ### `app.py`
 
 The core module. Contains:
 
-- `LangGraphApp` — main class, a dataclass that holds graph registrations and builds an `azure.functions.FunctionApp`
-- `_GraphRegistration` — internal record for a registered graph
-- `_handle_invoke()` — parses request, calls `graph.invoke()`, returns JSON
-- `_handle_stream()` — parses request, calls `graph.stream()`, collects chunks into buffered SSE
-- `_handle_state()` — retrieves thread state via `graph.get_state()` for StatefulGraph instances
-- `_build_openapi()` — generates OpenAPI 3.0 spec from registered graphs
-- `_handle_stream()` — parses request, calls `graph.stream()`, collects chunks into buffered SSE
-- `_error_response()` — consistent error response builder
+- `LangGraphApp` — main class (dataclass) that holds graph registrations and builds an `azure.functions.FunctionApp`.
+- `_GraphRegistration` — internal record for a registered graph.
+- Route wiring — delegates to `_handlers.py` for native routes and `platform/routes.py` for SDK-compatible routes.
+- `_build_openapi()` — generates OpenAPI 3.0 spec from registered graphs.
+- `_error_response()` — consistent error response builder.
+
+### `_handlers.py`
+
+Standalone request handlers extracted from `LangGraphApp`:
+
+- `handle_invoke()` — parses request, validates, calls `graph.invoke()`, returns JSON.
+- `handle_stream()` — parses request, validates, calls `graph.stream()`, collects chunks into buffered SSE.
+- `handle_state()` — retrieves thread state via `graph.get_state()` for `StatefulGraph` instances.
+
+### `_validation.py`
+
+Transport-agnostic input validators (pure functions returning error message or `None`):
+
+- `validate_graph_name()`, `validate_body_size()`, `validate_input_structure()`, `validate_thread_id()`.
+- Shared by both native handlers and platform routes.
 
 ### `contracts.py`
 
 Pydantic v2 models for request/response validation:
 
-- `InvokeRequest` — input, config, metadata
-- `StreamRequest` — input, config, stream_mode, metadata
-- `InvokeResponse` — output dict
-- `HealthResponse` — status + list of GraphInfo
-- `ErrorResponse` — error + detail
-- `GraphInfo` — name, description, has_checkpointer
-- `StateResponse` — thread state values, next steps, metadata, config, timestamps
-- `GraphInfo` — name, description, has_checkpointer
+- `InvokeRequest`, `InvokeResponse`, `StreamRequest` — graph operation models.
+- `HealthResponse`, `GraphInfo` — health endpoint models.
+- `ErrorResponse` — consistent error format.
+- `StateResponse` — thread state values, next steps, metadata, config, timestamps.
 
 ### `protocols.py`
 
 `typing.Protocol` interfaces with `@runtime_checkable`:
 
-- `InvocableGraph` — has `invoke(input, config)`
-- `StreamableGraph` — has `stream(input, config, stream_mode)`
-- `LangGraphLike` — combines both (matches `CompiledStateGraph`)
-- `StatefulGraph` — has `get_state(config)` for thread state inspection
-- `StreamableGraph` — has `stream(input, config, stream_mode)`
-- `LangGraphLike` — combines both (matches `CompiledStateGraph`)
+- `InvocableGraph` — has `invoke(input, config)`.
+- `StreamableGraph` — has `stream(input, config, stream_mode)`.
+- `LangGraphLike` — combines both (matches `CompiledStateGraph`).
+- `StatefulGraph` — has `get_state(config)`.
+- `UpdatableStateGraph` — has `update_state(config, values)`.
+- `StateHistoryGraph` — has `get_state_history(config)`.
 
 Using protocols avoids a hard import dependency on `langgraph` at the library level. Any object with the right methods works.
 
-## Design decisions
+### `platform/`
 
-### Accept compiled graphs only
+LangGraph Platform API compatibility layer (v0.3+):
 
-Users must call `.compile()` before registering. This ensures:
+- `routes.py` — SDK-compatible HTTP route handlers for threads, runs, assistants, state operations.
+- `contracts.py` — Platform API Pydantic models (Thread, Run, Assistant, Interrupt, etc.).
+- `stores.py` — `ThreadStore` protocol + `InMemoryThreadStore` default implementation.
+- `_sse.py` — SSE event formatting for platform streaming endpoints.
 
-- Checkpointer is configured before registration
-- Graph validation happens at user code level
-- The library does not need to know about compilation options
+### `checkpointers/`
+
+Persistent checkpoint storage (v0.4+):
+
+- `azure_blob.py` — `AzureBlobCheckpointSaver` (optional extra: `azure-functions-langgraph[azure-blob]`). Stores checkpoints as blob hierarchies: `{thread_id}/{checkpoint_ns}/{checkpoint_id}/checkpoint.bin`.
+
+### `stores/`
+
+Persistent thread storage (v0.4+):
+
+- `azure_table.py` — `AzureTableThreadStore` (optional extra: `azure-functions-langgraph[azure-table]`). Single-partition design with client-side filtering.
+
+## Public API Boundary
+
+Exported symbols (via `__all__`, all lazy-loaded via `__getattr__`):
+
+- `LangGraphApp` — main class for graph registration and route creation
+- `__version__` — package version string
+- `InvokeRequest`, `InvokeResponse`, `StreamRequest` — request/response contracts
+- `HealthResponse`, `GraphInfo`, `ErrorResponse`, `StateResponse` — endpoint models
+- `InvocableGraph`, `StreamableGraph`, `LangGraphLike`, `StatefulGraph` — protocol interfaces
+
+Lazy imports via `__getattr__` are a deliberate design choice: importing the package does not require `azure-functions` or `langgraph` to be installed, enabling use in environments where only contracts or protocols are needed.
+
+Everything else (handlers, validators, platform internals, storage implementations) is implementation detail.
+
+## Key Design Decisions
+
+### Compiled graphs as intended input
+
+Users typically call `.compile()` before registering. Registration enforces only the `InvocableGraph` protocol (requiring `invoke()`), so any object satisfying the protocol works — but compiled graphs are the primary expected input because they carry configured checkpointers and validated graph structure.
 
 ### Protocol-based graph acceptance
 
-Rather than importing `CompiledStateGraph` from `langgraph`, the library uses `typing.Protocol`. This means:
+Rather than importing `CompiledStateGraph` from `langgraph`, the library uses `typing.Protocol`. This means no hard dependency on `langgraph` at import time, any object with `invoke()` and `stream()` works, and testing with mock graphs is straightforward.
 
-- No hard dependency on `langgraph` at import time
-- Any object with `invoke()` and `stream()` works
-- Easy to test with mock graphs
+### Protocol-based capability detection (v0.4)
+
+`UpdatableStateGraph` and `StateHistoryGraph` protocols enable graceful degradation — graphs without these capabilities return 409 instead of failing. Route handlers use `isinstance()` checks with `@runtime_checkable`.
 
 ### Buffered SSE (v0.1)
 
-Azure Functions Python worker does not support true chunked HTTP streaming. In v0.1, all stream events are collected into memory and returned as a single SSE-formatted response. This is functional for development but not suitable for long-running streams in production.
+Azure Functions Python worker does not support true chunked HTTP streaming. All stream events are collected into memory and returned as a single SSE-formatted response. Functional for development but not suitable for long-running streams in production.
 
-### Thread ID in request body
+### Platform compatibility layer (v0.3)
 
-Following LangGraph conventions, `thread_id` is passed in `config.configurable.thread_id`, not as a URL path parameter. This keeps the API surface minimal and matches LangGraph's native client expectations.
+When `platform_compat=True`, the library registers routes that mirror the LangGraph Platform REST API, enabling the official `langgraph-sdk` Python client to work with Azure Functions–hosted graphs. This adds thread lifecycle management, SDK-compatible run endpoints, assistant listing, and state operations.
+
+### Azure Blob Storage checkpointer (v0.4)
+
+`AzureBlobCheckpointSaver` provides durable checkpoint persistence across Azure Functions instances. Installed as optional extra (`[azure-blob]`). Synchronous I/O, single-writer assumed.
+
+### Azure Table Storage thread store (v0.4)
+
+`AzureTableThreadStore` provides persistent thread metadata across restarts. Installed as optional extra (`[azure-table]`). Single-partition design works well for <100K threads.
+
+### Threadless runs (v0.4)
+
+`POST /runs/wait` and `POST /runs/stream` clone the graph with `checkpointer=None` for truly ephemeral executions. Client-supplied `thread_id` is stripped to prevent state pollution.
 
 ### Per-graph auth override (v0.2)
 
-Each graph registration can override the app-level `auth_level`. This allows mixed-auth deployments (e.g., public-facing graphs with `ANONYMOUS` auth and admin graphs with `FUNCTION` keys).
+Each graph registration can override the app-level `auth_level`, enabling mixed-auth deployments.
 
-### State endpoint via StatefulGraph (v0.2)
+### Thread ID in request body (native routes)
 
-Graphs compiled with a checkpointer implement the `StatefulGraph` protocol (`get_state(config)`). These graphs automatically get a state inspection endpoint. The protocol check uses `isinstance()` with `@runtime_checkable`, consistent with the existing protocol pattern.
+For native routes, `thread_id` is passed in `config.configurable.thread_id`, not as a URL path parameter. This keeps the native API surface minimal and matches LangGraph's client expectations. Platform-compatible routes (`/threads/{thread_id}/...`) do use path parameters to match the LangGraph Platform REST API.
+
+## Related Documents
+
+- [Usage Guide](usage.md)
+- [Configuration](configuration.md)
+- [API Reference](api.md)
+- [Getting Started](getting-started.md)
+- [Testing](testing.md)
+- [Troubleshooting](troubleshooting.md)
+
+## Sources
+
+- [Azure Functions Python developer reference](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-python)
+- [Azure Functions HTTP trigger](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-http-webhook-trigger)
+- [Supported languages in Azure Functions](https://learn.microsoft.com/en-us/azure/azure-functions/supported-languages)
+- [Azure Blob Storage documentation](https://learn.microsoft.com/en-us/azure/storage/blobs/)
+- [Azure Table Storage documentation](https://learn.microsoft.com/en-us/azure/storage/tables/)
+- [LangGraph documentation](https://langchain-ai.github.io/langgraph/)
+
+## See Also
+
+- [azure-functions-validation — Architecture](https://github.com/yeongseon/azure-functions-validation) — Request/response validation pipeline
+- [azure-functions-openapi — Architecture](https://github.com/yeongseon/azure-functions-openapi) — OpenAPI spec generation
+- [azure-functions-logging — Architecture](https://github.com/yeongseon/azure-functions-logging) — Structured logging with contextvars
+- [azure-functions-doctor — Architecture](https://github.com/yeongseon/azure-functions-doctor) — Pre-deploy diagnostic CLI
+- [azure-functions-scaffold — Architecture](https://github.com/yeongseon/azure-functions-scaffold) — Project scaffolding CLI


### PR DESCRIPTION
## Summary

- Rewrites `DESIGN.md` and `docs/architecture.md` to match the cross-repo architecture documentation template
- Adds Mermaid flowcharts for route families and module boundaries (with import dependency edges verified from source)
- Adds 3 sequence diagrams: native invoke, native stream (buffered SSE), platform thread run (SDK-compatible)
- Adds Public API Boundary section documenting `__all__` exports and lazy `__getattr__` import design
- Documents 10 Key Design Decisions from v0.1–v0.4
- Adds MS Learn references in Sources section and cross-repo links in See Also section
- Fixes duplicated entries (GraphInfo, StreamableGraph, LangGraphLike) from the old docs
- Oracle design review and post-impl review applied (7 accuracy fixes including correct function names, dependency edges, and scoped design decision language)

## Verification

- 645 tests passed, 91.40% coverage
- Lint clean (`make lint`)
- All Mermaid diagrams verified against source code import graph

Closes #72