### PR TITLE
docs: clarify buffered SSE behavior for all stream endpoints

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -158,6 +158,20 @@ from azure_functions_langgraph import LangGraphApp
 app = LangGraphApp(auth_level=func.AuthLevel.FUNCTION)
 ```
 
+### ストリーミングの挙動
+
+> **重要:** すべての `/stream` エンドポイント（ネイティブ `POST /api/graphs/{name}/stream`、
+> Platform互換の `POST /threads/{id}/runs/stream` および `POST /runs/stream`）は
+> **バッファリングされた SSE** を返します。グラフが emit したチャンクは実行中に
+> 収集され、実行が**完了した後**に SSE イベントとして一括送信されます。これは
+> トークン単位の真のストリーミングではなく、クライアントは部分トークンを逐次的には
+> 受け取れません。
+>
+> 真のチャンクストリーミングはロードマップにあり、Azure Functions Python v2 の
+> streaming response サポートに依存します。リアルタイムなトークンストリーミングが
+> 必要な場合は、長時間稼働するホスト（App Service や AKS など）でグラフを実行する
+> ことを検討してください。
+
 ### グラフごとの認証
 
 アプリレベルの認証設定をグラフごとにオーバーライドできます:
@@ -179,7 +193,7 @@ curl -X POST "https://<app>.azurewebsites.net/api/graphs/echo_agent/invoke?code=
 ### 生成されるエンドポイント
 
 1. `POST /api/graphs/echo_agent/invoke` — エージェントの呼び出し
-2. `POST /api/graphs/echo_agent/stream` — エージェントレスポンスのストリーミング（バッファリングSSE）
+2. `POST /api/graphs/echo_agent/stream` — エージェントレスポンスのストリーミング（バッファリングSSE、真のトークンストリーミングではない）
 3. `GET /api/graphs/echo_agent/threads/{thread_id}/state` — スレッド状態の検査
 4. `GET /api/health` — ヘルスチェック
 
@@ -195,9 +209,9 @@ curl -X POST "https://<app>.azurewebsites.net/api/graphs/echo_agent/invoke?code=
 13. `POST /threads/search` — スレッド検索
 14. `POST /threads/count` — スレッド数
 15. `POST /threads/{id}/runs/wait` — 実行して結果を待機
-16. `POST /threads/{id}/runs/stream` — 実行して結果をストリーミング
+16. `POST /threads/{id}/runs/stream` — 実行して結果をストリーミング（バッファリングSSE）
 17. `POST /runs/wait` — スレッドレス実行
-18. `POST /runs/stream` — スレッドレスストリーミング
+18. `POST /runs/stream` — スレッドレスストリーミング（バッファリングSSE）
 19. `GET /threads/{id}/state` — スレッド状態取得
 20. `POST /threads/{id}/state` — スレッド状態更新
 21. `POST /threads/{id}/history` — ステート履歴

--- a/README.ko.md
+++ b/README.ko.md
@@ -158,6 +158,18 @@ from azure_functions_langgraph import LangGraphApp
 app = LangGraphApp(auth_level=func.AuthLevel.FUNCTION)
 ```
 
+### 스트리밍 동작 방식
+
+> **중요:** 모든 `/stream` 엔드포인트(네이티브 `POST /api/graphs/{name}/stream`,
+> Platform 호환 `POST /threads/{id}/runs/stream`, `POST /runs/stream`)는
+> **버퍼링된 SSE**를 반환합니다. 그래프가 emit하는 청크는 실행 중에 수집되어
+> 실행이 **완료된 후**에 한꺼번에 SSE 이벤트로 전송됩니다. 즉, 진정한 토큰 단위
+> 스트리밍이 아니며, 클라이언트는 부분 토큰을 점진적으로 받지 못합니다.
+>
+> 진정한 청크 스트리밍은 로드맵에 있으며 Azure Functions Python v2의 streaming
+> response 지원에 의존합니다. 실시간 토큰 스트리밍이 필요한 경우, 장시간 실행
+> 호스트(예: App Service 또는 AKS)에서 그래프를 실행하는 것을 권장합니다.
+
 ### 그래프별 인증
 
 앱 수준 인증 설정을 그래프별로 재정의할 수 있습니다:
@@ -179,7 +191,7 @@ curl -X POST "https://<app>.azurewebsites.net/api/graphs/echo_agent/invoke?code=
 ### 생성되는 엔드포인트
 
 1. `POST /api/graphs/echo_agent/invoke` — 에이전트 호출
