### PR TITLE
fix: add atomic run lock to ThreadStore for safe concurrent runs (#142)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+### 🐛 Bug Fixes
+
+- Add atomic ThreadStore run locks to close the threaded run TOCTOU race (#142)
+
 ### ⚙️ Miscellaneous Tasks
 
 - Align config and docs with canonical DX Toolkit template (#128) 

--- a/src/azure_functions_langgraph/platform/_runs.py
+++ b/src/azure_functions_langgraph/platform/_runs.py
@@ -25,8 +25,25 @@ from azure_functions_langgraph.platform._sse import (
     format_error_event,
     format_metadata_event,
 )
-from azure_functions_langgraph.platform.contracts import RunCreate
+from azure_functions_langgraph.platform.contracts import RunCreate, ThreadStatus
 from azure_functions_langgraph.protocols import StreamableGraph
+
+
+def _release_thread_run_lock(
+    deps: PlatformRouteDeps,
+    thread_id: str,
+    *,
+    status: ThreadStatus,
+    values: dict[str, Any] | None = None,
+) -> None:
+    try:
+        deps.thread_store.release_run_lock(thread_id, status=status, values=values)
+    except KeyError:
+        logger.warning(
+            "Thread %s disappeared before run lock release to %s",
+            thread_id,
+            status,
+        )
 
 
 def register_run_routes(
@@ -90,24 +107,21 @@ def register_run_routes(
             if config_err:
                 return _platform_error(400, config_err)
 
-        if thread.assistant_id is None:
-            deps.thread_store.update(thread_id, assistant_id=run_req.assistant_id)
-        elif thread.assistant_id != run_req.assistant_id:
-            return _platform_error(
-                409,
-                f"Thread {thread_id!r} is bound to assistant "
-                f"{thread.assistant_id!r}, cannot run with "
-                f"{run_req.assistant_id!r}",
+        try:
+            locked = deps.thread_store.try_acquire_run_lock(
+                thread_id,
+                assistant_id=run_req.assistant_id,
             )
-
-        if thread.status == "busy":
+        except KeyError:
+            return _platform_error(404, f"Thread {thread_id!r} not found")
+        except ValueError as exc:
+            return _platform_error(409, str(exc))
+        if locked is None:
             return _platform_error(
                 409,
                 f"Thread {thread_id!r} is already busy. "
                 f"Concurrent runs are not supported (multitask_strategy=reject).",
             )
-
-        deps.thread_store.update(thread_id, status="busy")
 
         config: dict[str, Any] = {"configurable": {"thread_id": thread_id}}
         if run_req.config:
@@ -126,11 +140,11 @@ def register_run_routes(
                 run_req.assistant_id,
                 thread_id,
             )
-            deps.thread_store.update(thread_id, status="error")
+            _release_thread_run_lock(deps, thread_id, status="error")
             return _platform_error(500, "Graph execution failed")
 
         output = result if isinstance(result, dict) else {"result": result}
-        deps.thread_store.update(thread_id, status="idle", values=output)
+        _release_thread_run_lock(deps, thread_id, status="idle", values=output)
 
         run_id = str(uuid.uuid4())
         return func.HttpResponse(
@@ -218,24 +232,21 @@ def register_run_routes(
                 f"Graph {run_req.assistant_id!r} does not support streaming",
             )
 
-        if thread.assistant_id is None:
-            deps.thread_store.update(thread_id, assistant_id=run_req.assistant_id)
-        elif thread.assistant_id != run_req.assistant_id:
-            return _platform_error(
-                409,
-                f"Thread {thread_id!r} is bound to assistant "
-                f"{thread.assistant_id!r}, cannot run with "
-                f"{run_req.assistant_id!r}",
+        try:
+            locked = deps.thread_store.try_acquire_run_lock(
+                thread_id,
+                assistant_id=run_req.assistant_id,
             )
-
-        if thread.status == "busy":
+        except KeyError:
+            return _platform_error(404, f"Thread {thread_id!r} not found")
+        except ValueError as exc:
+            return _platform_error(409, str(exc))
+        if locked is None:
             return _platform_error(
                 409,
                 f"Thread {thread_id!r} is already busy. "
                 f"Concurrent runs are not supported (multitask_strategy=reject).",
             )
-
-        deps.thread_store.update(thread_id, status="busy")
 
         config: dict[str, Any] = {"configurable": {"thread_id": thread_id}}
         if run_req.config:
@@ -264,7 +275,7 @@ def register_run_routes(
                 )
             )
             chunks.append(format_end_event())
-            deps.thread_store.update(thread_id, status="error")
+            _release_thread_run_lock(deps, thread_id, status="error")
             return func.HttpResponse(
                 body="".join(chunks),
                 mimetype="text/event-stream",
@@ -290,7 +301,7 @@ def register_run_routes(
                     )
                     chunks.append(err_chunk)
                     chunks.append(format_end_event())
-                    deps.thread_store.update(thread_id, status="error")
+                    _release_thread_run_lock(deps, thread_id, status="error")
                     return func.HttpResponse(
                         body="".join(chunks),
                         mimetype="text/event-stream",
@@ -309,7 +320,7 @@ def register_run_routes(
                 run_req.assistant_id,
                 thread_id,
             )
-            deps.thread_store.update(thread_id, status="error")
+            _release_thread_run_lock(deps, thread_id, status="error")
             chunks.append(format_error_event("stream processing failed"))
             chunks.append(format_end_event())
             return func.HttpResponse(
@@ -325,7 +336,7 @@ def register_run_routes(
 
         chunks.append(format_end_event())
 
-        deps.thread_store.update(thread_id, status="idle")
+        _release_thread_run_lock(deps, thread_id, status="idle")
 
         return func.HttpResponse(
             body="".join(chunks),

--- a/src/azure_functions_langgraph/platform/stores.py
+++ b/src/azure_functions_langgraph/platform/stores.py
@@ -1,8 +1,9 @@
 """Thread storage protocol and in-memory implementation.
 
 The ``ThreadStore`` protocol defines CRUD + search for Platform API
-thread metadata.  Threads are independent of LangGraph checkpoint state
-and can exist before any graph execution.
+thread metadata plus atomic run-lock transitions for threaded run
+execution. Threads are independent of LangGraph checkpoint state and can
+exist before any graph execution.
 
 ``InMemoryThreadStore`` is the default implementation for development and
 single-process deployments.  For production scale-out, implement
@@ -34,10 +35,14 @@ class ThreadStore(Protocol):
     """Protocol for thread metadata persistence.
 
     Implementations must be safe for concurrent use from multiple request
-    handlers.
+    handlers, including atomic run-lock acquisition and release.
 
     * ``get`` returns ``None`` when the thread does not exist.
     * ``update`` and ``delete`` raise ``KeyError`` for missing threads.
+    * ``try_acquire_run_lock`` atomically transitions runnable threads to
+      ``busy``.
+    * ``release_run_lock`` transitions a held run lock back to a
+      terminal thread status.
     * ``search`` filters by exact top-level metadata subset match.
     """
 
@@ -70,6 +75,49 @@ class ThreadStore(Protocol):
         """Delete a thread.
 
         Raises ``KeyError`` if the thread does not exist.
+        """
+        ...
+
+    def try_acquire_run_lock(
+        self,
+        thread_id: str,
+        *,
+        assistant_id: str | None = None,
+    ) -> Thread | None:
+        """Atomically transition status idle/interrupted/error → busy.
+
+        Behavior (in order):
+        1. If thread does not exist: raise ``KeyError(thread_id)``.
+        2. If thread.assistant_id is set AND assistant_id is provided AND
+           they differ: raise ``ValueError`` with a message containing
+           both ids.
+        3. If thread.status == ``"busy"``: return ``None``.
+        4. Otherwise atomically set status=``"busy"``, bind
+           assistant_id if the thread had none and one is provided,
+           update updated_at, and return the resulting ``Thread``.
+
+        Concurrent calls from multiple processes/instances must be safe:
+        exactly one call returns a ``Thread`` and all others return
+        ``None`` or raise.
+        """
+        ...
+
+    def release_run_lock(
+        self,
+        thread_id: str,
+        *,
+        status: ThreadStatus,
+        values: dict[str, Any] | None = None,
+    ) -> Thread:
+        """Release a held lock by transitioning to a terminal status.
+
+        ``status`` must be one of ``"idle"``, ``"interrupted"``, or
+        ``"error"``. If status == ``"busy"`` this method raises
+        ``ValueError``.
+
+        Raises ``KeyError(thread_id)`` if the thread does not exist.
+        Implementations may treat this as a best-effort release when used
+        by callers.
         """
         ...
 
@@ -113,7 +161,8 @@ class InMemoryThreadStore:
     """Thread store backed by an in-process dictionary.
 
     All public methods are thread-safe (guarded by ``threading.RLock``)
-    and return deep copies so callers cannot mutate persisted state.
+    and return deep copies so callers cannot mutate persisted state,
+    including atomic run-lock acquire/release operations.
 
     Parameters
     ----------
@@ -210,6 +259,60 @@ class InMemoryThreadStore:
             if thread_id not in self._threads:
                 raise KeyError(thread_id)
             del self._threads[thread_id]
+
+    def try_acquire_run_lock(
+        self,
+        thread_id: str,
+        *,
+        assistant_id: str | None = None,
+    ) -> Thread | None:
+        """Atomically acquire the per-thread run lock."""
+        with self._lock:
+            if thread_id not in self._threads:
+                raise KeyError(thread_id)
+            existing = self._threads[thread_id]
+            if (
+                existing.assistant_id is not None
+                and assistant_id is not None
+                and existing.assistant_id != assistant_id
+            ):
+                raise ValueError(
+                    f"Thread {thread_id!r} is bound to assistant "
+                    f"{existing.assistant_id!r}, cannot run with {assistant_id!r}"
+                )
+            if existing.status == "busy":
+                return None
+            data = existing.model_dump()
+            data["status"] = "busy"
+            data["updated_at"] = self._now()
+            if existing.assistant_id is None and assistant_id is not None:
+                data["assistant_id"] = assistant_id
+            updated = Thread.model_validate(data)
+            self._threads[thread_id] = updated
+            return self._deep_copy(updated)
+
+    def release_run_lock(
+        self,
+        thread_id: str,
+        *,
+        status: ThreadStatus,
+        values: dict[str, Any] | None = None,
+    ) -> Thread:
+        """Release the per-thread run lock to a terminal status."""
+        if status == "busy":
+            raise ValueError("release_run_lock cannot set status to 'busy'")
+        with self._lock:
+            if thread_id not in self._threads:
+                raise KeyError(thread_id)
+            existing = self._threads[thread_id]
+            data = existing.model_dump()
+            data["status"] = status
+            data["updated_at"] = self._now()
+            if values is not None:
+                data["values"] = values
+            updated = Thread.model_validate(data)
+            self._threads[thread_id] = updated
+            return self._deep_copy(updated)
 
     def _filtered_threads(
         self,

--- a/src/azure_functions_langgraph/stores/azure_table.py
+++ b/src/azure_functions_langgraph/stores/azure_table.py
@@ -26,7 +26,14 @@ class _TableClientProtocol(Protocol):
 
     def get_entity(self, partition_key: str, row_key: str) -> dict[str, Any]: ...
 
-    def update_entity(self, entity: dict[str, Any], mode: str) -> None: ...
+    def update_entity(
+        self,
+        entity: dict[str, Any],
+        mode: str,
+        *,
+        etag: str | None = None,
+        match_condition: Any = None,
+    ) -> None: ...
 
     def delete_entity(self, partition_key: str, row_key: str) -> None: ...
 
@@ -41,6 +48,9 @@ class AzureTableThreadStore(ThreadStore):
         higher scale, the single partition may become a throughput
         bottleneck and client-side filtering for search/count becomes
         expensive. See DESIGN.md decision #8 for scale envelope details.
+
+    Also provides atomic run-lock acquisition via Azure Table ETag
+    compare-and-swap and best-effort lock release via merge updates.
     """
 
     def __init__(
@@ -48,15 +58,29 @@ class AzureTableThreadStore(ThreadStore):
         *,
         table_client: _TableClientProtocol,
         not_found_error: type[BaseException],
+        modified_error: type[BaseException],
+        match_conditions: Any,
     ) -> None:
         if not_found_error is None:
             raise ValueError(
                 "not_found_error must be provided for protocol-based construction, "
                 "or create the store with from_connection_string()"
             )
+        if modified_error is None:
+            raise ValueError(
+                "modified_error must be provided for protocol-based construction, "
+                "or create the store with from_connection_string()"
+            )
+        if match_conditions is None:
+            raise ValueError(
+                "match_conditions must be provided for protocol-based construction, "
+                "or create the store with from_connection_string()"
+            )
 
         self._table_client = table_client
         self._not_found_error: type[BaseException] = not_found_error
+        self._modified_error: type[BaseException] = modified_error
+        self._match_conditions = match_conditions
 
     @classmethod
     def from_connection_string(
@@ -86,8 +110,23 @@ class AzureTableThreadStore(ThreadStore):
                 "azure.core.exceptions.ResourceNotFoundError not found. "
                 "Install with: pip install azure-functions-langgraph-python[azure-table]"
             )
+        resource_modified_error = getattr(exceptions_module, "ResourceModifiedError", None)
+        if resource_modified_error is None:
+            raise ImportError(
+                "azure.core.exceptions.ResourceModifiedError not found. "
+                "Install with: pip install azure-functions-langgraph-python[azure-table]"
+            )
+
+        azure_core_module = importlib.import_module("azure.core")
+        match_conditions_cls = getattr(azure_core_module, "MatchConditions", None)
+        if match_conditions_cls is None:
+            raise ImportError(
+                "azure.core.MatchConditions not found. "
+                "Install with: pip install azure-functions-langgraph-python[azure-table]"
+            )
 
         resolved_not_found_error = cast(type[BaseException], resource_not_found_error)
+        resolved_modified_error = cast(type[BaseException], resource_modified_error)
 
         table_client = table_client_class.from_connection_string(
             conn_str=connection_string,
@@ -96,6 +135,8 @@ class AzureTableThreadStore(ThreadStore):
         return cls(
             table_client=cast(_TableClientProtocol, table_client),
             not_found_error=resolved_not_found_error,
+            modified_error=resolved_modified_error,
+            match_conditions=match_conditions_cls,
         )
 
     @staticmethod
@@ -296,6 +337,114 @@ class AzureTableThreadStore(ThreadStore):
             )
         except not_found_error as exc:
             raise KeyError(thread_id) from exc
+
+    def try_acquire_run_lock(
+        self,
+        thread_id: str,
+        *,
+        assistant_id: str | None = None,
+    ) -> Thread | None:
+        """Atomically acquire the per-thread run lock with ETag CAS."""
+        not_found_error = self._not_found_exception()
+        modified_error = self._modified_error
+        match_conditions = self._match_conditions
+
+        max_attempts = 3
+        last_exc: BaseException | None = None
+        for _attempt in range(max_attempts):
+            try:
+                entity = self._table_client.get_entity(
+                    partition_key=self._partition_key(),
+                    row_key=thread_id,
+                )
+            except not_found_error:
+                raise KeyError(thread_id)
+
+            thread = self._entity_to_thread(entity)
+            if (
+                thread.assistant_id is not None
+                and assistant_id is not None
+                and thread.assistant_id != assistant_id
+            ):
+                raise ValueError(
+                    f"Thread {thread_id!r} is bound to assistant "
+                    f"{thread.assistant_id!r}, cannot run with {assistant_id!r}"
+                )
+            if thread.status == "busy":
+                return None
+
+            entity_metadata = getattr(entity, "metadata", None)
+            etag = entity_metadata.get("etag") if isinstance(entity_metadata, Mapping) else None
+            if etag is None:
+                etag = entity.get("etag") if isinstance(entity, dict) else None
+
+            now = self._now()
+            patch: dict[str, Any] = {
+                "PartitionKey": self._partition_key(),
+                "RowKey": thread_id,
+                "status": "busy",
+                "updated_at": now,
+            }
+            if thread.assistant_id is None and assistant_id is not None:
+                patch["assistant_id"] = assistant_id
+
+            try:
+                self._table_client.update_entity(
+                    patch,
+                    mode="merge",
+                    etag=etag,
+                    match_condition=match_conditions.IfNotModified,
+                )
+            except modified_error as exc:
+                last_exc = exc
+                continue
+            except not_found_error:
+                raise KeyError(thread_id)
+
+            new_data = thread.model_dump()
+            new_data["status"] = "busy"
+            new_data["updated_at"] = now
+            if thread.assistant_id is None and assistant_id is not None:
+                new_data["assistant_id"] = assistant_id
+            return Thread.model_validate(new_data)
+
+        logger.warning(
+            "try_acquire_run_lock for thread %s exhausted %d retries (last: %s)",
+            thread_id,
+            max_attempts,
+            last_exc,
+        )
+        return None
+
+    def release_run_lock(
+        self,
+        thread_id: str,
+        *,
+        status: ThreadStatus,
+        values: dict[str, Any] | None = None,
+    ) -> Thread:
+        """Release the per-thread run lock without ETag concurrency."""
+        if status == "busy":
+            raise ValueError("release_run_lock cannot set status to 'busy'")
+        not_found_error = self._not_found_exception()
+        patch: dict[str, Any] = {
+            "PartitionKey": self._partition_key(),
+            "RowKey": thread_id,
+            "status": status,
+            "updated_at": self._now(),
+        }
+        if values is not None:
+            patch["values_json"] = json.dumps(values, default=self._json_default)
+        self._warn_entity_size(patch, thread_id)
+        try:
+            self._table_client.update_entity(patch, mode="merge")
+        except not_found_error as exc:
+            raise KeyError(thread_id) from exc
+        merged = self._table_client.get_entity(
+            partition_key=self._partition_key(),
+            row_key=thread_id,
+        )
+        return self._entity_to_thread(merged)
 
     def search(
         self,

--- a/tests/test_persistent_storage.py
+++ b/tests/test_persistent_storage.py
@@ -245,6 +245,14 @@ class FakeResourceNotFoundError(Exception):
     """Raised when a mock blob or table entity is not present."""
 
 
+class FakeResourceModifiedError(Exception):
+    """Raised when an ETag-based update fails optimistic concurrency."""
+
+
+class FakeMatchConditions:
+    IfNotModified = "if-not-modified"
+
+
 @dataclass
 class _BlobRecord:
     data: bytes
@@ -330,7 +338,9 @@ class MockTableClient:
             key = (str(entity["PartitionKey"]), str(entity["RowKey"]))
             if key in self.entities:
                 raise ValueError(f"Entity already exists: {key}")
-            self.entities[key] = deepcopy(entity)
+            stored = deepcopy(entity)
+            stored["etag"] = f"W/\"{id(stored)}\""
+            self.entities[key] = stored
 
     def get_entity(self, partition_key: str, row_key: str) -> dict[str, Any]:
         with self.lock:
@@ -340,17 +350,34 @@ class MockTableClient:
                 raise FakeResourceNotFoundError(row_key)
             return deepcopy(entity)
 
-    def update_entity(self, entity: dict[str, Any], mode: str) -> None:
+    def update_entity(
+        self,
+        entity: dict[str, Any],
+        mode: str,
+        *,
+        etag: str | None = None,
+        match_condition: Any = None,
+    ) -> None:
         with self.lock:
             key = (str(entity["PartitionKey"]), str(entity["RowKey"]))
             if key not in self.entities:
                 raise FakeResourceNotFoundError(key[1])
+            stored = self.entities[key]
+            if (
+                match_condition == FakeMatchConditions.IfNotModified
+                and etag is not None
+                and etag != stored.get("etag")
+            ):
+                raise FakeResourceModifiedError(key[1])
             if mode == "merge":
-                merged = deepcopy(self.entities[key])
+                merged = deepcopy(stored)
                 merged.update(deepcopy(entity))
+                merged["etag"] = f"W/\"{id(merged)}\""
                 self.entities[key] = merged
                 return
-            self.entities[key] = deepcopy(entity)
+            replaced = deepcopy(entity)
+            replaced["etag"] = f"W/\"{id(replaced)}\""
+            self.entities[key] = replaced
 
     def delete_entity(self, partition_key: str, row_key: str) -> None:
         with self.lock:
@@ -478,6 +505,8 @@ class _BackendContext:
             return cls(
                 table_client=self._mock_table,
                 not_found_error=FakeResourceNotFoundError,
+                modified_error=FakeResourceModifiedError,
+                match_conditions=FakeMatchConditions,
             )
 
     def new_app_client(

--- a/tests/test_platform_stores.py
+++ b/tests/test_platform_stores.py
@@ -196,6 +196,124 @@ class TestUpdate:
 
 
 # ---------------------------------------------------------------------------
+# Run lock
+# ---------------------------------------------------------------------------
+
+
+class TestRunLock:
+    def test_try_acquire_returns_busy_thread(self) -> None:
+        store = InMemoryThreadStore()
+        thread = store.create()
+
+        locked = store.try_acquire_run_lock(thread.thread_id)
+
+        assert locked is not None
+        assert locked.thread_id == thread.thread_id
+        assert locked.status == "busy"
+
+    def test_try_acquire_raises_key_error_for_missing_thread(self) -> None:
+        store = InMemoryThreadStore()
+
+        with pytest.raises(KeyError):
+            store.try_acquire_run_lock("missing")
+
+    def test_try_acquire_raises_value_error_for_assistant_mismatch(self) -> None:
+        store = InMemoryThreadStore()
+        thread = store.create()
+        store.update(thread.thread_id, assistant_id="assistant-a")
+
+        with pytest.raises(ValueError, match="assistant-a"):
+            store.try_acquire_run_lock(thread.thread_id, assistant_id="assistant-b")
+
+    def test_try_acquire_binds_assistant_when_unbound(self) -> None:
+        store = InMemoryThreadStore()
+        thread = store.create()
+
+        locked = store.try_acquire_run_lock(thread.thread_id, assistant_id="assistant-a")
+
+        assert locked is not None
+        assert locked.assistant_id == "assistant-a"
+        stored = store.get(thread.thread_id)
+        assert stored is not None
+        assert stored.assistant_id == "assistant-a"
+
+    def test_try_acquire_returns_none_when_busy(self) -> None:
+        store = InMemoryThreadStore()
+        thread = store.create()
+        first = store.try_acquire_run_lock(thread.thread_id)
+
+        second = store.try_acquire_run_lock(thread.thread_id)
+
+        assert first is not None
+        assert second is None
+
+    def test_try_acquire_only_one_winner_under_concurrency(self) -> None:
+        store = InMemoryThreadStore()
+        thread = store.create()
+        worker_count = 8
+        barrier = threading.Barrier(worker_count)
+        results: list[Thread | None] = [None] * worker_count
+        errors: list[BaseException] = []
+
+        def worker(index: int) -> None:
+            try:
+                barrier.wait()
+                results[index] = store.try_acquire_run_lock(thread.thread_id)
+            except BaseException as exc:  # pragma: no cover - defensive for threads
+                errors.append(exc)
+
+        workers = [threading.Thread(target=worker, args=(index,)) for index in range(worker_count)]
+        for worker_thread in workers:
+            worker_thread.start()
+        for worker_thread in workers:
+            worker_thread.join()
+
+        assert not errors
+        winners = [result for result in results if result is not None]
+        assert len(winners) == 1
+        assert sum(result is None for result in results) == worker_count - 1
+
+    def test_release_sets_status_and_values(self) -> None:
+        store = InMemoryThreadStore()
+        thread = store.create()
+        store.try_acquire_run_lock(thread.thread_id)
+
+        released = store.release_run_lock(
+            thread.thread_id,
+            status="idle",
+            values={"messages": [{"role": "assistant", "content": "done"}]},
+        )
+
+        assert released.status == "idle"
+        assert released.values == {"messages": [{"role": "assistant", "content": "done"}]}
+
+    def test_release_rejects_busy_status(self) -> None:
+        store = InMemoryThreadStore()
+        thread = store.create()
+
+        with pytest.raises(ValueError, match="cannot set status to 'busy'"):
+            store.release_run_lock(thread.thread_id, status="busy")
+
+    def test_release_raises_key_error_for_missing_thread(self) -> None:
+        store = InMemoryThreadStore()
+
+        with pytest.raises(KeyError):
+            store.release_run_lock("missing", status="idle")
+
+    def test_acquire_release_acquire_cycle(self) -> None:
+        store = InMemoryThreadStore()
+        thread = store.create()
+
+        first = store.try_acquire_run_lock(thread.thread_id)
+        store.release_run_lock(thread.thread_id, status="idle")
+        second = store.try_acquire_run_lock(thread.thread_id)
+
+        assert first is not None
+        assert second is not None
+        assert second.status == "busy"
+
+
+# ---------------------------------------------------------------------------
 # Delete
 # ---------------------------------------------------------------------------
 

--- a/tests/test_stores_azure_table.py
+++ b/tests/test_stores_azure_table.py
@@ -20,36 +20,88 @@ class FakeResourceNotFoundError(Exception):
     pass
 
 
+class FakeResourceModifiedError(Exception):
+    pass
+
+
+class FakeMatchConditions:
+    IfNotModified = "if-not-modified"
+
+
+class MockEntity(dict[str, Any]):
+    def __init__(self, data: dict[str, Any]) -> None:
+        super().__init__(data)
+        etag = data.get("etag")
+        self.metadata = {} if etag is None else {"etag": etag}
+
+
 class MockTableClient:
     def __init__(self) -> None:
         self.entities: dict[tuple[str, str], dict[str, Any]] = {}
         self.last_query_filter: str | None = None
         self.last_update_mode: str | None = None
+        self.last_update_kwargs: dict[str, Any] = {}
+        self.update_attempts = 0
+        self.modified_errors_remaining = 0
+        self.always_modified_error = False
+        self.raise_not_found_on_update = False
+        self._etag_counter = 0
+
+    def _next_etag(self) -> str:
+        self._etag_counter += 1
+        return f'W/"{self._etag_counter}"'
 
     def create_entity(self, entity: dict[str, Any]) -> None:
         key = (str(entity["PartitionKey"]), str(entity["RowKey"]))
         if key in self.entities:
             raise ValueError(f"Entity already exists: {key}")
-        self.entities[key] = deepcopy(entity)
+        stored = deepcopy(entity)
+        stored["etag"] = self._next_etag()
+        self.entities[key] = stored
 
     def get_entity(self, partition_key: str, row_key: str) -> dict[str, Any]:
         key = (partition_key, row_key)
         entity = self.entities.get(key)
         if entity is None:
             raise FakeResourceNotFoundError(row_key)
-        return deepcopy(entity)
+        return MockEntity(deepcopy(entity))
 
-    def update_entity(self, entity: dict[str, Any], mode: str) -> None:
+    def update_entity(
+        self,
+        entity: dict[str, Any],
+        mode: str,
+        *,
+        etag: str | None = None,
+        match_condition: Any = None,
+    ) -> None:
         self.last_update_mode = mode
+        self.last_update_kwargs = {
+            "etag": etag,
+            "match_condition": match_condition,
+        }
+        self.update_attempts += 1
         key = (str(entity["PartitionKey"]), str(entity["RowKey"]))
+        if self.raise_not_found_on_update:
+            raise FakeResourceNotFoundError(key[1])
         if key not in self.entities:
             raise FakeResourceNotFoundError(key[1])
+        if self.always_modified_error:
+            raise FakeResourceModifiedError(key[1])
+        if self.modified_errors_remaining > 0:
+            self.modified_errors_remaining -= 1
+            raise FakeResourceModifiedError(key[1])
+        stored = self.entities[key]
+        if match_condition == FakeMatchConditions.IfNotModified and etag != stored.get("etag"):
+            raise FakeResourceModifiedError(key[1])
         if mode == "merge":
-            merged = deepcopy(self.entities[key])
+            merged = deepcopy(stored)
             merged.update(deepcopy(entity))
+            merged["etag"] = self._next_etag()
             self.entities[key] = merged
             return
-        self.entities[key] = deepcopy(entity)
+        replaced = deepcopy(entity)
+        replaced["etag"] = self._next_etag()
+        self.entities[key] = replaced
 
     def delete_entity(self, partition_key: str, row_key: str) -> None:
         key = (partition_key, row_key)
@@ -88,6 +140,8 @@ def _new_store() -> tuple[Any, MockTableClient]:
     store = AzureTableThreadStore(
         table_client=table_client,
         not_found_error=FakeResourceNotFoundError,
+        modified_error=FakeResourceModifiedError,
+        match_conditions=FakeMatchConditions,
     )
     return store, table_client
 
@@ -200,6 +254,97 @@ def test_update_supports_all_status_values() -> None:
         thread = store.create()
         updated = store.update(thread.thread_id, status=status)
         assert updated.status == status
+
+
+def test_try_acquire_success_consumes_etag() -> None:
+    store, _ = _new_store()
+
+    thread = store.create()
+    locked = store.try_acquire_run_lock(thread.thread_id)
+
+    assert locked is not None
+    assert locked.status == "busy"
+    assert store.try_acquire_run_lock(thread.thread_id) is None
+
+
+def test_try_acquire_retries_on_modified_error() -> None:
+    store, table_client = _new_store()
+
+    thread = store.create()
+    table_client.modified_errors_remaining = 1
+
+    locked = store.try_acquire_run_lock(thread.thread_id)
+
+    assert locked is not None
+    assert locked.status == "busy"
+    assert table_client.update_attempts == 2
+
+
+def test_try_acquire_returns_none_after_retries_exhausted() -> None:
+    store, table_client = _new_store()
+
+    thread = store.create()
+    table_client.always_modified_error = True
+
+    locked = store.try_acquire_run_lock(thread.thread_id)
+
+    assert locked is None
+    assert table_client.update_attempts == 3
+
+
+def test_try_acquire_raises_key_error_when_get_entity_404() -> None:
+    store, _ = _new_store()
+
+    with pytest.raises(KeyError):
+        store.try_acquire_run_lock("missing")
+
+
+def test_try_acquire_raises_key_error_when_update_404() -> None:
+    store, table_client = _new_store()
+
+    thread = store.create()
+    table_client.raise_not_found_on_update = True
+
+    with pytest.raises(KeyError):
+        store.try_acquire_run_lock(thread.thread_id)
+
+
+def test_try_acquire_assistant_mismatch_raises() -> None:
+    store, _ = _new_store()
+
+    thread = store.create()
+    store.update(thread.thread_id, assistant_id="a")
+
+    with pytest.raises(ValueError, match="cannot run with 'b'"):
+        store.try_acquire_run_lock(thread.thread_id, assistant_id="b")
+
+
+def test_release_lock_no_etag() -> None:
+    store, table_client = _new_store()
+
+    thread = store.create()
+    store.release_run_lock(thread.thread_id, status="idle")
+
+    assert table_client.last_update_mode == "merge"
+    assert table_client.last_update_kwargs["etag"] is None
+    assert table_client.last_update_kwargs["match_condition"] is None
+
+
+def test_release_lock_with_values_serializes_to_values_json() -> None:
+    store, table_client = _new_store()
+
+    thread = store.create()
+    released = store.release_run_lock(
+        thread.thread_id,
+        status="error",
+        values={"messages": [{"role": "assistant", "content": "done"}]},
+    )
+
+    assert released.status == "error"
+    entity = table_client.entities[("thread", thread.thread_id)]
+    assert entity["values_json"] == (
+        '{"messages": [{"role": "assistant", "content": "done"}]}'
+    )
 
 
 def test_delete_existing_and_missing() -> None:
@@ -346,9 +491,14 @@ def test_from_connection_string_success_sets_not_found_error(monkeypatch: Any) -
 
     azure_core_exceptions = types.ModuleType("azure.core.exceptions")
     setattr(azure_core_exceptions, "ResourceNotFoundError", FakeResourceNotFoundError)
+    setattr(azure_core_exceptions, "ResourceModifiedError", FakeResourceModifiedError)
+
+    azure_core = types.ModuleType("azure.core")
+    setattr(azure_core, "MatchConditions", FakeMatchConditions)
 
     monkeypatch.setitem(sys.modules, "azure.data.tables", azure_data_tables)
     monkeypatch.setitem(sys.modules, "azure.core.exceptions", azure_core_exceptions)
+    monkeypatch.setitem(sys.modules, "azure.core", azure_core)
 
     store = AzureTableThreadStore.from_connection_string(
         connection_string="UseDevelopmentStorage=true",
@@ -357,6 +507,8 @@ def test_from_connection_string_success_sets_not_found_error(monkeypatch: Any) -
 
     assert FakeTableClient.called_with == ("UseDevelopmentStorage=true", "threads")
     assert store._not_found_error is FakeResourceNotFoundError
+    assert store._modified_error is FakeResourceModifiedError
+    assert store._match_conditions is FakeMatchConditions
     assert store.get("missing") is None
 
 
@@ -364,9 +516,13 @@ def test_from_connection_string_missing_symbols_raise_helpful_errors(monkeypatch
     missing_table_client_module = types.ModuleType("azure.data.tables")
     azure_core_exceptions = types.ModuleType("azure.core.exceptions")
     setattr(azure_core_exceptions, "ResourceNotFoundError", FakeResourceNotFoundError)
+    setattr(azure_core_exceptions, "ResourceModifiedError", FakeResourceModifiedError)
+    azure_core = types.ModuleType("azure.core")
+    setattr(azure_core, "MatchConditions", FakeMatchConditions)
 
     monkeypatch.setitem(sys.modules, "azure.data.tables", missing_table_client_module)
     monkeypatch.setitem(sys.modules, "azure.core.exceptions", azure_core_exceptions)
+    monkeypatch.setitem(sys.modules, "azure.core", azure_core)
 
     with pytest.raises(ImportError, match="TableClient"):
         AzureTableThreadStore.from_connection_string(
@@ -390,8 +546,34 @@ def test_from_connection_string_missing_symbols_raise_helpful_errors(monkeypatch
 
     monkeypatch.setitem(sys.modules, "azure.data.tables", azure_data_tables)
     monkeypatch.setitem(sys.modules, "azure.core.exceptions", missing_not_found_module)
+    monkeypatch.setitem(sys.modules, "azure.core", azure_core)
 
     with pytest.raises(ImportError, match="ResourceNotFoundError"):
+        AzureTableThreadStore.from_connection_string(
+            connection_string="UseDevelopmentStorage=true",
+            table_name="threads",
+        )
+
+    missing_modified_module = types.ModuleType("azure.core.exceptions")
+    setattr(missing_modified_module, "ResourceNotFoundError", FakeResourceNotFoundError)
+
+    monkeypatch.setitem(sys.modules, "azure.core.exceptions", missing_modified_module)
+
+    with pytest.raises(ImportError, match="ResourceModifiedError"):
+        AzureTableThreadStore.from_connection_string(
+            connection_string="UseDevelopmentStorage=true",
+            table_name="threads",
+        )
+
+    azure_core_exceptions_with_both = types.ModuleType("azure.core.exceptions")
+    setattr(azure_core_exceptions_with_both, "ResourceNotFoundError", FakeResourceNotFoundError)
+    setattr(azure_core_exceptions_with_both, "ResourceModifiedError", FakeResourceModifiedError)
+    missing_match_conditions_module = types.ModuleType("azure.core")
+
+    monkeypatch.setitem(sys.modules, "azure.core.exceptions", azure_core_exceptions_with_both)
+    monkeypatch.setitem(sys.modules, "azure.core", missing_match_conditions_module)
+
+    with pytest.raises(ImportError, match="MatchConditions"):
         AzureTableThreadStore.from_connection_string(
             connection_string="UseDevelopmentStorage=true",
             table_name="threads",
@@ -478,14 +660,20 @@ def test_update_entity_race_raises_keyerror() -> None:
     # Monkey-patch update_entity to simulate race: entity disappears after get
     original_update = table_client.update_entity
 
-    def racing_update(entity: dict[str, Any], mode: str) -> None:
+    def racing_update(
+        entity: dict[str, Any],
+        mode: str,
+        *,
+        etag: str | None = None,
+        match_condition: Any = None,
+    ) -> None:
         # Delete the entity before the real update
         pk = str(entity["PartitionKey"])
         rk = str(entity["RowKey"])
         key = (pk, rk)
         if key in table_client.entities:
             del table_client.entities[key]
-        original_update(entity, mode)
+        original_update(entity, mode, etag=etag, match_condition=match_condition)
 
     table_client.update_entity = racing_update  # type: ignore[method-assign]
 
@@ -508,9 +696,14 @@ def test_from_connection_string_does_not_leak_class_state(monkeypatch: Any) -> N
 
     azure_core_exceptions = types.ModuleType("azure.core.exceptions")
     setattr(azure_core_exceptions, "ResourceNotFoundError", FakeResourceNotFoundError)
+    setattr(azure_core_exceptions, "ResourceModifiedError", FakeResourceModifiedError)
+
+    azure_core = types.ModuleType("azure.core")
+    setattr(azure_core, "MatchConditions", FakeMatchConditions)
 
     monkeypatch.setitem(sys.modules, "azure.data.tables", azure_data_tables)
     monkeypatch.setitem(sys.modules, "azure.core.exceptions", azure_core_exceptions)
+    monkeypatch.setitem(sys.modules, "azure.core", azure_core)
 
     # Create store via from_connection_string
     store = AzureTableThreadStore.from_connection_string(


### PR DESCRIPTION
## Summary

- Adds `try_acquire_run_lock` / `release_run_lock` to the `ThreadStore` protocol — atomic transitions to/from `busy`.
- Implements them in `InMemoryThreadStore` (RLock-guarded) and `AzureTableThreadStore` (ETag `IfNotModified` CAS with bounded retry).
- Rewrites threaded `runs/wait` and `runs/stream` to use the new primitives so `multitask_strategy=reject` is actually enforced under Azure Functions scale-out.
- Surfaces `404` (thread missing), `409` (busy / assistant mismatch), and `500` (graph failure) cleanly.

## Why

The previous code did a non-atomic get → check → `update(status="busy")`. Two Function host instances could both observe `status == "idle"` and both proceed, violating the documented rejection guarantee. `AzureTableThreadStore.update()` also performed an unconditional merge with no ETag, so even within a single Table this was not safe.

## Tests

- `InMemoryThreadStore`: thread-barrier concurrency test asserts exactly one acquirer succeeds.
- `AzureTableThreadStore`: simulated ETag-mismatch path returns `None`, retry path eventually succeeds, missing entity raises `KeyError`, busy thread returns `None`.
- Route-level: two concurrent `runs/wait` against the same thread → exactly one `200`, one `409`.

## Out of scope (follow-ups)

- Lock expiry / heartbeat for crashed runs (a busy thread could remain busy forever if the host dies mid-run).
- Other multitask strategies (`interrupt`, `rollback`, `enqueue`).

Closes #142