### PR TITLE
fix: switch Mermaid fence format to fence_div_format for rendering

### DIFF
--- a/docs/javascripts/mermaid-init.js
+++ b/docs/javascripts/mermaid-init.js
@@ -1,0 +1,15 @@
+(function () {
+  if (typeof mermaid === "undefined") return;
+
+  mermaid.initialize({ startOnLoad: false });
+
+  var renderMermaid = function () {
+    mermaid.run({ querySelector: ".mermaid" });
+  };
+
+  if (typeof document$ !== "undefined") {
+    document$.subscribe(renderMermaid);
+  } else {
+    document.addEventListener("DOMContentLoaded", renderMermaid);
+  }
+})();

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -43,7 +43,7 @@ markdown_extensions:
       custom_fences:
         - name: mermaid
           class: mermaid
-          format: !!python/name:pymdownx.superfences.fence_code_format
+          format: !!python/name:pymdownx.superfences.fence_div_format
   - pymdownx.highlight:
       anchor_linenums: true
   - pymdownx.tabbed:
@@ -73,3 +73,4 @@ extra:
 
 extra_javascript:
   - https://unpkg.com/mermaid@11.14.0/dist/mermaid.min.js
+  - javascripts/mermaid-init.js


### PR DESCRIPTION
## Summary

- Switch `pymdownx.superfences.fence_code_format` → `fence_div_format` in mkdocs.yml
- Add `docs/javascripts/mermaid-init.js` for robust Mermaid initialization

## Problem

Mermaid diagrams on the architecture page render as empty containers. `fence_code_format` produces `<pre class="mermaid"><code>...</code></pre>` which Mermaid v11 cannot parse — it silently replaces elements with empty `<div>` tags.

## Fix

`fence_div_format` produces `<div class="mermaid">diagram text</div>` which Mermaid auto-init handles correctly. The init script ensures diagrams re-render on MkDocs Material page navigations.

## Verification

- `make test && make lint` passes (645 tests, 91.40% coverage)
- Local `mkdocs build --strict` produces correct `<div class="mermaid">` HTML output

Closes #80