### PR TITLE
feat(checkpointers): add retention helpers + document storage scale envelope (#143)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,17 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### 🚀 Features
+
+- Add `delete_old_checkpoints` and `delete_checkpoints_before` retention helpers to `AzureBlobCheckpointSaver` (#143)
+
 ### 🐛 Bug Fixes
 
 - Add atomic ThreadStore run locks to close the threaded run TOCTOU race (#142)
+
+### 📚 Documentation
+
+- Document persistent storage scale envelope across all README locales (#143)
 
 ### ⚙️ Miscellaneous Tasks
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -279,6 +279,38 @@ func_app = app.function_app
 
 チェックポイントとスレッドメタデータはAzure Functions再起動後も維持され、インスタンス間で拡張されます。
 
+### スケール許容範囲
+
+同梱される永続化バックエンドは、開発および中小規模の本番デプロイを想定しています。以下の限界を超える前に計画を立ててください:
+
+| バックエンド | 推奨範囲 | 注意ゾーン | バックエンド変更を検討 |
+|---|---|---|---|
+| `AzureBlobCheckpointSaver` | スレッドあたりチェックポイント < 100、スレッド < 10K | スレッドあたりチェックポイント 100–1000 | Cosmos DB または Redis ベースのチェックポインターを使用 |
+| `AzureTableThreadStore` | スレッド < 100K、軽い検索負荷 | スレッド 100K–500K | シャーディングされたスレッドストアまたは Cosmos DB を使用 |
+
+注意事項:
+
+- **単一パーティション** — `AzureTableThreadStore` は全スレッドを単一の PartitionKey に格納し、Azure Table のパーティション単位スループット（Standard アカウントで約 2000 エンティティ/秒）が上限となります。`status` 以外の検索とカウントは**クライアントサイド**でフィルタリングされます。[COMPATIBILITY.md](COMPATIBILITY.md) を参照してください。
+- **プレフィックススキャン** — `AzureBlobCheckpointSaver` は blob プレフィックススキャンでチェックポイントを列挙するため、トランザクション数とレイテンシはスレッドあたりのチェックポイント数に比例して増加します。下記のリテンションヘルパーで境界を保ちましょう。
+- **エンティティサイズ** — Azure Table エンティティは 1 MB が上限で、しきい値の 90% で警告がログに記録されます。
+
+#### リテンションヘルパー
+
+`AzureBlobCheckpointSaver` は、定期クリーンアップ（例: Timer トリガーの Function）向けに 2 つのヘルパーを公開しています:
+
+```python
+# (thread, namespace) ごとに最新 50 件のチェックポイントだけ保持
+saver.delete_old_checkpoints(thread_id="conversation-1", keep_last=50)
+
+# あるいは特定のチェックポイント id より古いものをまとめて削除
+saver.delete_checkpoints_before(
+    thread_id="conversation-1",
+    before_checkpoint_id="01HXY...",
+)
+```
+
+どちらのヘルパーもチャンネル値 blob と `latest.json` ポインターを保持するため、残ったチェックポイントはそのまま利用できます。
+
 ### v0.3.0からのアップグレード
 
 v0.4.0はv0.3.0と完全に後方互換です。ブレイキングチェンジはありません。

--- a/README.ko.md
+++ b/README.ko.md
@@ -277,6 +277,38 @@ func_app = app.function_app
 
 체크포인트와 스레드 메타데이터는 Azure Functions 재시작 후에도 유지되며 인스턴스 간 확장됩니다.
 
+### 스케일 가이드
+
+번들된 영구 저장 백엔드는 개발 및 중소 규모 프로덕션 배포를 위한 것입니다. 다음 한계를 넘기 전에 계획을 세우세요:
+
+| 백엔드 | 권장 범위 | 주의 구간 | 백엔드 교체 권장 |
+|---|---|---|---|
+| `AzureBlobCheckpointSaver` | 스레드당 체크포인트 < 100개, 스레드 < 10K개 | 스레드당 체크포인트 100–1000개 | Cosmos DB 또는 Redis 기반 체크포인터 사용 |
+| `AzureTableThreadStore` | 스레드 < 100K개, 가벼운 검색 부하 | 스레드 100K–500K개 | 샤딩된 스레드 스토어 또는 Cosmos DB 사용 |
+
+참고 사항:
+
+- **단일 파티션** — `AzureTableThreadStore`는 모든 스레드를 단일 PartitionKey에 저장하며, Azure Table 파티션당 처리량(Standard 계정 기준 약 2000 엔티티/초)에 의해 제한됩니다. `status` 외의 검색 및 카운트 필터링은 **클라이언트 사이드**에서 수행됩니다. [COMPATIBILITY.md](COMPATIBILITY.md) 참고.
+- **Prefix 스캔** — `AzureBlobCheckpointSaver`는 blob prefix 스캔으로 체크포인트를 나열하므로 트랜잭션 수와 지연이 스레드당 체크포인트 수에 비례하여 증가합니다. 아래 보존 헬퍼로 이를 제한하세요.
+- **엔티티 크기** — Azure Table 엔티티는 1 MB로 제한되며, 임계값의 90%에서 경고가 기록됩니다.
+
+#### 보존 헬퍼
+
+`AzureBlobCheckpointSaver`는 정기 정리(예: Timer 트리거 Function)를 위한 두 가지 헬퍼를 제공합니다:
+
+```python
+# (스레드, 네임스페이스)별로 최근 50개의 체크포인트만 유지
+saver.delete_old_checkpoints(thread_id="conversation-1", keep_last=50)
+
+# 또는 특정 체크포인트 id 이전의 모든 체크포인트 삭제
+saver.delete_checkpoints_before(
+    thread_id="conversation-1",
+    before_checkpoint_id="01HXY...",
+)
+```
+
+두 헬퍼 모두 채널 값 blob과 `latest.json` 포인터를 보존하므로, 유지되는 체크포인트는 그대로 사용 가능합니다.
+
 ### v0.3.0에서 업그레이드
 
 v0.4.0은 v0.3.0과 완전히 하위 호환됩니다. 브레이킹 체인지가 없습니다.

--- a/README.md
+++ b/README.md
@@ -317,6 +317,38 @@ func_app = app.function_app
 
 Checkpoints and thread metadata survive Azure Functions restarts and scale across instances.
 
+### Scale envelope
+
+The bundled persistent backends are intended for development and small-to-medium production deployments. Plan ahead before pushing past these limits:
+
+| Backend | Comfortable | Caution zone | Switch backends |
+|---|---|---|---|
+| `AzureBlobCheckpointSaver` | < 100 checkpoints/thread, < 10K threads | 100–1000 checkpoints/thread | Use Cosmos DB or Redis-backed checkpointer |
+| `AzureTableThreadStore` | < 100K threads, light search load | 100K–500K threads | Use a sharded thread store or Cosmos DB |
+
+Notes:
+
+- **Single partition** — `AzureTableThreadStore` keys every thread under a single PartitionKey, capped by Azure Table per-partition throughput (~2000 entities/sec on Standard accounts). Search and count beyond `status` filtering are **client-side**; see [COMPATIBILITY.md](COMPATIBILITY.md).
+- **Prefix scans** — `AzureBlobCheckpointSaver` lists checkpoints via blob prefix scans; transaction count and latency grow with checkpoints-per-thread. Use the retention helpers below to keep that bounded.
+- **Entity size** — Azure Table entities are capped at 1 MB; the store logs a warning at 90% of the threshold.
+
+#### Retention helpers
+
+`AzureBlobCheckpointSaver` exposes two helpers for scheduled cleanup (e.g. from a Timer-triggered Function):
+
+```python
+# Keep only the most recent 50 checkpoints per (thread, namespace)
+saver.delete_old_checkpoints(thread_id="conversation-1", keep_last=50)
+
+# Or delete everything older than a known checkpoint id
+saver.delete_checkpoints_before(
+    thread_id="conversation-1",
+    before_checkpoint_id="01HXY...",
+)
+```
+
+Both helpers preserve channel value blobs and the `latest.json` pointer, so retained checkpoints remain fully usable.
+
 ### Upgrading
 
 #### v0.3.0 → v0.4.0

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -277,6 +277,38 @@ func_app = app.function_app
 
 检查点和线程元数据在 Azure Functions 重启后仍然保留，并可跨实例扩展。
 
+### 规模适用范围
+
+随包提供的持久化后端面向开发与中小规模生产部署。在突破以下限制前请提前规划:
+
+| 后端 | 舒适区间 | 注意区间 | 建议更换后端 |
+|---|---|---|---|
+| `AzureBlobCheckpointSaver` | 每线程检查点 < 100，线程数 < 10K | 每线程检查点 100–1000 | 使用 Cosmos DB 或基于 Redis 的检查点器 |
+| `AzureTableThreadStore` | 线程数 < 100K，搜索负载较轻 | 线程数 100K–500K | 使用分片线程存储或 Cosmos DB |
+
+说明:
+
+- **单分区** — `AzureTableThreadStore` 将所有线程置于同一 PartitionKey 下，受 Azure Table 单分区吞吐量（Standard 账户约 2000 实体/秒）限制。除 `status` 以外的搜索与计数过滤均在**客户端**完成，详见 [COMPATIBILITY.md](COMPATIBILITY.md)。
+- **前缀扫描** — `AzureBlobCheckpointSaver` 通过 blob 前缀扫描列出检查点，事务数与延迟随每线程检查点数量增长。请使用下文的保留辅助函数加以约束。
+- **实体大小** — Azure Table 实体上限为 1 MB；当达到阈值的 90% 时会记录警告。
+
+#### 保留辅助函数
+
+`AzureBlobCheckpointSaver` 提供两个用于定期清理（例如 Timer 触发的 Function）的辅助方法:
+
+```python
+# 每个 (线程, 命名空间) 仅保留最新 50 个检查点
+saver.delete_old_checkpoints(thread_id="conversation-1", keep_last=50)
+
+# 或删除某个检查点 id 之前的所有检查点
+saver.delete_checkpoints_before(
+    thread_id="conversation-1",
+    before_checkpoint_id="01HXY...",
+)
+```
+
+两个辅助函数都会保留通道值 blob 和 `latest.json` 指针，因此保留下来的检查点仍可正常使用。
+
 ### 从 v0.3.0 升级
 
 v0.4.0 与 v0.3.0 完全向后兼容。无破坏性变更。

--- a/docs/production-guide.md
+++ b/docs/production-guide.md
@@ -326,6 +326,48 @@ thread_store = AzureTableThreadStore.from_connection_string(
 
 Use `langgraphthreads` as the default production table name unless you need a custom naming scheme.
 
+### Checkpoint retention
+
+`AzureBlobCheckpointSaver` lists checkpoints via blob prefix scans, so per-thread cost grows with the number of stored checkpoints. For long-lived threads, schedule a Timer-triggered Function to prune old checkpoints:
+
+```python
+import os
+
+import azure.functions as func
+from azure.storage.blob import ContainerClient
+
+from azure_functions_langgraph.checkpointers.azure_blob import AzureBlobCheckpointSaver
+from azure_functions_langgraph.stores.azure_table import AzureTableThreadStore
+
+retention_app = func.FunctionApp()
+
+
+@retention_app.schedule(
+    schedule="0 0 3 * * *",
+    arg_name="timer",
+    run_on_startup=False,
+    use_monitor=True,
+)
+def prune_checkpoints(timer: func.TimerRequest) -> None:
+    del timer
+    container = ContainerClient.from_connection_string(
+        os.environ["AZURE_STORAGE_CONNECTION_STRING"],
+        "langgraph-checkpoints",
+    )
+    saver = AzureBlobCheckpointSaver(container_client=container)
+
+    threads = AzureTableThreadStore.from_connection_string(
+        os.environ["AZURE_STORAGE_CONNECTION_STRING"],
+        table_name="langgraphthreads",
+    )
+    for thread in threads.search(limit=10_000):
+        saver.delete_old_checkpoints(thread.thread_id, keep_last=50)
+```
+
+Both helpers preserve channel value blobs and the `latest.json` pointer, so retained checkpoints remain fully usable.
+
+If you want absolute cutoffs instead of "keep N", use `delete_checkpoints_before(thread_id, before_checkpoint_id=...)`. Checkpoint ids are lexicographically sortable, so `before_checkpoint_id` can be the id of any boundary checkpoint your application picks (e.g. the last successful production checkpoint of a previous day).
+
 ### Connection string security
 
 Do not hardcode storage secrets in source code or deployment artifacts.

--- a/src/azure_functions_langgraph/checkpointers/azure_blob.py
+++ b/src/azure_functions_langgraph/checkpointers/azure_blob.py
@@ -324,6 +324,114 @@ class AzureBlobCheckpointSaver(BaseCheckpointSaver[str]):
         for blob in self._container_client.list_blobs(name_starts_with=thread_prefix):
             self._container_client.get_blob_client(blob.name).delete_blob()
 
+    def delete_checkpoints_before(
+        self,
+        thread_id: str,
+        *,
+        before_checkpoint_id: str,
+        checkpoint_ns: str | None = None,
+    ) -> int:
+        """Delete checkpoints older than ``before_checkpoint_id``.
+
+        Checkpoint IDs are lexicographically sortable timestamps, so "older"
+        means ``id < before_checkpoint_id``. The reference checkpoint itself
+        is preserved.
+
+        Channel value blobs (under ``values/``) and the ``latest.json``
+        pointer are intentionally left untouched: values may still be
+        referenced by retained checkpoints, and the latest pointer remains
+        valid as long as the latest checkpoint itself is retained.
+
+        Parameters
+        ----------
+        thread_id:
+            Target thread identifier.
+        before_checkpoint_id:
+            Cutoff checkpoint id (exclusive); checkpoints strictly older are
+            deleted.
+        checkpoint_ns:
+            Restrict deletion to a single checkpoint namespace. ``None``
+            (default) sweeps every namespace under the thread.
+
+        Returns
+        -------
+        int
+            Number of distinct checkpoint ids deleted across the targeted
+            namespaces.
+        """
+        namespaces = (
+            [checkpoint_ns]
+            if checkpoint_ns is not None
+            else self._list_checkpoint_namespaces(thread_id)
+        )
+
+        deleted = 0
+        for ns in namespaces:
+            for cid in self._list_checkpoint_ids(thread_id, ns):
+                if cid >= before_checkpoint_id:
+                    continue
+                self._delete_checkpoint_blobs(thread_id, ns, cid)
+                deleted += 1
+        return deleted
+
+    def delete_old_checkpoints(
+        self,
+        thread_id: str,
+        *,
+        keep_last: int = 20,
+        checkpoint_ns: str | None = None,
+    ) -> int:
+        """Retain only the ``keep_last`` newest checkpoints per namespace.
+
+        Channel value blobs and ``latest.json`` are preserved (see
+        :meth:`delete_checkpoints_before` for the rationale).
+
+        Parameters
+        ----------
+        thread_id:
+            Target thread identifier.
+        keep_last:
+            Number of newest checkpoints to keep per namespace. Must be
+            non-negative; ``0`` deletes every checkpoint in the namespace.
+        checkpoint_ns:
+            Restrict pruning to a single namespace. ``None`` (default)
+            prunes every namespace under the thread.
+
+        Returns
+        -------
+        int
+            Number of checkpoints deleted across the targeted namespaces.
+        """
+        if keep_last < 0:
+            raise ValueError("keep_last must be non-negative")
+
+        namespaces = (
+            [checkpoint_ns]
+            if checkpoint_ns is not None
+            else self._list_checkpoint_namespaces(thread_id)
+        )
+
+        deleted = 0
+        for ns in namespaces:
+            checkpoint_ids = self._list_checkpoint_ids(thread_id, ns)
+            for cid in checkpoint_ids[keep_last:]:
+                self._delete_checkpoint_blobs(thread_id, ns, cid)
+                deleted += 1
+        return deleted
+
+    def _delete_checkpoint_blobs(
+        self,
+        thread_id: str,
+        checkpoint_ns: str,
+        checkpoint_id: str,
+    ) -> None:
+        base_prefix = self._checkpoint_base_prefix(thread_id, checkpoint_ns, checkpoint_id)
+        for blob in self._container_client.list_blobs(name_starts_with=base_prefix):
+            try:
+                self._container_client.get_blob_client(blob.name).delete_blob()
+            except self._not_found_error:
+                continue
+
     def _build_tuple(
         self,
         *,

--- a/tests/test_checkpointers_azure_blob.py
+++ b/tests/test_checkpointers_azure_blob.py
@@ -49,6 +49,22 @@ class _CheckpointSaverProtocol(Protocol):
 
     def delete_thread(self, thread_id: str) -> None: ...
 
+    def delete_checkpoints_before(
+        self,
+        thread_id: str,
+        *,
+        before_checkpoint_id: str,
+        checkpoint_ns: str | None = None,
+    ) -> int: ...
+
+    def delete_old_checkpoints(
+        self,
+        thread_id: str,
+        *,
+        keep_last: int = 20,
+        checkpoint_ns: str | None = None,
+    ) -> int: ...
+
 
 class FakeResourceNotFoundError(Exception):
     """Raised when a mock blob is not present."""
@@ -437,6 +453,138 @@ def test_delete_thread(
     assert saver.get_tuple(_config(thread_id="t-1", checkpoint_ns="ns")) is None
     assert saver.get_tuple(_config(thread_id="t-2", checkpoint_ns="ns")) is not None
     assert all(not name.startswith("threads/t-1/") for name in container.blobs)
+
+
+def _put_sequence(
+    saver: _CheckpointSaverProtocol,
+    *,
+    thread_id: str,
+    checkpoint_ns: str,
+    checkpoint_ids: Sequence[str],
+) -> None:
+    for step, cid in enumerate(checkpoint_ids, start=1):
+        saver.put(
+            _config(thread_id=thread_id, checkpoint_ns=checkpoint_ns),
+            _checkpoint(cid),
+            _metadata(step=step),
+            {},
+        )
+
+
+def test_delete_old_checkpoints_keeps_last_n(
+    saver_and_container: tuple[_CheckpointSaverProtocol, MockContainerClient],
+) -> None:
+    saver, container = saver_and_container
+    _put_sequence(
+        saver,
+        thread_id="t-1",
+        checkpoint_ns="ns",
+        checkpoint_ids=["cp-001", "cp-002", "cp-003", "cp-004", "cp-005"],
+    )
+
+    deleted = saver.delete_old_checkpoints("t-1", keep_last=2, checkpoint_ns="ns")
+
+    assert deleted == 3
+    remaining_checkpoint_blobs = sorted(
+        name
+        for name in container.blobs
+        if name.startswith("threads/t-1/ns/ns/checkpoints/")
+        and name.endswith("/checkpoint.bin")
+    )
+    assert remaining_checkpoint_blobs == [
+        "threads/t-1/ns/ns/checkpoints/cp-004/checkpoint.bin",
+        "threads/t-1/ns/ns/checkpoints/cp-005/checkpoint.bin",
+    ]
+    assert "threads/t-1/ns/ns/latest.json" in container.blobs
+
+
+def test_delete_old_checkpoints_preserves_values_and_latest_pointer(
+    saver_and_container: tuple[_CheckpointSaverProtocol, MockContainerClient],
+) -> None:
+    saver, container = saver_and_container
+    cfg = _config(thread_id="t-1", checkpoint_ns="ns")
+    saver.put(
+        cfg,
+        _checkpoint("cp-001", channel_values={"k": 1}, channel_versions={"k": "v1"}),
+        _metadata(step=1),
+        {"k": "v1"},
+    )
+    saver.put(
+        cfg,
+        _checkpoint("cp-002", channel_values={"k": 2}, channel_versions={"k": "v2"}),
+        _metadata(step=2),
+        {"k": "v2"},
+    )
+
+    deleted = saver.delete_old_checkpoints("t-1", keep_last=1, checkpoint_ns="ns")
+    assert deleted == 1
+
+    value_blobs = sorted(name for name in container.blobs if "/values/k/" in name)
+    assert value_blobs == [
+        "threads/t-1/ns/ns/values/k/v1.bin",
+        "threads/t-1/ns/ns/values/k/v2.bin",
+    ]
+    latest = saver.get_tuple(cfg)
+    assert latest is not None
+    assert latest.checkpoint["id"] == "cp-002"
+
+
+def test_delete_old_checkpoints_sweeps_all_namespaces(
+    saver_and_container: tuple[_CheckpointSaverProtocol, MockContainerClient],
+) -> None:
+    saver, _ = saver_and_container
+    _put_sequence(
+        saver,
+        thread_id="t-1",
+        checkpoint_ns="ns-a",
+        checkpoint_ids=["cp-001", "cp-002", "cp-003"],
+    )
+    _put_sequence(
+        saver,
+        thread_id="t-1",
+        checkpoint_ns="ns-b",
+        checkpoint_ids=["cp-001", "cp-002"],
+    )
+
+    deleted = saver.delete_old_checkpoints("t-1", keep_last=1)
+
+    assert deleted == 3
+
+
+def test_delete_old_checkpoints_rejects_negative_keep_last(
+    saver_and_container: tuple[_CheckpointSaverProtocol, MockContainerClient],
+) -> None:
+    saver, _ = saver_and_container
+    with pytest.raises(ValueError):
+        saver.delete_old_checkpoints("t-1", keep_last=-1)
+
+
+def test_delete_checkpoints_before_strict_cutoff(
+    saver_and_container: tuple[_CheckpointSaverProtocol, MockContainerClient],
+) -> None:
+    saver, container = saver_and_container
+    _put_sequence(
+        saver,
+        thread_id="t-1",
+        checkpoint_ns="ns",
+        checkpoint_ids=["cp-001", "cp-002", "cp-003"],
+    )
+
+    deleted = saver.delete_checkpoints_before(
+        "t-1", before_checkpoint_id="cp-002", checkpoint_ns="ns"
+    )
+
+    assert deleted == 1
+    remaining_checkpoint_blobs = sorted(
+        name
+        for name in container.blobs
+        if name.startswith("threads/t-1/ns/ns/checkpoints/")
+        and name.endswith("/checkpoint.bin")
+    )
+    assert remaining_checkpoint_blobs == [
+        "threads/t-1/ns/ns/checkpoints/cp-002/checkpoint.bin",
+        "threads/t-1/ns/ns/checkpoints/cp-003/checkpoint.bin",
+    ]
 
 
 def test_channel_value_dedup(


### PR DESCRIPTION
## Summary

- Adds two retention helpers to \`AzureBlobCheckpointSaver\`:
  - \`delete_old_checkpoints(thread_id, keep_last=N)\` — keep newest N per namespace
  - \`delete_checkpoints_before(thread_id, before_checkpoint_id=...)\` — strict cutoff
- Documents persistent-storage scale envelope across all four READMEs (en, ko, ja, zh-CN) and adds a Timer-triggered retention example to \`docs/production-guide.md\`.

## Why

Both backends were previously documented only in code comments and \`DESIGN.md\`. Users adopting the README path could hit the single-PartitionKey throughput cap on \`AzureTableThreadStore\` or unbounded prefix-scan growth on \`AzureBlobCheckpointSaver\`. Operators also had no built-in way to prune checkpoints.

## Design notes

- Both helpers leave channel value blobs (\`values/\`) and the \`latest.json\` pointer untouched. Values are version-keyed and may still be referenced by retained checkpoints; \`latest.json\` stays valid as long as the latest checkpoint is retained.
- Whole-thread purge stays a separate concern via \`delete_thread\`.
- \`delete_old_checkpoints\` rejects negative \`keep_last\`; \`keep_last=0\` is allowed and deletes everything in the namespace.

## Tests

- New unit tests: keep-last-N semantics, value/latest preservation, namespace sweep, strict cutoff, input validation.
- Full suite: 728 passing, coverage 92.22%.

## Out of scope

- Garbage collection of orphaned channel value blobs (would require reverse-mapping versions to checkpoints).
- Retention controls for \`AzureTableThreadStore\` (separate concern).

Closes #143