### PR TITLE
fix: suppress bandit B311 false positive for non-security random usage

### DIFF
--- a/src/azure_functions_langgraph/checkpointers/azure_blob.py
+++ b/src/azure_functions_langgraph/checkpointers/azure_blob.py
@@ -115,7 +115,7 @@ class AzureBlobCheckpointSaver(BaseCheckpointSaver[str]):
         else:
             current_v = int(current.split(".")[0])
         next_v = current_v + 1
-        next_h = random.random()  # nosec B311 — ordering/uniqueness only, not security
+        next_h = random.random()  # nosec B311 - non-crypto ordering/uniqueness only
         return f"{next_v:032}.{next_h:016}"
 
     def get_tuple(self, config: RunnableConfig) -> CheckpointTuple | None:


### PR DESCRIPTION
## Summary

- Add `# nosec B311` inline suppression for `random.random()` in checkpoint version string generation
- This is used for ordering/uniqueness only, not for security/cryptographic purposes
- `make check-all` now passes cleanly (0 bandit issues, 1 specifically disabled)

Closes #82