### PR TITLE
docs: fix architecture doc inaccuracies from Oracle post-merge review

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -44,11 +44,8 @@ flowchart TB
 
 ## Key Decisions
 
-### 1. Accept `CompiledStateGraph` only (not `StateGraph`)
-Users must call `.compile()` themselves. This ensures:
-- Checkpointer is configured before registration
-- Graph validation happens at user code level
-- We don't need to know about graph compilation options
+### 1. Compiled graphs as intended input
+Registration enforces only the `InvocableGraph` protocol (requiring `invoke()`), so any object satisfying the protocol works. In practice, users call `.compile()` before registering because compiled graphs carry configured checkpointers and validated graph structure. The library does not import or check for `CompiledStateGraph` directly.
 
 ### 2. SSE streaming as buffered response (v0.1)
 Azure Functions doesn't natively support true SSE streaming (no chunked transfer encoding in the Python worker). In v0.1, we buffer all stream events and return them as a single SSE-formatted response. This is functional but not truly streaming.
@@ -91,7 +88,7 @@ Graphs that implement `get_state(config)` (i.e., graphs compiled with a checkpoi
 
 **Context**: The LangGraph SDK supports `runs.wait(None, ...)` and `runs.stream(None, ...)` for fire-and-forget executions that don't need a persistent thread.
 
-**Decision**: Add `POST /runs/wait` and `POST /runs/stream` endpoints. These clone the registered graph with `checkpointer=None`, producing a stateless execution. Client-supplied `thread_id` in config is stripped to prevent accidental state pollution.
+**Decision**: Add `POST /runs/wait` and `POST /runs/stream` endpoints. These clone the registered graph with `checkpointer=None`, producing a stateless execution. Client-supplied `thread_id` in config is rejected with 422 to prevent semantic confusion.
 
 **Consequences**: SDK clients can run graphs without pre-creating threads. No checkpoint is saved, so the execution is truly ephemeral. The thread store is not modified by threadless runs.
 
@@ -111,7 +108,7 @@ Graphs that implement `get_state(config)` (i.e., graphs compiled with a checkpoi
 src/azure_functions_langgraph/
 ├── __init__.py              # Package init, lazy imports, __version__
 ├── app.py                   # LangGraphApp class, route registration
-├── _handlers.py             # Native route handlers (invoke, stream, state, health)
+├── _handlers.py             # Native route handlers (invoke, stream, state)
 ├── _validation.py           # Transport-agnostic request validators
 ├── contracts.py             # Pydantic request/response models
 ├── protocols.py             # Protocol interfaces (LangGraphLike, StatefulGraph, etc.)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -113,7 +113,7 @@ sequenceDiagram
     Routes->>Graph: graph.invoke(input, config)
     Graph-->>Routes: result dict
     Routes->>Store: update thread status → idle (or error on failure)
-    Routes-->>AzureFunctions: HttpResponse (200, JSON Run)
+    Routes-->>AzureFunctions: HttpResponse (200, final values JSON + Content-Location header)
     AzureFunctions-->>SDK: JSON response
 ```
 
@@ -173,7 +173,7 @@ The core module. Contains:
 - `_GraphRegistration` — internal record for a registered graph.
 - Route wiring — delegates to `_handlers.py` for native routes and `platform/routes.py` for SDK-compatible routes.
 - `_build_openapi()` — generates OpenAPI 3.0 spec from registered graphs.
-- `_error_response()` — consistent error response builder.
+- `health()` — health check handler returning registered graph list.
 
 ### `_handlers.py`
 
@@ -182,6 +182,7 @@ Standalone request handlers extracted from `LangGraphApp`:
 - `handle_invoke()` — parses request, validates, calls `graph.invoke()`, returns JSON.
 - `handle_stream()` — parses request, validates, calls `graph.stream()`, collects chunks into buffered SSE.
 - `handle_state()` — retrieves thread state via `graph.get_state()` for `StatefulGraph` instances.
+- `_error_response()` — consistent error response builder for native routes.
 
 ### `_validation.py`
 
@@ -279,7 +280,7 @@ When `platform_compat=True`, the library registers routes that mirror the LangGr
 
 ### Threadless runs (v0.4)
 
-`POST /runs/wait` and `POST /runs/stream` clone the graph with `checkpointer=None` for truly ephemeral executions. Client-supplied `thread_id` is stripped to prevent state pollution.
+`POST /runs/wait` and `POST /runs/stream` clone the graph with `checkpointer=None` for truly ephemeral executions. Client-supplied `thread_id` in config is rejected with 422 to prevent semantic confusion.
 
 ### Per-graph auth override (v0.2)
 


### PR DESCRIPTION
## Summary

Follow-up to PR #74 (issue #72). Oracle post-merge review identified 5 factual inaccuracies:

- **DESIGN.md**: `register()` enforces `InvocableGraph` protocol, not `CompiledStateGraph` directly — softened heading and description
- **DESIGN.md + architecture.md**: Threadless routes reject `thread_id` with 422, not strip it silently
- **DESIGN.md**: Health handler lives in `app.py`, not `_handlers.py` — fixed module tree comment
- **architecture.md**: `_error_response()` is in `_handlers.py`, not `app.py` — moved to correct module description
- **architecture.md**: `runs_wait` returns final values JSON + `Content-Location` header, not a "JSON Run" object

## Verification

- 645 tests passed, 91.40% coverage
- Lint clean (`make lint`)
- All changes are doc-only, no code changes

Follow-up to #72 / PR #74