### PR TITLE
feat: add CloneableGraph protocol and refactor _get_threadless_graph

### DIFF
--- a/src/azure_functions_langgraph/__init__.py
+++ b/src/azure_functions_langgraph/__init__.py
@@ -21,6 +21,7 @@ if TYPE_CHECKING:
         StreamRequest,
     )
     from azure_functions_langgraph.protocols import (
+        CloneableGraph,
         InvocableGraph,
         LangGraphLike,
         StatefulGraph,
@@ -98,6 +99,10 @@ def __getattr__(name: str) -> object:
         from azure_functions_langgraph.protocols import StatefulGraph
 
         return StatefulGraph
+    if name == "CloneableGraph":
+        from azure_functions_langgraph.protocols import CloneableGraph
+
+        return CloneableGraph
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
@@ -117,6 +122,7 @@ __all__ = [
     "RegisteredGraphMetadata",
     "RouteMetadata",
     # Protocols
+    "CloneableGraph",
     "InvocableGraph",
     "StreamableGraph",
     "LangGraphLike",

--- a/src/azure_functions_langgraph/platform/routes.py
+++ b/src/azure_functions_langgraph/platform/routes.py
@@ -64,6 +64,7 @@ from azure_functions_langgraph.platform.contracts import (
 )
 from azure_functions_langgraph.platform.stores import ThreadStore
 from azure_functions_langgraph.protocols import (
+    CloneableGraph,
     StatefulGraph,
     StateHistoryGraph,
     StreamableGraph,
@@ -131,21 +132,22 @@ def _get_threadless_graph(graph: Any) -> Any | None:
     so that threadless runs never persist orphaned state.  If the graph has
     no checkpointer, return it as-is.
 
-    If the graph has a checkpointer but no ``copy`` method, or ``copy()``
-    raises, return ``None`` — threadless runs are not safe for this graph.
+    The graph must satisfy the :class:`CloneableGraph` protocol (i.e. have a
+    ``copy(*, update)`` method).  If it does not, or ``copy()`` raises, return
+    ``None`` — threadless runs are not safe for this graph.
     """
     checkpointer = getattr(graph, "checkpointer", None)
     if checkpointer is None:
         return graph  # No checkpointer — safe as-is
     # Has checkpointer — try to disable it
-    copy_fn = getattr(graph, "copy", None)
-    if copy_fn is None:
+    if not isinstance(graph, CloneableGraph):
         logger.warning(
-            "Graph has checkpointer but no copy() method; threadless runs unavailable"
+            "Graph has checkpointer but does not satisfy CloneableGraph protocol; "
+            "threadless runs unavailable"
         )
-        return None  # Cannot disable checkpointer safely
+        return None
     try:
-        return copy_fn(update={"checkpointer": None})
+        return graph.copy(update={"checkpointer": None})
     except Exception:
         logger.warning(
             "Failed to clone graph with checkpointer disabled",

--- a/src/azure_functions_langgraph/protocols.py
+++ b/src/azure_functions_langgraph/protocols.py
@@ -56,6 +56,17 @@ class StateHistoryGraph(Protocol):
 
 
 @runtime_checkable
+class CloneableGraph(Protocol):
+    """Protocol for a graph that supports cloning with updated configuration.
+
+    Used by threadless runs to create a checkpoint-disabled copy of the graph.
+    Matches LangGraph's ``CompiledStateGraph.copy(update=...)`` interface.
+    """
+
+    def copy(self, *, update: dict[str, Any] | None = ...) -> Any: ...
+
+
+@runtime_checkable
 class LangGraphLike(InvocableGraph, StreamableGraph, Protocol):
     """Protocol combining invoke and stream — matches LangGraph's CompiledStateGraph."""
 

--- a/tests/test_protocols.py
+++ b/tests/test_protocols.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 from azure_functions_langgraph.protocols import (
+    CloneableGraph,
     InvocableGraph,
     LangGraphLike,
     StatefulGraph,
@@ -44,3 +47,18 @@ class TestProtocols:
     def test_fake_graph_not_stateful(self) -> None:
         graph = FakeCompiledGraph()
         assert not isinstance(graph, StatefulGraph)
+
+    def test_copyable_graph_satisfies_cloneable(self) -> None:
+        class _Copyable:
+            def copy(self, *, update: dict[str, Any] | None = None) -> "_Copyable":
+                return _Copyable()
+
+        assert isinstance(_Copyable(), CloneableGraph)
+
+    def test_plain_object_not_cloneable(self) -> None:
+        assert not isinstance(object(), CloneableGraph)
+
+    def test_fake_compiled_graph_not_cloneable(self) -> None:
+        """FakeCompiledGraph has no copy() method — should NOT satisfy CloneableGraph."""
+        graph = FakeCompiledGraph()
+        assert not isinstance(graph, CloneableGraph)

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -37,6 +37,7 @@ def test_all_exports() -> None:
     assert "StreamableGraph" in azure_functions_langgraph.__all__
     assert "LangGraphLike" in azure_functions_langgraph.__all__
     assert "StatefulGraph" in azure_functions_langgraph.__all__
+    assert "CloneableGraph" in azure_functions_langgraph.__all__
 
 
 def test_contracts_importable() -> None:
@@ -79,6 +80,7 @@ def test_all_contracts_importable() -> None:
 
 def test_all_protocols_importable() -> None:
     from azure_functions_langgraph import (
+        CloneableGraph,
         InvocableGraph,
         LangGraphLike,
         StatefulGraph,
@@ -89,6 +91,7 @@ def test_all_protocols_importable() -> None:
     assert StreamableGraph is not None
     assert LangGraphLike is not None
     assert StatefulGraph is not None
+    assert CloneableGraph is not None
 
 
 def test_invalid_attr_raises() -> None:


### PR DESCRIPTION
## Summary
- Adds `CloneableGraph` runtime-checkable protocol to formalize the `copy(*, update)` interface used by threadless runs
- Refactors `_get_threadless_graph()` to use `isinstance(graph, CloneableGraph)` instead of duck-typed `getattr(graph, "copy", None)` check
- Exports `CloneableGraph` from package `__init__.py` (TYPE_CHECKING, lazy `__getattr__`, `__all__`)
- Adds 3 protocol tests and public API export assertions

## Motivation
Oracle design review items #95 and #96 recommended formalizing the implicit `copy(update=...)` dependency into the protocol system for consistency with the existing protocol-based architecture (InvocableGraph, StreamableGraph, StatefulGraph, etc.).

## Design decisions
- **Standalone protocol**: `CloneableGraph` is NOT composed into `LangGraphLike` — cloneability is an optional capability for threadless checkpoint handling, not a core graph trait
- **Return type `Any`**: Kept instead of `Self` to avoid `typing_extensions` dependency for Python 3.10 support
- **`isinstance` check**: Provides readability and API-contract improvement; real safety still comes from the guarded `try/except` around `graph.copy(update=...)`

## Verification
- `make check-all` passes: lint ✅, typecheck ✅, 695 tests ✅, bandit ✅, 91.79% coverage ✅
- Oracle review: approved ✅

Closes #95, closes #96