-2. `POST /api/graphs/echo_agent/stream` — 에이전트 응답 스트리밍 (버퍼링된 SSE)
+2. `POST /api/graphs/echo_agent/stream` — 에이전트 응답 스트리밍 (버퍼링된 SSE, 진정한 토큰 스트리밍 아님)
 3. `GET /api/graphs/echo_agent/threads/{thread_id}/state` — 스레드 상태 조회
 4. `GET /api/health` — 헬스 체크
 
@@ -195,9 +207,9 @@ curl -X POST "https://<app>.azurewebsites.net/api/graphs/echo_agent/invoke?code=
 13. `POST /threads/search` — 스레드 검색
 14. `POST /threads/count` — 스레드 수
 15. `POST /threads/{id}/runs/wait` — 실행 후 결과 대기
-16. `POST /threads/{id}/runs/stream` — 실행 후 결과 스트리밍
+16. `POST /threads/{id}/runs/stream` — 실행 후 결과 스트리밍 (버퍼링된 SSE)
 17. `POST /runs/wait` — 스레드리스 실행
-18. `POST /runs/stream` — 스레드리스 스트리밍
+18. `POST /runs/stream` — 스레드리스 스트리밍 (버퍼링된 SSE)
 19. `GET /threads/{id}/state` — 스레드 상태 조회
 20. `POST /threads/{id}/state` — 스레드 상태 수정
 21. `POST /threads/{id}/history` — 상태 히스토리

--- a/README.md
+++ b/README.md
@@ -195,6 +195,18 @@ from azure_functions_langgraph import LangGraphApp
 app = LangGraphApp(auth_level=func.AuthLevel.FUNCTION)
 ```
 
+### Streaming behavior
+
+> **Important:** All `/stream` endpoints (both the native `POST /api/graphs/{name}/stream`
+> and the Platform-compatible `POST /threads/{id}/runs/stream` and `POST /runs/stream`)
+> return **buffered SSE**. Chunks emitted by the graph are collected during execution
+> and flushed as SSE events **after the run completes** — this is **not** true
+> token-level streaming, and clients will not receive partial tokens incrementally.
+>
+> True chunked streaming is on the roadmap and depends on Azure Functions Python v2
+> streaming response support. If you need real-time token streaming today, run the
+> graph behind a long-running host (e.g. App Service or AKS) instead.
+
 ### Per-graph auth
 
 Override app-level auth settings per graph:
@@ -216,7 +228,7 @@ curl -X POST "https://<app>.azurewebsites.net/api/graphs/echo_agent/invoke?code=
 ### What you get
 
 1. `POST /api/graphs/echo_agent/invoke` — invoke the agent
-2. `POST /api/graphs/echo_agent/stream` — stream agent responses (buffered SSE)
+2. `POST /api/graphs/echo_agent/stream` — stream agent responses (buffered SSE, not true token streaming)
 3. `GET /api/graphs/echo_agent/threads/{thread_id}/state` — inspect thread state
 4. `GET /api/health` — health check
 
@@ -232,9 +244,9 @@ With `platform_compat=True`, you also get SDK-compatible endpoints:
 13. `POST /threads/search` — search threads
 14. `POST /threads/count` — count threads
 15. `POST /threads/{id}/runs/wait` — run and wait for result
-16. `POST /threads/{id}/runs/stream` — run and stream result
+16. `POST /threads/{id}/runs/stream` — run and stream result (buffered SSE)
 17. `POST /runs/wait` — threadless run
-18. `POST /runs/stream` — threadless stream
+18. `POST /runs/stream` — threadless stream (buffered SSE)
 19. `GET /threads/{id}/state` — get thread state
 20. `POST /threads/{id}/state` — update thread state
 21. `POST /threads/{id}/history` — get state history

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -158,6 +158,18 @@ from azure_functions_langgraph import LangGraphApp
 app = LangGraphApp(auth_level=func.AuthLevel.FUNCTION)
 ```
 
+### 流式传输行为
+
+> **重要：** 所有 `/stream` 端点（包括原生的 `POST /api/graphs/{name}/stream`，
+> 以及 Platform 兼容的 `POST /threads/{id}/runs/stream` 和 `POST /runs/stream`）
+> 都返回**缓冲式 SSE**。图执行过程中产生的 chunk 会先被收集，待运行**完成后**
+> 一次性以 SSE 事件形式发送。这并非真正的逐 token 流式传输，客户端无法增量
+> 接收部分 token。
+>
+> 真正的分块流式传输已列入路线图，依赖于 Azure Functions Python v2 对
+> streaming response 的支持。如果当前确实需要实时 token 级流式传输，建议
+> 在长时间运行的宿主（如 App Service 或 AKS）中运行图。
+
 ### 按图认证
 
 可以按图覆盖应用级认证设置：
@@ -179,7 +191,7 @@ curl -X POST "https://<app>.azurewebsites.net/api/graphs/echo_agent/invoke?code=
 ### 生成的端点
 
 1. `POST /api/graphs/echo_agent/invoke` — 调用智能体
