### PR TITLE
chore(deps): pin langgraph to >=1.0,<2.0 with min-version CI compat job (#145)

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -59,13 +59,16 @@ jobs:
         with:
           python-version: "3.10"
 
-      - name: Install Hatch and dependencies via Makefile
+      - name: Install package and dev dependencies
         run: |
-          pip install hatch
-          make install
+          python -m pip install --upgrade pip
+          pip install -e ".[dev,azure-blob,azure-table]"
 
       - name: Pin langgraph to minimum supported (1.0.0)
-        run: .venv/bin/pip install "langgraph==1.0.0"
+        run: pip install "langgraph==1.0.0"
+
+      - name: Show resolved versions
+        run: pip show langgraph langgraph-sdk | grep -E '^(Name|Version):'
 
       - name: Run tests against minimum langgraph
-        run: .venv/bin/pytest tests/ --no-cov -q
+        run: pytest tests/ --no-cov -q

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -46,3 +46,26 @@ jobs:
           fail_ci_if_error: false
         env:
           CODECOV_RETRIES: 3
+
+  langgraph-min:
+    name: langgraph compat (min supported)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Set up Python 3.10
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: "3.10"
+
+      - name: Install Hatch and dependencies via Makefile
+        run: |
+          pip install hatch
+          make install
+
+      - name: Pin langgraph to minimum supported (1.0.0)
+        run: .venv/bin/pip install "langgraph==1.0.0"
+
+      - name: Run tests against minimum langgraph
+        run: .venv/bin/pytest tests/ --no-cov -q

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to this project will be documented in this file.
 
 ### ⚙️ Miscellaneous Tasks
 
+- Pin `langgraph` to `>=1.0,<2.0` and add a CI compatibility job for the minimum supported release; correct the stale `langgraph-sdk` row in `COMPATIBILITY.md` to match the runtime `>=0.3,<0.4` pin (#145)
 - Align config and docs with canonical DX Toolkit template (#128) 
 - *(deps)* Bump ruff from 0.15.8 to 0.15.10 (#124) 
 

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -4,14 +4,14 @@
 
 | Package | Supported Versions | Notes |
 |---|---|---|
-| `langgraph` | `>=0.2` | Runtime dependency. Tested with 0.2.x in CI. |
-| `langgraph-sdk` | `~0.1` | Platform compat layer mirrors this SDK version's REST API shapes. |
+| `langgraph` | `>=1.0,<2.0` | Runtime dependency. CI covers the minimum supported 1.x release (1.0.0) plus the latest resolved 1.x release on every Python version (3.10–3.14). |
+| `langgraph-sdk` | `>=0.3,<0.4` | Platform compat layer mirrors this SDK version's REST API shapes. |
 | `pydantic` | `>=2.0` | Required for request/response models. |
 | `azure-functions` | `>=1.17` | Azure Functions Python v2 programming model. |
 
 ## Platform Compatibility Layer
 
-The `platform/` subpackage mirrors the LangGraph Platform REST API as understood by `langgraph-sdk ~0.1`. This means:
+The `platform/` subpackage mirrors the LangGraph Platform REST API as understood by `langgraph-sdk >=0.3,<0.4`. This means:
 
 1. **Response shapes** — JSON response structures match what `langgraph-sdk` expects. Required fields, types, and nesting are tested via contract tests in `tests/test_sdk_contracts.py`.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 
 dependencies = [
     "azure-functions",
-    "langgraph>=0.2",
+    "langgraph>=1.0,<2.0",
     "pydantic>=2.0,<3.0",
 ]
 


### PR DESCRIPTION
## Summary

- Pin `langgraph` to `>=1.0,<2.0` in `pyproject.toml` (was `>=0.2` with no upper bound).
- Add a single CI compat job pinned to `langgraph==1.0.0` on Python 3.10 — verifies the floor without expanding into a full Python × langgraph matrix.
- Update `COMPATIBILITY.md` `langgraph` row and fix the stale `langgraph-sdk ~0.1` references to the actual runtime pin (`>=0.3,<0.4`).

## Why this pin

Per Oracle review (read-only consultation, full reasoning recorded in the PR commit):

- Coupling to `langgraph` is small and protocol-based — only `langgraph.checkpoint.{base,serde.base}` are hard-imported in `src/`, plus the platform layer's `get_state` / `update_state` / `get_state_history` assumptions. A **major-line cap** (`<2.0`) is the right balance: tighter than the unpinned status quo, looser than `<1.2` next-minor cap which would force a release on every upstream minor bump for no documented benefit.
- The previous `>=0.2` floor was not credible — CI in practice resolves to 1.1.x. Honest floor is what we test.
- Verified `langgraph==1.0.0` passes the full suite locally (`739 passed`) before picking the floor.

## Verification

- `make lint && make typecheck` — clean
- `make test` (latest langgraph 1.1.9): 739 passed, 92.22% coverage
- `langgraph==1.0.0` venv smoke run: 739 passed
- New `langgraph-min` CI job runs the same suite against `langgraph==1.0.0`

## Out of scope

- Scheduled "latest LangGraph 1.x" smoke job (Oracle's optional follow-up #1) — separate enhancement issue.
- README explicit "supports LangGraph 1.x" statement (Oracle's optional follow-up #2) — separate docs issue.

Closes #145