### PR TITLE
chore: prepare v0.5.0 release (#118)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,45 @@
 
 All notable changes to this project will be documented in this file.
 
-## [Unreleased]
+## [0.5.0] - 2026-04-07
 
 ### Breaking Changes
 
-- Removed deprecated `GET /api/openapi.json` endpoint and internal `_build_openapi()` method. Use `azure-functions-openapi` with `register_with_openapi()` bridge instead.
+- Removed deprecated `GET /api/openapi.json` endpoint and internal `_build_openapi()` method. Use `azure-functions-openapi` with `register_with_openapi()` bridge instead (#99, PR #113).
+
+### Added
+
+- **Metadata API**: Immutable dataclass-based metadata (`GraphMetadata`, `AppMetadata`) with deep-frozen snapshot semantics (#87)
+- **OpenAPI bridge module**: `azure_functions_langgraph.openapi` integration module for `azure-functions-openapi` ecosystem interop (#87)
+- **`CloneableGraph` protocol**: Explicit protocol for graphs supporting `clone()`, refactored `_get_threadless_graph` for cleaner threadless run support (#95, #96)
+- **SDK compatibility policy**: Formal version compatibility matrix and contract tests for `langgraph-sdk` (#91, PR #102)
+- **Production hardening guide**: Auth, observability, timeouts, concurrency, and storage configuration (#105)
+- **Deployment guide**: Step-by-step Azure deployment with real verified output for all plans (#73, PR #108)
+- **Choose-a-plan guide**: Hosting plan comparison for developers new to Azure Functions
+- **Azure deployment verification**: Real Azure deployment outputs verified and documented (#110, #111)
+- 695+ tests total, 91%+ coverage
+
+### Changed
+
+- **Auth level tightened**: Production warning when `auth_level=ANONYMOUS` in non-local environments (#97)
+- **Platform routes modularized**: Split monolithic `platform/routes.py` into `threads.py`, `runs.py`, `assistants.py` resource modules (#89, PR #101)
+- **Documentation rewrite**: All docs rewritten for general-developer friendliness with step-by-step instructions (#115)
+- Concurrency constraints, scale envelopes, and SSE buffering behavior documented (#90, #92, #93, #98, #100, PR #103)
+
+### Fixed
+
+- Mermaid fence format switched to `fence_div_format` for correct rendering (#81)
+- Bandit B311 false positive suppressed for non-security random usage (#88)
+- MkDocs strict-mode failures: nav entries, anchor slugs, and out-of-docs links (#116, PR #117)
+- Deep immutability enforced on metadata snapshots (Oracle review follow-up)
+
+### Documentation
+
+- README restructured for ecosystem positioning (#84, PR #85)
+- DESIGN.md updated with architecture accuracy fixes and new ADRs (#72, #75, #77)
+- MkDocs Mermaid rendering standardized with pinned JS version (#78, #79)
+- Deployment docs include real Azure CLI output and troubleshooting tables
+- Full i18n updates (ko/en) for OpenAPI removal and deployment guides
 
 ## [0.4.0] - 2026-04-05
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,16 +6,73 @@ This project follows [Conventional Commits](https://www.conventionalcommits.org/
 
 For the full changelog, see [CHANGELOG.md](https://github.com/yeongseon/azure-functions-langgraph/blob/main/CHANGELOG.md) in the repository root.
 
-## 0.1.0a0 (Unreleased)
+## 0.5.0 (2026-04-07)
+
+### Breaking Changes
+
+- Removed deprecated `GET /api/openapi.json` endpoint and internal `_build_openapi()` method. Use `azure-functions-openapi` with `register_with_openapi()` bridge instead.
 
 ### Added
 
-- `LangGraphApp` class for deploying compiled LangGraph graphs as Azure Functions HTTP endpoints
-- `POST /api/graphs/{name}/invoke` endpoint for synchronous graph invocation
-- `POST /api/graphs/{name}/stream` endpoint for buffered SSE streaming
-- `GET /api/health` endpoint listing registered graphs with checkpointer status
-- Protocol-based graph acceptance (`InvocableGraph`, `StreamableGraph`, `LangGraphLike`)
-- Pydantic v2 request/response validation (`InvokeRequest`, `StreamRequest`, `InvokeResponse`, etc.)
-- Support for invoke-only graphs (stream endpoint returns 501)
-- Checkpointer pass-through via LangGraph config
-- Configurable Azure Functions auth level
+- Metadata API with immutable dataclass-based snapshots (`GraphMetadata`, `AppMetadata`)
+- OpenAPI bridge module for `azure-functions-openapi` ecosystem integration
+- `CloneableGraph` protocol for explicit clone support in threadless runs
+- SDK compatibility policy and contract tests
+- Production hardening guide (auth, observability, timeouts, concurrency, storage)
+- Step-by-step deployment guide with real Azure-verified output
+- Choose-a-plan hosting guide for developers new to Azure Functions
+- 695+ tests, 91%+ coverage
+
+### Changed
+
+- Production warning when `auth_level=ANONYMOUS` in non-local environments
+- Platform routes split into `threads.py`, `runs.py`, `assistants.py` resource modules
+- All documentation rewritten for general-developer friendliness
+
+### Fixed
+
+- Mermaid fence format for correct rendering
+- Bandit B311 false positive
+- MkDocs strict-mode nav, anchor, and link failures
+
+## 0.4.0 (2026-04-05)
+
+### Added
+
+- Thread update, delete, search, and count endpoints
+- Assistants count endpoint
+- Threadless runs (stateless execution without thread)
+- Thread state update and history endpoints
+- Azure Blob Storage checkpointer (`AzureBlobCheckpointSaver`)
+- Azure Table Storage thread store (`AzureTableThreadStore`)
+- Persistent storage integration tests
+- 645 tests, 91% coverage
+
+## 0.3.0 (2026-04-05)
+
+### Added
+
+- Platform API compatibility layer (full `langgraph-sdk`-compatible HTTP surface)
+- Thread store protocol and in-memory implementation
+- SSE streaming with platform event sequence
+- Input validation and request size limits
+- SDK compatibility tests
+- 427 tests, 96% coverage
+
+## 0.2.0 (2026-04-05)
+
+### Added
+
+- State endpoint for retrieving thread state
+- Per-graph auth level override
+- Release automation
+- 105 tests, 98%+ coverage
+
+## 0.1.0a0 (2026-04-02)
+
+### Added
+
+- Initial release with `LangGraphApp`, invoke/stream/health endpoints
+- Protocol-based graph registration
+- Pydantic v2 contracts
+- Example simple agent


### PR DESCRIPTION
## Summary

- Complete CHANGELOG.md: expand `[Unreleased]` into `[0.5.0] - 2026-04-07` with all features, changes, and fixes since v0.4.0
- Sync `docs/changelog.md` with root CHANGELOG
- `__version__` already `0.5.0`, `test_public_api.py` already matches

## After merge

1. Tag: `git tag v0.5.0 && git push origin v0.5.0`
2. Tag push triggers `publish-pypi.yml` → first PyPI publish via Trusted Publisher
3. Tag push triggers `release.yml` → GitHub Release with git-cliff notes

Closes #118