-2. `POST /api/graphs/echo_agent/stream` — 流式传输智能体响应（缓冲式 SSE）
+2. `POST /api/graphs/echo_agent/stream` — 流式传输智能体响应（缓冲式 SSE，非真正逐 token 流式传输）
 3. `GET /api/graphs/echo_agent/threads/{thread_id}/state` — 检查线程状态
 4. `GET /api/health` — 健康检查
 
@@ -195,9 +207,9 @@ curl -X POST "https://<app>.azurewebsites.net/api/graphs/echo_agent/invoke?code=
 13. `POST /threads/search` — 搜索线程
 14. `POST /threads/count` — 线程计数
 15. `POST /threads/{id}/runs/wait` — 运行并等待结果
-16. `POST /threads/{id}/runs/stream` — 运行并流式传输结果
+16. `POST /threads/{id}/runs/stream` — 运行并流式传输结果（缓冲式 SSE）
 17. `POST /runs/wait` — 无线程运行
-18. `POST /runs/stream` — 无线程流式传输
+18. `POST /runs/stream` — 无线程流式传输（缓冲式 SSE）
 19. `GET /threads/{id}/state` — 获取线程状态
 20. `POST /threads/{id}/state` — 更新线程状态
 21. `POST /threads/{id}/history` — 获取状态历史

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -128,9 +128,9 @@ gapp = LangGraphApp(thread_store=store, platform_compat=True)
 - `POST /api/threads` — Create thread
 - `GET /api/threads/{thread_id}` — Get thread
 - `POST /api/threads/{thread_id}/runs/wait` — Run and wait
-- `POST /api/threads/{thread_id}/runs/stream` — Run and stream
+- `POST /api/threads/{thread_id}/runs/stream` — Run and stream (buffered SSE)
 - `POST /api/runs/wait` — Threadless run
-- `POST /api/runs/stream` — Threadless stream
+- `POST /api/runs/stream` — Threadless stream (buffered SSE)
 - `POST /api/threads/{thread_id}/state` — Update state
 - `POST /api/threads/{thread_id}/history` — State history
 

--- a/llms.txt
+++ b/llms.txt
@@ -14,7 +14,7 @@
 ## What It Does
 
 Thin adapter that deploys LangGraph StateGraph agents as Azure Functions HTTP endpoints.
-Handles invoke, SSE streaming, thread/run management, and state persistence — all from
+Handles invoke, buffered SSE streaming, thread/run management, and state persistence — all from
 a two-line registration API.
 
 ## Core API


### PR DESCRIPTION
## Summary

Closes #140.

The package marketed `/stream` endpoints with `Content-Type: text/event-stream` while the implementation buffers all chunks and flushes them after the run completes. The comparison table at the top of the README was honest, but the Quick Start, Platform endpoint list, and `llms*.txt` files were not loud enough about this. Users coming from LangGraph Platform or expecting LLM token streaming on Azure Functions would be misled.

## Changes

- **New 'Streaming behavior' callout** placed right after the Production authentication section in all four READMEs (`README.md`, `README.ko.md`, `README.ja.md`, `README.zh-CN.md`). It states explicitly that:
  - All `/stream` endpoints (native + Platform-compatible) return **buffered SSE**.
  - Chunks are collected during execution and flushed **after** the run completes.
  - This is **not** token-level streaming.
  - True chunked streaming is on the roadmap (gated on Azure Functions Python v2 streaming response support).
  - For real-time token streaming today, run the graph behind a long-running host (App Service / AKS).
- **Tightened endpoint descriptions** in the 'What you get' lists across all four READMEs:
  - `/api/graphs/{name}/stream` → adds 'not true token streaming'
  - `/threads/{id}/runs/stream` → adds '(buffered SSE)'
  - `/runs/stream` → adds '(buffered SSE)'
- **Mirrored to AI assistant docs** so Copilot/Cursor/Claude surface the same expectation:
  - `llms.txt` line 17: 'SSE streaming' → 'buffered SSE streaming'
  - `llms-full.txt` lines 131/133: added '(buffered SSE)' to platform stream entries (line 122 was already accurate)

## Verification

- `make lint` not relevant (Markdown / plain text only).
- The existing `Streaming | True SSE | Buffered SSE` row in the comparison table (line 55 of each README) is now reinforced rather than contradicted by surrounding text.
- Auth callout was already present and untouched; this PR only adds the streaming callout.
- No code paths or behavior change.

## Out of scope

- True chunked streaming implementation — tracked as a roadmap item, dependent on Azure Functions Python v2 worker support.
- Storage scale notes — covered by #143.