### PR TITLE
feat: add CloneableGraph protocol and refactor _get_threadless_graph (#95, #96)

### DIFF
--- a/src/azure_functions_langgraph/__init__.py
+++ b/src/azure_functions_langgraph/__init__.py
@@ -21,6 +21,7 @@ if TYPE_CHECKING:
         StreamRequest,
     )
     from azure_functions_langgraph.protocols import (
+        CloneableGraph,
         InvocableGraph,
         LangGraphLike,
         StatefulGraph,
@@ -98,6 +99,10 @@ def __getattr__(name: str) -> object:
         from azure_functions_langgraph.protocols import StatefulGraph
 
         return StatefulGraph
+    if name == "CloneableGraph":
+        from azure_functions_langgraph.protocols import CloneableGraph
+
+        return CloneableGraph
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
@@ -121,4 +126,5 @@ __all__ = [
     "StreamableGraph",
     "LangGraphLike",
     "StatefulGraph",
+    "CloneableGraph",
 ]

--- a/src/azure_functions_langgraph/platform/_common.py
+++ b/src/azure_functions_langgraph/platform/_common.py
@@ -14,6 +14,7 @@ from azure_functions_langgraph.platform.contracts import (
     ThreadState,
 )
 from azure_functions_langgraph.platform.stores import ThreadStore
+from azure_functions_langgraph.protocols import CloneableGraph
 
 logger = logging.getLogger(__name__)
 
@@ -67,21 +68,22 @@ def _get_threadless_graph(graph: Any) -> Any | None:
     so that threadless runs never persist orphaned state.  If the graph has
     no checkpointer, return it as-is.
 
-    If the graph has a checkpointer but no ``copy`` method, or ``copy()``
-    raises, return ``None`` - threadless runs are not safe for this graph.
+    The graph must satisfy the :class:`CloneableGraph` protocol (i.e. have a
+    ``copy(*, update)`` method).  If it does not, or ``copy()`` raises, return
+    ``None`` — threadless runs are not safe for this graph.
     """
     checkpointer = getattr(graph, "checkpointer", None)
     if checkpointer is None:
         return graph  # No checkpointer - safe as-is
     # Has checkpointer - try to disable it
-    copy_fn = getattr(graph, "copy", None)
-    if copy_fn is None:
+    if not isinstance(graph, CloneableGraph):
         logger.warning(
-            "Graph has checkpointer but no copy() method; threadless runs unavailable"
+            "Graph has checkpointer but does not satisfy CloneableGraph protocol; "
+            "threadless runs unavailable"
         )
-        return None  # Cannot disable checkpointer safely
+        return None
     try:
-        return copy_fn(update={"checkpointer": None})
+        return graph.copy(update={"checkpointer": None})
     except Exception:
         logger.warning(
             "Failed to clone graph with checkpointer disabled",

--- a/src/azure_functions_langgraph/protocols.py
+++ b/src/azure_functions_langgraph/protocols.py
@@ -54,6 +54,16 @@ class StateHistoryGraph(Protocol):
 
     def get_state_history(self, config: dict[str, Any]) -> Any: ...
 
+@runtime_checkable
+class CloneableGraph(Protocol):
+    """Protocol for a graph that supports cloning with updated configuration.
+
+    Used by threadless runs to create a checkpoint-disabled copy of the graph.
+    Matches LangGraph's ``CompiledStateGraph.copy(update=...)`` interface.
+    """
+
+    def copy(self, *, update: dict[str, Any] | None = ...) -> Any: ...
+
 
 @runtime_checkable
 class LangGraphLike(InvocableGraph, StreamableGraph, Protocol):

--- a/tests/test_protocols.py
+++ b/tests/test_protocols.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 from azure_functions_langgraph.protocols import (
+    CloneableGraph,
     InvocableGraph,
     LangGraphLike,
     StatefulGraph,
@@ -44,3 +47,18 @@ class TestProtocols:
     def test_fake_graph_not_stateful(self) -> None:
         graph = FakeCompiledGraph()
         assert not isinstance(graph, StatefulGraph)
+
+    def test_copyable_graph_satisfies_cloneable(self) -> None:
+        class _Copyable:
+            def copy(self, *, update: dict[str, Any] | None = None) -> "_Copyable":
+                return _Copyable()
+
+        assert isinstance(_Copyable(), CloneableGraph)
+
+    def test_plain_object_not_cloneable(self) -> None:
+        assert not isinstance(object(), CloneableGraph)
+
+    def test_fake_compiled_graph_not_cloneable(self) -> None:
+        """FakeCompiledGraph has no copy() method — should NOT satisfy CloneableGraph."""
+        graph = FakeCompiledGraph()
+        assert not isinstance(graph, CloneableGraph)

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -37,6 +37,7 @@ def test_all_exports() -> None:
     assert "StreamableGraph" in azure_functions_langgraph.__all__
     assert "LangGraphLike" in azure_functions_langgraph.__all__
     assert "StatefulGraph" in azure_functions_langgraph.__all__
+    assert "CloneableGraph" in azure_functions_langgraph.__all__
 
 
 def test_contracts_importable() -> None:
@@ -79,6 +80,7 @@ def test_all_contracts_importable() -> None:
 
 def test_all_protocols_importable() -> None:
     from azure_functions_langgraph import (
+        CloneableGraph,
         InvocableGraph,
         LangGraphLike,
         StatefulGraph,
@@ -89,6 +91,7 @@ def test_all_protocols_importable() -> None:
     assert StreamableGraph is not None
     assert LangGraphLike is not None
     assert StatefulGraph is not None
+    assert CloneableGraph is not None
 
 
 def test_invalid_attr_raises() -> None:


### PR DESCRIPTION
## Summary

Replaces PR #104 which had irreconcilable merge conflicts after #101's route split.

- Adds `CloneableGraph` runtime-checkable protocol to `protocols.py`
- Refactors `_get_threadless_graph()` in `_common.py` to use `isinstance(graph, CloneableGraph)` instead of duck-typed `getattr` pattern
- Exports `CloneableGraph` from package `__init__.py` (TYPE_CHECKING, lazy `__getattr__`, `__all__`)

## Motivation

Issues #95 and #96 identified that `_get_threadless_graph()` used a duck-typed `getattr(graph, "copy", None)` pattern, inconsistent with the project's protocol-based design. This PR:

1. **Defines `CloneableGraph`** — a `Protocol` with `copy(*, update)` matching LangGraph's `CompiledStateGraph.copy()` interface
2. **Enforces protocol compliance** — `isinstance(graph, CloneableGraph)` gives clear, typed validation
3. **Exports publicly** — consumers can type-check their own graph implementations

## Changes

| File | Change |
|------|--------|
| `protocols.py` | Add `@runtime_checkable class CloneableGraph(Protocol)` |
| `platform/_common.py` | Replace `getattr` duck-typing with `isinstance(graph, CloneableGraph)` |
| `__init__.py` | Export `CloneableGraph` (TYPE_CHECKING + lazy import + `__all__`) |
| `tests/test_protocols.py` | 3 new tests: satisfaction, plain-object rejection, FakeCompiledGraph rejection |
| `tests/test_public_api.py` | Assert `CloneableGraph` in `__all__` and importable |

## Validation

- `make check-all` ✅ (708 tests, 91.91% coverage, lint/typecheck/bandit clean)

Closes #95, closes #96
Supersedes #104