### PR TITLE
feat(checkpointers): add safe garbage collection for orphaned Azure Blob channel values (#153)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -311,7 +311,23 @@ saver.delete_checkpoints_before(
 
 どちらのヘルパーもチェックポイントマーカー、メタデータ、write blob のみを削除します。チャンネル値 blob（`values/` 配下）と `latest.json` ポインターは意図的に保持するため、残ったチェックポイントはそのまま利用できます。
 
-> **注意** — これらのヘルパーは安全ですが**完全ではありません**。今回削除されたチェックポイントから**のみ**参照されていたチャンネル値 blob は orphan となり、削除されません。頻繁にチェックポイントを取る長時間実行スレッドでは、時間とともに orphan blob がストレージ使用量の大半を占める可能性があります。値 blob のフル GC は [#153](https://github.com/yeongseon/azure-functions-langgraph-python/issues/153) で opt-in ヘルパーの候補として追跡されています。
+> **注意** — `delete_old_checkpoints` / `delete_checkpoints_before` は安全ですが**完全ではありません**。今回削除されたチェックポイントから**のみ**参照されていたチャンネル値 blob は orphan となり、削除されません。頻繁にチェックポイントを取る長時間実行スレッドでは、時間とともに orphan blob がストレージ使用量の大半を占める可能性があります。第2段階として `collect_orphaned_values()`（以下）をスケジュール実行してください。
+
+#### orphan チャンネル値のガベージコレクション
+
+チェックポイントを削除した後、`collect_orphaned_values()` は生き残ったチェックポイントを走査し、参照される `(channel, version)` の集合を構築して、その集合外の `values/` blob を削除します。デフォルトは **dry-run** なので、まず監査できます:
+
+```python
+audit = saver.collect_orphaned_values(thread_id="conversation-1")
+print(audit.would_delete)
+
+result = saver.collect_orphaned_values(thread_id="conversation-1", dry_run=False)
+print(f"{len(result.deleted)} 個の orphan blob を削除")
+```
+
+このヘルパーは2つの補完的な仕組みで同時実行安全性を提供します: (1) 最近書き込みの grace period — `last_modified` が `grace_period_seconds`（デフォルト **300秒**）以内の値 blob は次回の GC パスに延期され、`result.skipped_recent` に記録されます（value blob のアップロードと `latest.json` の確定の間のギャップを保護）。(2) orphan ごとの再スキャン — 各削除の直前に survivor セットが再計算されるため、スナップショット後に新しく確定したチェックポイントが参照し始めた*古い* value blob も保護されます。
+
+名前空間単位で **fail-closed** に動作します: `latest.json` が存在しない、または生存しているチェックポイント blob のいずれかが読めない / デシリアライズに失敗した場合、その名前空間全体がスキップされ（`result.skipped_namespaces` に記録）、設定ミスや一時的に利用できないストレージが破壊的な削除を引き起こさないようにします。
 
 ### v0.3.0からのアップグレード
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -309,7 +309,23 @@ saver.delete_checkpoints_before(
 
 두 헬퍼 모두 체크포인트 마커, 메타데이터, write blob만 삭제합니다. 채널 값 blob(`values/` 아래)과 `latest.json` 포인터는 의도적으로 보존하므로, 유지되는 체크포인트는 그대로 사용 가능합니다.
 
-> **참고** — 이 헬퍼들은 안전하지만 **완전하지는 않습니다**. 방금 삭제된 체크포인트에서**만** 참조되던 채널 값 blob은 orphan 상태가 되며 제거되지 않습니다. 자주 체크포인트되는 장기 실행 스레드의 경우, 시간이 지나면 이러한 orphan blob이 스토리지 사용량의 대부분을 차지할 수 있습니다. 전체 값 blob 가비지 컬렉션은 [#153](https://github.com/yeongseon/azure-functions-langgraph-python/issues/153)에서 opt-in 헬퍼 후보로 추적되고 있습니다.
+> **참고** — `delete_old_checkpoints` / `delete_checkpoints_before`는 안전하지만 **완전하지는 않습니다**. 방금 삭제된 체크포인트에서**만** 참조되던 채널 값 blob은 orphan 상태가 되며 제거되지 않습니다. 자주 체크포인트되는 장기 실행 스레드의 경우, 시간이 지나면 이러한 orphan blob이 스토리지 사용량의 대부분을 차지할 수 있습니다. 두 번째 단계로 `collect_orphaned_values()`(아래)를 스케줄에 따라 실행하세요.
+
+#### 고아 채널 값 가비지 컬렉션
+
+체크포인트 정리 후 `collect_orphaned_values()`는 살아남은 체크포인트를 순회하며 참조되는 `(channel, version)` 집합을 만들고, 그 집합 밖의 `values/` blob을 삭제합니다. 기본값은 **dry-run**이므로 먼저 감사할 수 있습니다:
+
+```python
+audit = saver.collect_orphaned_values(thread_id="conversation-1")
+print(audit.would_delete)
+
+result = saver.collect_orphaned_values(thread_id="conversation-1", dry_run=False)
+print(f"고아 blob {len(result.deleted)}개 삭제됨")
+```
+
+이 헬퍼는 두 가지 보완적인 메커니즘으로 동시성 안전성을 제공합니다: (1) 최근 쓰기 grace period — `last_modified`가 `grace_period_seconds`(기본 **300초**) 이내인 값 blob은 다음 GC 패스로 연기되며 `result.skipped_recent`에 기록됩니다(value blob 업로드와 `latest.json` 확정 사이의 갭을 보호). (2) orphan별 재스캔 — 각 삭제 직전에 survivor 집합을 다시 계산하므로, 스냅샷 이후에 새로 확정된 체크포인트가 참조하기 시작한 *오래된* value blob도 보존됩니다.
+
+네임스페이스별로 **fail-closed** 동작합니다: `latest.json`이 없거나 살아남은 체크포인트 blob 중 하나라도 읽을 수 없거나 역직렬화에 실패하면, 해당 네임스페이스 전체가 건너뛰어지고(`result.skipped_namespaces`에 기록) 잘못 구성되었거나 일시적으로 사용할 수 없는 스토리지에서 파괴적인 삭제가 트리거되지 않도록 합니다.
 
 ### v0.3.0에서 업그레이드
 

--- a/README.md
+++ b/README.md
@@ -425,7 +425,14 @@ result = saver.collect_orphaned_values(thread_id="conversation-1", dry_run=False
 print(f"Deleted {len(result.deleted)} orphaned value blobs")
 ```
 
-The helper is concurrency-safe: a fresh survivor scan is performed before each delete, so a checkpoint written mid-collection still protects its referenced values. Per namespace, if `latest.json` is missing the namespace is skipped entirely (recorded in `result.skipped_namespaces`) to avoid stomping a misconfigured store.
+The helper is concurrency-safe by two complementary mechanisms:
+
+1. **Recent-write grace period** — value blobs whose `last_modified` is within `grace_period_seconds` (default **300s**) are deferred to a future GC pass and recorded in `result.skipped_recent`. This protects the window between a value blob being uploaded and its checkpoint commit marker (`latest.json`) being finalized.
+2. **Per-orphan re-scan** — immediately before each delete, the survivor set is recomputed; an *older* value blob that a newly finalized checkpoint started referencing after the snapshot is preserved (such blobs appear in `would_delete` but not `deleted`).
+
+Per namespace, the helper **fails closed** — if `latest.json` is missing **or** any surviving checkpoint blob is unreadable / fails deserialization, the namespace is skipped entirely (recorded in `result.skipped_namespaces`) so a misconfigured or transiently-unavailable store cannot trigger destructive deletion.
+
+Set `grace_period_seconds=0` to disable the recent-write guard during an offline maintenance window when no concurrent checkpoint writes are possible.
 
 #### DB checkpointer backends
 

--- a/README.md
+++ b/README.md
@@ -409,7 +409,23 @@ saver.delete_checkpoints_before(
 
 Both helpers only delete checkpoint marker, metadata, and write blobs. They intentionally preserve channel value blobs (under `values/`) and the `latest.json` pointer so retained checkpoints remain fully usable.
 
-> **Note** — These helpers are safe but **not exhaustive**. Channel value blobs that were referenced *only* by the now-deleted checkpoints become orphaned and are not removed. For long-running threads with frequent checkpointing, those orphans can dominate the storage footprint over time. Full value-blob garbage collection is tracked in [#153](https://github.com/yeongseon/azure-functions-langgraph-python/issues/153) as a candidate opt-in helper.
+> **Note** — `delete_old_checkpoints` / `delete_checkpoints_before` are safe but **not exhaustive**. Channel value blobs that were referenced *only* by the now-deleted checkpoints become orphaned and are not removed. For long-running threads with frequent checkpointing, those orphans can dominate the storage footprint over time. Run `collect_orphaned_values()` (below) on a schedule as the second step.
+
+#### Garbage-collecting orphaned channel values
+
+After pruning checkpoints, `collect_orphaned_values()` walks the surviving checkpoints, builds the set of `(channel, version)` pairs they reference, and removes any `values/` blob outside that set. Default is **dry-run** so you can audit first:
+
+```python
+# Dry run — see what would be deleted, change nothing
+audit = saver.collect_orphaned_values(thread_id="conversation-1")
+print(audit.would_delete)
+
+# Real run — actually delete orphans
+result = saver.collect_orphaned_values(thread_id="conversation-1", dry_run=False)
+print(f"Deleted {len(result.deleted)} orphaned value blobs")
+```
+
+The helper is concurrency-safe: a fresh survivor scan is performed before each delete, so a checkpoint written mid-collection still protects its referenced values. Per namespace, if `latest.json` is missing the namespace is skipped entirely (recorded in `result.skipped_namespaces`) to avoid stomping a misconfigured store.
 
 #### DB checkpointer backends
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -309,7 +309,23 @@ saver.delete_checkpoints_before(
 
 两个辅助函数仅删除检查点标记、元数据和 write blob。通道值 blob（位于 `values/` 下）和 `latest.json` 指针被有意保留，因此保留下来的检查点仍可正常使用。
 
-> **注意** — 这些辅助函数是安全的，但**并不完整**。仅被刚刚删除的检查点引用的通道值 blob 会变为 orphan 且不会被删除。对于频繁创建检查点的长时间运行线程，这些 orphan blob 会随时间逐渐占据大部分存储空间。完整的值 blob 垃圾回收作为可选的 opt-in 辅助函数候选项在 [#153](https://github.com/yeongseon/azure-functions-langgraph-python/issues/153) 中跟踪。
+> **注意** — `delete_old_checkpoints` / `delete_checkpoints_before` 是安全的，但**并不完整**。仅被刚刚删除的检查点引用的通道值 blob 会变为 orphan 且不会被删除。对于频繁创建检查点的长时间运行线程，这些 orphan blob 会随时间逐渐占据大部分存储空间。请将 `collect_orphaned_values()`（见下文）作为第二步按计划运行。
+
+#### 收集孤立的通道值 blob
+
+清理检查点之后，`collect_orphaned_values()` 会遍历存活的检查点，构建它们引用的 `(channel, version)` 集合，并删除该集合之外的所有 `values/` blob。默认是 **dry-run**，您可以先审计：
+
+```python
+audit = saver.collect_orphaned_values(thread_id="conversation-1")
+print(audit.would_delete)
+
+result = saver.collect_orphaned_values(thread_id="conversation-1", dry_run=False)
+print(f"删除了 {len(result.deleted)} 个 orphan 值 blob")
+```
+
+该辅助函数通过两个互补机制保证并发安全：(1) 最近写入的宽限期 — `last_modified` 在 `grace_period_seconds`（默认 **300 秒**）窗口内的值 blob 将延后到下一轮 GC，并记录在 `result.skipped_recent` 中（保护值 blob 上传到 `latest.json` 最终确定之间的窗口）。(2) 每个 orphan 的重新扫描 — 在每次删除之前重新计算 survivor 集合，从而保护被快照之后新确定的检查点开始引用的*较旧*值 blob。
+
+每个命名空间都**失败关闭**：如果 `latest.json` 缺失，或任何存活的检查点 blob 不可读 / 反序列化失败，则跳过整个命名空间（记录在 `result.skipped_namespaces` 中），以防止配置错误或暂时不可用的存储触发破坏性删除。
 
 ### 从 v0.3.0 升级
 

--- a/docs/production-guide.md
+++ b/docs/production-guide.md
@@ -366,7 +366,23 @@ def prune_checkpoints(timer: func.TimerRequest) -> None:
 
 Both helpers only delete checkpoint marker, metadata, and write blobs. They intentionally preserve channel value blobs (under `values/`) and the `latest.json` pointer so retained checkpoints remain fully usable.
 
-> **Note** — These helpers are safe but **not exhaustive**. Channel value blobs that were referenced *only* by the now-deleted checkpoints become orphaned and are not removed. For long-running threads with frequent checkpointing, those orphans can dominate the storage footprint over time. Full value-blob garbage collection is tracked in [#153](https://github.com/yeongseon/azure-functions-langgraph-python/issues/153) as a candidate opt-in helper.
+> **Note** — `delete_old_checkpoints` / `delete_checkpoints_before` are safe but **not exhaustive**. Channel value blobs that were referenced *only* by the now-deleted checkpoints become orphaned and are not removed. For long-running threads with frequent checkpointing, those orphans can dominate the storage footprint over time. Run `collect_orphaned_values()` (below) on a schedule as the second step.
+
+#### Garbage-collecting orphaned channel values
+
+After pruning checkpoints, `collect_orphaned_values()` walks the surviving checkpoints, builds the set of `(channel, version)` pairs they reference, and removes any `values/` blob outside that set. Default is **dry-run** so you can audit first:
+
+```python
+audit = saver.collect_orphaned_values(thread_id="conversation-1")
+print(audit.would_delete)
+
+result = saver.collect_orphaned_values(thread_id="conversation-1", dry_run=False)
+print(f"Deleted {len(result.deleted)} orphaned value blobs")
+```
+
+The helper is concurrency-safe by two complementary mechanisms: a recent-write grace period (default `grace_period_seconds=300`) defers deletion of any value blob whose `last_modified` is within the window — protecting the gap between a value blob upload and the corresponding `latest.json` finalization — and a per-orphan re-scan immediately before each delete preserves any older value blob that a newly finalized checkpoint started referencing after the snapshot.
+
+The helper **fails closed** per namespace: if `latest.json` is missing or any surviving checkpoint blob is unreadable / fails deserialization, the namespace is skipped (recorded in `result.skipped_namespaces`) so a misconfigured or transiently-unavailable store cannot trigger destructive deletion.
 
 If you want absolute cutoffs instead of "keep N", use `delete_checkpoints_before(thread_id, before_checkpoint_id=...)`. Checkpoint ids are lexicographically sortable, so `before_checkpoint_id` can be the id of any boundary checkpoint your application picks (e.g. the last successful production checkpoint of a previous day).
 

--- a/src/azure_functions_langgraph/checkpointers/__init__.py
+++ b/src/azure_functions_langgraph/checkpointers/__init__.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from .azure_blob import (
         AzureBlobCheckpointSaver,
+        OrphanedValueCollectionResult,
     )
     from .cosmos import create_cosmos_checkpointer
     from .postgres import create_postgres_checkpointer
@@ -18,6 +19,10 @@ def __getattr__(name: str) -> object:
         from .azure_blob import AzureBlobCheckpointSaver
 
         return AzureBlobCheckpointSaver
+    if name == "OrphanedValueCollectionResult":
+        from .azure_blob import OrphanedValueCollectionResult
+
+        return OrphanedValueCollectionResult
     if name == "create_postgres_checkpointer":
         from .postgres import create_postgres_checkpointer
 
@@ -35,6 +40,7 @@ def __getattr__(name: str) -> object:
 
 __all__ = [
     "AzureBlobCheckpointSaver",
+    "OrphanedValueCollectionResult",
     "create_cosmos_checkpointer",
     "create_postgres_checkpointer",
     "create_sqlite_checkpointer",

--- a/src/azure_functions_langgraph/checkpointers/azure_blob.py
+++ b/src/azure_functions_langgraph/checkpointers/azure_blob.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Iterator, Sequence
 from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
 import importlib
 import json
 import logging
@@ -42,19 +43,32 @@ class OrphanedValueCollectionResult:
         captures the candidates *before* the per-blob re-check: a blob
         listed here may still be skipped (and absent from ``deleted``)
         if a concurrent writer references it mid-collection.
+        Blobs deferred by the recent-write grace window are **not**
+        listed here; they appear in ``skipped_recent`` instead.
     deleted:
         Channel value blob paths actually deleted. Only populated when
         ``dry_run`` is ``False``. Always a subset of ``would_delete``.
     skipped_namespaces:
-        ``(thread_id, checkpoint_ns)`` pairs whose ``latest.json`` could
-        not be loaded — the helper skipped them entirely to avoid
-        deleting live data on a misconfigured store.
+        ``(thread_id, checkpoint_ns)`` pairs whose survivor set could
+        not be trusted — either ``latest.json`` could not be loaded, or
+        at least one surviving checkpoint blob was unreadable / could
+        not be deserialized. The helper skips such namespaces entirely
+        to avoid deleting live data on a misconfigured or transiently
+        unavailable store. Failure reasons are logged at WARNING level.
+    skipped_recent:
+        Channel value blob paths that were recent enough to fall inside
+        the ``grace_period_seconds`` window (or that exposed no
+        ``last_modified`` timestamp). These are deferred to a future GC
+        pass so an in-flight checkpoint write that uploaded the value
+        blob *before* finalizing its checkpoint commit marker is not
+        deleted out from under it.
     """
 
     dry_run: bool
     would_delete: list[str] = field(default_factory=list)
     deleted: list[str] = field(default_factory=list)
     skipped_namespaces: list[tuple[str, str]] = field(default_factory=list)
+    skipped_recent: list[str] = field(default_factory=list)
 
 
 class _BlobDownloadProtocol(Protocol):
@@ -77,6 +91,7 @@ class _BlobClientProtocol(Protocol):
 
 class _BlobItemProtocol(Protocol):
     name: str
+    last_modified: datetime | None
 
 
 class _ContainerClientProtocol(Protocol):
@@ -472,6 +487,7 @@ class AzureBlobCheckpointSaver(BaseCheckpointSaver[str]):
         *,
         checkpoint_ns: str | None = None,
         dry_run: bool = True,
+        grace_period_seconds: int = 300,
     ) -> OrphanedValueCollectionResult:
         """Garbage-collect channel value blobs orphaned by checkpoint deletion.
 
@@ -484,20 +500,31 @@ class AzureBlobCheckpointSaver(BaseCheckpointSaver[str]):
 
         Safety contract:
 
-        * Per-namespace: if ``latest.json`` cannot be loaded the
-          namespace is skipped entirely (recorded in
-          :attr:`OrphanedValueCollectionResult.skipped_namespaces`).
-          Without a known-good latest pointer the helper has no signal
-          that the survivor set is trustworthy and refuses to delete.
+        * Per-namespace fail-closed: the namespace is skipped (recorded
+          in :attr:`OrphanedValueCollectionResult.skipped_namespaces`)
+          if ``latest.json`` cannot be loaded **or** any surviving
+          checkpoint blob listed under the namespace is unreadable /
+          fails deserialization. Without a complete, trustworthy
+          survivor set the helper has no way to compute the retained
+          ``(channel, version)`` set, so it refuses to delete.
         * Set semantics: a blob is preserved if **any** surviving
           checkpoint references its ``(channel, version)``. Versions
           shared across checkpoints are never deleted as long as one
           owner survives.
-        * Concurrency: the survivor list is snapshotted before deletion,
-          but each delete is preceded by a fresh per-namespace survivor
-          re-scan so a checkpoint written after the snapshot still
-          protects its referenced values. A blob may therefore appear in
-          ``would_delete`` but not in ``deleted``.
+        * Recent-write grace period: any value blob whose
+          ``last_modified`` falls inside the ``grace_period_seconds``
+          window — or whose ``last_modified`` is unavailable — is
+          deferred to a future GC pass and recorded in
+          :attr:`OrphanedValueCollectionResult.skipped_recent`.
+          The checkpoint write order is values → metadata → checkpoint
+          → ``latest.json``, so a value blob that exists but is not yet
+          referenced by any checkpoint may simply be a write in flight.
+        * Concurrency re-check: even after the grace filter, the
+          survivor set is re-scanned per orphan immediately before
+          deletion. This protects an *older* value blob that a newly
+          finalized checkpoint started referencing after the initial
+          snapshot. Such blobs appear in ``would_delete`` but not in
+          ``deleted``.
 
         Parameters
         ----------
@@ -510,6 +537,12 @@ class AzureBlobCheckpointSaver(BaseCheckpointSaver[str]):
             When ``True`` (default), nothing is deleted; the returned
             ``would_delete`` list captures every blob a non-dry-run pass
             over the same snapshot would attempt to delete.
+        grace_period_seconds:
+            Defer deletion of any value blob whose ``last_modified`` is
+            within this many seconds of now (default 300). Set to ``0``
+            to disable the recent-write guard — only safe when the
+            caller can guarantee no concurrent checkpoint writes (e.g.
+            an offline maintenance window).
 
         Returns
         -------
@@ -524,17 +557,32 @@ class AzureBlobCheckpointSaver(BaseCheckpointSaver[str]):
             else self._list_checkpoint_namespaces(thread_id)
         )
 
+        cutoff = self._utcnow() - timedelta(seconds=grace_period_seconds)
+
         for ns in namespaces:
             if self._read_latest_checkpoint_id(thread_id, ns) is None:
+                logger.warning(
+                    "collect_orphaned_values: skipping namespace (thread=%s, ns=%s); "
+                    "latest.json missing or unreadable",
+                    thread_id,
+                    ns,
+                )
                 result.skipped_namespaces.append((thread_id, ns))
                 continue
 
             retained = self._collect_retained_versions(thread_id, ns)
-            value_blob_paths = self._list_value_blobs(thread_id, ns)
+            if retained is None:
+                result.skipped_namespaces.append((thread_id, ns))
+                continue
+
+            value_blobs = self._list_value_blobs(thread_id, ns)
 
             ns_orphans: list[str] = []
-            for blob_path, channel_version in value_blob_paths:
+            for blob_path, channel_version, last_modified in value_blobs:
                 if channel_version is None or channel_version in retained:
+                    continue
+                if last_modified is None or last_modified > cutoff:
+                    result.skipped_recent.append(blob_path)
                     continue
                 ns_orphans.append(blob_path)
                 result.would_delete.append(blob_path)
@@ -544,6 +592,15 @@ class AzureBlobCheckpointSaver(BaseCheckpointSaver[str]):
 
             for blob_path in ns_orphans:
                 fresh_retained = self._collect_retained_versions(thread_id, ns)
+                if fresh_retained is None:
+                    logger.warning(
+                        "collect_orphaned_values: aborting deletes for namespace "
+                        "(thread=%s, ns=%s) mid-pass; survivor re-scan untrustworthy",
+                        thread_id,
+                        ns,
+                    )
+                    result.skipped_namespaces.append((thread_id, ns))
+                    break
                 channel_version = self._parse_value_blob_path(thread_id, ns, blob_path)
                 if channel_version is not None and channel_version in fresh_retained:
                     continue
@@ -555,38 +612,52 @@ class AzureBlobCheckpointSaver(BaseCheckpointSaver[str]):
 
         return result
 
+    def _utcnow(self) -> datetime:
+        return datetime.now(timezone.utc)
+
     def _collect_retained_versions(
         self, thread_id: str, checkpoint_ns: str
-    ) -> set[tuple[str, str]]:
+    ) -> set[tuple[str, str]] | None:
         retained: set[tuple[str, str]] = set()
         for cid in self._list_checkpoint_ids(thread_id, checkpoint_ns):
             blob_path = self._checkpoint_blob_path(thread_id, checkpoint_ns, cid)
             typed_blob = self._download_typed_blob(blob_path)
             if typed_blob is None:
-                continue
+                logger.warning(
+                    "collect_orphaned_values: surviving checkpoint blob %s missing or "
+                    "lacks serde_type metadata; treating namespace as untrustworthy",
+                    blob_path,
+                )
+                return None
             try:
                 checkpoint_data: Checkpoint = self.serde.loads_typed(
                     (typed_blob[0], typed_blob[1])
                 )
+                channel_versions = checkpoint_data["channel_versions"]
             except Exception:
                 logger.warning(
-                    "Failed to deserialize checkpoint blob %s; "
-                    "skipping its referenced channel versions",
+                    "collect_orphaned_values: failed to deserialize surviving "
+                    "checkpoint blob %s; treating namespace as untrustworthy",
                     blob_path,
                 )
-                continue
-            for channel, version in checkpoint_data["channel_versions"].items():
+                return None
+            for channel, version in channel_versions.items():
                 retained.add((channel, str(version)))
         return retained
 
     def _list_value_blobs(
         self, thread_id: str, checkpoint_ns: str
-    ) -> List[tuple[str, tuple[str, str] | None]]:
+    ) -> List[tuple[str, tuple[str, str] | None, datetime | None]]:
         values_prefix = f"{self._namespace_prefix(thread_id, checkpoint_ns)}values/"
-        items: List[tuple[str, tuple[str, str] | None]] = []
+        items: List[tuple[str, tuple[str, str] | None, datetime | None]] = []
         for blob in self._container_client.list_blobs(name_starts_with=values_prefix):
+            last_modified = getattr(blob, "last_modified", None)
             items.append(
-                (blob.name, self._parse_value_blob_path(thread_id, checkpoint_ns, blob.name))
+                (
+                    blob.name,
+                    self._parse_value_blob_path(thread_id, checkpoint_ns, blob.name),
+                    last_modified,
+                )
             )
         return items
 

--- a/src/azure_functions_langgraph/checkpointers/azure_blob.py
+++ b/src/azure_functions_langgraph/checkpointers/azure_blob.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterator, Sequence
+from dataclasses import dataclass, field
 import importlib
 import json
 import logging
@@ -22,6 +23,38 @@ from langgraph.checkpoint.base import (
     get_checkpoint_metadata,
 )
 from langgraph.checkpoint.serde.base import SerializerProtocol
+
+
+@dataclass
+class OrphanedValueCollectionResult:
+    """Result of :meth:`AzureBlobCheckpointSaver.collect_orphaned_values`.
+
+    Attributes
+    ----------
+    dry_run:
+        Whether the caller requested a dry run. When ``True`` the helper
+        does not delete anything; ``would_delete`` lists every blob path
+        that *would* have been removed in a non-dry-run pass over the
+        same store snapshot.
+    would_delete:
+        Channel value blob paths the helper identified as orphaned. In a
+        dry run this is the only populated list. In a real run this
+        captures the candidates *before* the per-blob re-check: a blob
+        listed here may still be skipped (and absent from ``deleted``)
+        if a concurrent writer references it mid-collection.
+    deleted:
+        Channel value blob paths actually deleted. Only populated when
+        ``dry_run`` is ``False``. Always a subset of ``would_delete``.
+    skipped_namespaces:
+        ``(thread_id, checkpoint_ns)`` pairs whose ``latest.json`` could
+        not be loaded — the helper skipped them entirely to avoid
+        deleting live data on a misconfigured store.
+    """
+
+    dry_run: bool
+    would_delete: list[str] = field(default_factory=list)
+    deleted: list[str] = field(default_factory=list)
+    skipped_namespaces: list[tuple[str, str]] = field(default_factory=list)
 
 
 class _BlobDownloadProtocol(Protocol):
@@ -344,9 +377,9 @@ class AzureBlobCheckpointSaver(BaseCheckpointSaver[str]):
         .. note::
            This is safe but not exhaustive. Channel value blobs that
            were referenced *only* by the now-deleted checkpoints become
-           orphaned and are not removed. Full value-blob garbage
-           collection is tracked separately and will land as an opt-in
-           helper in a future release.
+           orphaned and are not removed. Use
+           :meth:`collect_orphaned_values` as the second step to reclaim
+           them.
 
         Parameters
         ----------
@@ -396,9 +429,9 @@ class AzureBlobCheckpointSaver(BaseCheckpointSaver[str]):
         .. note::
            This is safe but not exhaustive. Channel value blobs that
            were referenced *only* by the now-deleted checkpoints become
-           orphaned and are not removed. Full value-blob garbage
-           collection is tracked separately and will land as an opt-in
-           helper in a future release.
+           orphaned and are not removed. Use
+           :meth:`collect_orphaned_values` as the second step to reclaim
+           them.
 
         Parameters
         ----------
@@ -432,6 +465,144 @@ class AzureBlobCheckpointSaver(BaseCheckpointSaver[str]):
                 self._delete_checkpoint_blobs(thread_id, ns, cid)
                 deleted += 1
         return deleted
+
+    def collect_orphaned_values(
+        self,
+        thread_id: str,
+        *,
+        checkpoint_ns: str | None = None,
+        dry_run: bool = True,
+    ) -> OrphanedValueCollectionResult:
+        """Garbage-collect channel value blobs orphaned by checkpoint deletion.
+
+        :meth:`delete_old_checkpoints` and :meth:`delete_checkpoints_before`
+        intentionally preserve channel value blobs because they may still
+        be referenced by retained checkpoints. This helper closes the
+        loop: it walks the surviving checkpoints, builds the set of
+        ``(channel, version)`` pairs they reference, and removes any
+        ``values/`` blob outside that retained set.
+
+        Safety contract:
+
+        * Per-namespace: if ``latest.json`` cannot be loaded the
+          namespace is skipped entirely (recorded in
+          :attr:`OrphanedValueCollectionResult.skipped_namespaces`).
+          Without a known-good latest pointer the helper has no signal
+          that the survivor set is trustworthy and refuses to delete.
+        * Set semantics: a blob is preserved if **any** surviving
+          checkpoint references its ``(channel, version)``. Versions
+          shared across checkpoints are never deleted as long as one
+          owner survives.
+        * Concurrency: the survivor list is snapshotted before deletion,
+          but each delete is preceded by a fresh per-namespace survivor
+          re-scan so a checkpoint written after the snapshot still
+          protects its referenced values. A blob may therefore appear in
+          ``would_delete`` but not in ``deleted``.
+
+        Parameters
+        ----------
+        thread_id:
+            Target thread identifier.
+        checkpoint_ns:
+            Restrict collection to a single namespace. ``None`` (default)
+            sweeps every namespace under the thread.
+        dry_run:
+            When ``True`` (default), nothing is deleted; the returned
+            ``would_delete`` list captures every blob a non-dry-run pass
+            over the same snapshot would attempt to delete.
+
+        Returns
+        -------
+        OrphanedValueCollectionResult
+            Audit record of what was identified, deleted, and skipped.
+        """
+        result = OrphanedValueCollectionResult(dry_run=dry_run)
+
+        namespaces = (
+            [checkpoint_ns]
+            if checkpoint_ns is not None
+            else self._list_checkpoint_namespaces(thread_id)
+        )
+
+        for ns in namespaces:
+            if self._read_latest_checkpoint_id(thread_id, ns) is None:
+                result.skipped_namespaces.append((thread_id, ns))
+                continue
+
+            retained = self._collect_retained_versions(thread_id, ns)
+            value_blob_paths = self._list_value_blobs(thread_id, ns)
+
+            ns_orphans: list[str] = []
+            for blob_path, channel_version in value_blob_paths:
+                if channel_version is None or channel_version in retained:
+                    continue
+                ns_orphans.append(blob_path)
+                result.would_delete.append(blob_path)
+
+            if dry_run:
+                continue
+
+            for blob_path in ns_orphans:
+                fresh_retained = self._collect_retained_versions(thread_id, ns)
+                channel_version = self._parse_value_blob_path(thread_id, ns, blob_path)
+                if channel_version is not None and channel_version in fresh_retained:
+                    continue
+                try:
+                    self._container_client.get_blob_client(blob_path).delete_blob()
+                except self._not_found_error:
+                    pass
+                result.deleted.append(blob_path)
+
+        return result
+
+    def _collect_retained_versions(
+        self, thread_id: str, checkpoint_ns: str
+    ) -> set[tuple[str, str]]:
+        retained: set[tuple[str, str]] = set()
+        for cid in self._list_checkpoint_ids(thread_id, checkpoint_ns):
+            blob_path = self._checkpoint_blob_path(thread_id, checkpoint_ns, cid)
+            typed_blob = self._download_typed_blob(blob_path)
+            if typed_blob is None:
+                continue
+            try:
+                checkpoint_data: Checkpoint = self.serde.loads_typed(
+                    (typed_blob[0], typed_blob[1])
+                )
+            except Exception:
+                logger.warning(
+                    "Failed to deserialize checkpoint blob %s; "
+                    "skipping its referenced channel versions",
+                    blob_path,
+                )
+                continue
+            for channel, version in checkpoint_data["channel_versions"].items():
+                retained.add((channel, str(version)))
+        return retained
+
+    def _list_value_blobs(
+        self, thread_id: str, checkpoint_ns: str
+    ) -> List[tuple[str, tuple[str, str] | None]]:
+        values_prefix = f"{self._namespace_prefix(thread_id, checkpoint_ns)}values/"
+        items: List[tuple[str, tuple[str, str] | None]] = []
+        for blob in self._container_client.list_blobs(name_starts_with=values_prefix):
+            items.append(
+                (blob.name, self._parse_value_blob_path(thread_id, checkpoint_ns, blob.name))
+            )
+        return items
+
+    def _parse_value_blob_path(
+        self, thread_id: str, checkpoint_ns: str, blob_path: str
+    ) -> tuple[str, str] | None:
+        values_prefix = f"{self._namespace_prefix(thread_id, checkpoint_ns)}values/"
+        if not blob_path.startswith(values_prefix):
+            return None
+        relative = blob_path[len(values_prefix):]
+        parts = relative.split("/")
+        if len(parts) != 2 or not parts[1].endswith(".bin"):
+            return None
+        channel = unquote(parts[0])
+        version = unquote(parts[1].removesuffix(".bin"))
+        return (channel, version)
 
     def _delete_checkpoint_blobs(
         self,

--- a/tests/test_checkpointers_azure_blob.py
+++ b/tests/test_checkpointers_azure_blob.py
@@ -66,6 +66,14 @@ class _CheckpointSaverProtocol(Protocol):
         checkpoint_ns: str | None = None,
     ) -> int: ...
 
+    def collect_orphaned_values(
+        self,
+        thread_id: str,
+        *,
+        checkpoint_ns: str | None = None,
+        dry_run: bool = True,
+    ) -> Any: ...
+
 
 class FakeResourceNotFoundError(Exception):
     """Raised when a mock blob is not present."""
@@ -715,3 +723,232 @@ def test_latest_json_monotonic_write(
     saver.put(cfg, _checkpoint("cp-001"), _metadata(step=1), {})
     latest_data = json.loads(container.blobs[latest_path].data.decode())
     assert latest_data["checkpoint_id"] == "cp-002"  # Still cp-002, not cp-001
+
+
+def _value_blob_paths(container: MockContainerClient) -> list[str]:
+    return sorted(name for name in container.blobs if "/values/" in name)
+
+
+def test_collect_orphaned_values_no_orphans_when_single_checkpoint(
+    saver_and_container: tuple[_CheckpointSaverProtocol, MockContainerClient],
+) -> None:
+    saver, container = saver_and_container
+    cfg = _config(thread_id="t-1", checkpoint_ns="ns")
+    saver.put(
+        cfg,
+        _checkpoint("cp-001", channel_values={"k": 1}, channel_versions={"k": "v1"}),
+        _metadata(step=1),
+        {"k": "v1"},
+    )
+
+    before = _value_blob_paths(container)
+    result = saver.collect_orphaned_values("t-1", checkpoint_ns="ns", dry_run=False)
+    after = _value_blob_paths(container)
+
+    assert result.dry_run is False
+    assert result.would_delete == []
+    assert result.deleted == []
+    assert result.skipped_namespaces == []
+    assert before == after
+
+
+def test_collect_orphaned_values_preserves_shared_versions(
+    saver_and_container: tuple[_CheckpointSaverProtocol, MockContainerClient],
+) -> None:
+    saver, container = saver_and_container
+    cfg = _config(thread_id="t-1", checkpoint_ns="ns")
+    saver.put(
+        cfg,
+        _checkpoint("cp-001", channel_values={"k": 1}, channel_versions={"k": "v1"}),
+        _metadata(step=1),
+        {"k": "v1"},
+    )
+    saver.put(
+        cfg,
+        _checkpoint("cp-002", channel_values={"k": 1}, channel_versions={"k": "v1"}),
+        _metadata(step=2),
+        {},
+    )
+
+    saver.delete_checkpoints_before(
+        "t-1", before_checkpoint_id="cp-002", checkpoint_ns="ns"
+    )
+
+    result = saver.collect_orphaned_values("t-1", checkpoint_ns="ns", dry_run=False)
+
+    assert result.would_delete == []
+    assert result.deleted == []
+    assert "threads/t-1/ns/ns/values/k/v1.bin" in container.blobs
+
+
+def test_collect_orphaned_values_collects_orphans(
+    saver_and_container: tuple[_CheckpointSaverProtocol, MockContainerClient],
+) -> None:
+    saver, container = saver_and_container
+    cfg = _config(thread_id="t-1", checkpoint_ns="ns")
+    saver.put(
+        cfg,
+        _checkpoint("cp-001", channel_values={"k": 1}, channel_versions={"k": "v1"}),
+        _metadata(step=1),
+        {"k": "v1"},
+    )
+    saver.put(
+        cfg,
+        _checkpoint("cp-002", channel_values={"k": 2}, channel_versions={"k": "v2"}),
+        _metadata(step=2),
+        {"k": "v2"},
+    )
+
+    deleted_count = saver.delete_old_checkpoints("t-1", keep_last=1, checkpoint_ns="ns")
+    assert deleted_count == 1
+
+    pre_paths = _value_blob_paths(container)
+    assert "threads/t-1/ns/ns/values/k/v1.bin" in pre_paths
+    assert "threads/t-1/ns/ns/values/k/v2.bin" in pre_paths
+
+    result = saver.collect_orphaned_values("t-1", checkpoint_ns="ns", dry_run=False)
+
+    assert result.would_delete == ["threads/t-1/ns/ns/values/k/v1.bin"]
+    assert result.deleted == ["threads/t-1/ns/ns/values/k/v1.bin"]
+    assert "threads/t-1/ns/ns/values/k/v1.bin" not in container.blobs
+    assert "threads/t-1/ns/ns/values/k/v2.bin" in container.blobs
+
+
+def test_collect_orphaned_values_dry_run_does_not_delete(
+    saver_and_container: tuple[_CheckpointSaverProtocol, MockContainerClient],
+) -> None:
+    saver, container = saver_and_container
+    cfg = _config(thread_id="t-1", checkpoint_ns="ns")
+    saver.put(
+        cfg,
+        _checkpoint("cp-001", channel_values={"k": 1}, channel_versions={"k": "v1"}),
+        _metadata(step=1),
+        {"k": "v1"},
+    )
+    saver.put(
+        cfg,
+        _checkpoint("cp-002", channel_values={"k": 2}, channel_versions={"k": "v2"}),
+        _metadata(step=2),
+        {"k": "v2"},
+    )
+    saver.delete_old_checkpoints("t-1", keep_last=1, checkpoint_ns="ns")
+
+    blobs_before = dict(container.blobs)
+
+    dry_result = saver.collect_orphaned_values("t-1", checkpoint_ns="ns", dry_run=True)
+
+    assert dry_result.dry_run is True
+    assert dry_result.would_delete == ["threads/t-1/ns/ns/values/k/v1.bin"]
+    assert dry_result.deleted == []
+    assert container.blobs == blobs_before
+
+    real_result = saver.collect_orphaned_values("t-1", checkpoint_ns="ns", dry_run=False)
+    assert real_result.deleted == dry_result.would_delete
+
+
+def test_collect_orphaned_values_skips_namespace_without_latest(
+    saver_and_container: tuple[_CheckpointSaverProtocol, MockContainerClient],
+) -> None:
+    saver, container = saver_and_container
+    cfg = _config(thread_id="t-1", checkpoint_ns="ns")
+    saver.put(
+        cfg,
+        _checkpoint("cp-001", channel_values={"k": 1}, channel_versions={"k": "v1"}),
+        _metadata(step=1),
+        {"k": "v1"},
+    )
+    saver.put(
+        cfg,
+        _checkpoint("cp-002", channel_values={"k": 2}, channel_versions={"k": "v2"}),
+        _metadata(step=2),
+        {"k": "v2"},
+    )
+    saver.delete_old_checkpoints("t-1", keep_last=1, checkpoint_ns="ns")
+
+    del container.blobs["threads/t-1/ns/ns/latest.json"]
+
+    blobs_before = dict(container.blobs)
+    result = saver.collect_orphaned_values("t-1", checkpoint_ns="ns", dry_run=False)
+
+    assert result.skipped_namespaces == [("t-1", "ns")]
+    assert result.would_delete == []
+    assert result.deleted == []
+    assert container.blobs == blobs_before
+
+
+def test_collect_orphaned_values_concurrent_write_protects_blob(
+    saver_and_container: tuple[_CheckpointSaverProtocol, MockContainerClient],
+) -> None:
+    """Concurrent checkpoint write that references a candidate version
+    must protect the blob even after it appeared in the snapshot."""
+    saver, container = saver_and_container
+    cfg = _config(thread_id="t-1", checkpoint_ns="ns")
+    saver.put(
+        cfg,
+        _checkpoint("cp-001", channel_values={"k": 1}, channel_versions={"k": "v1"}),
+        _metadata(step=1),
+        {"k": "v1"},
+    )
+    saver.put(
+        cfg,
+        _checkpoint("cp-002", channel_values={"k": 2}, channel_versions={"k": "v2"}),
+        _metadata(step=2),
+        {"k": "v2"},
+    )
+    saver.delete_old_checkpoints("t-1", keep_last=1, checkpoint_ns="ns")
+
+    original_collect = saver._collect_retained_versions  # type: ignore[attr-defined]
+    call_count = {"n": 0}
+
+    def patched(thread_id: str, checkpoint_ns: str) -> set[tuple[str, str]]:
+        retained: set[tuple[str, str]] = original_collect(thread_id, checkpoint_ns)
+        if call_count["n"] == 1:
+            saver.put(
+                cfg,
+                _checkpoint(
+                    "cp-003",
+                    channel_values={"k": 1},
+                    channel_versions={"k": "v1"},
+                ),
+                _metadata(step=3),
+                {},
+            )
+            retained = original_collect(thread_id, checkpoint_ns)
+        call_count["n"] += 1
+        return retained
+
+    saver._collect_retained_versions = patched  # type: ignore[attr-defined]
+
+    result = saver.collect_orphaned_values("t-1", checkpoint_ns="ns", dry_run=False)
+
+    assert "threads/t-1/ns/ns/values/k/v1.bin" in result.would_delete
+    assert result.deleted == []
+    assert "threads/t-1/ns/ns/values/k/v1.bin" in container.blobs
+
+
+def test_collect_orphaned_values_sweeps_all_namespaces(
+    saver_and_container: tuple[_CheckpointSaverProtocol, MockContainerClient],
+) -> None:
+    saver, container = saver_and_container
+    for ns in ("ns-a", "ns-b"):
+        cfg = _config(thread_id="t-1", checkpoint_ns=ns)
+        saver.put(
+            cfg,
+            _checkpoint("cp-001", channel_values={"k": 1}, channel_versions={"k": "v1"}),
+            _metadata(step=1),
+            {"k": "v1"},
+        )
+        saver.put(
+            cfg,
+            _checkpoint("cp-002", channel_values={"k": 2}, channel_versions={"k": "v2"}),
+            _metadata(step=2),
+            {"k": "v2"},
+        )
+        saver.delete_old_checkpoints("t-1", keep_last=1, checkpoint_ns=ns)
+
+    result = saver.collect_orphaned_values("t-1", dry_run=False)
+
+    assert sorted(result.deleted) == [
+        "threads/t-1/ns/ns-a/values/k/v1.bin",
+        "threads/t-1/ns/ns-b/values/k/v1.bin",
+    ]

--- a/tests/test_checkpointers_azure_blob.py
+++ b/tests/test_checkpointers_azure_blob.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
 import importlib
 import json
 import re
@@ -72,6 +73,7 @@ class _CheckpointSaverProtocol(Protocol):
         *,
         checkpoint_ns: str | None = None,
         dry_run: bool = True,
+        grace_period_seconds: int = 300,
     ) -> Any: ...
 
 
@@ -79,15 +81,20 @@ class FakeResourceNotFoundError(Exception):
     """Raised when a mock blob is not present."""
 
 
+_DEFAULT_BLOB_LAST_MODIFIED = datetime(2020, 1, 1, tzinfo=timezone.utc)
+
+
 @dataclass
 class _BlobRecord:
     data: bytes
     metadata: dict[str, str]
+    last_modified: datetime = field(default=_DEFAULT_BLOB_LAST_MODIFIED)
 
 
 @dataclass
 class _BlobItem:
     name: str
+    last_modified: datetime | None = None
 
 
 class _MockDownloadStream:
@@ -111,7 +118,13 @@ class MockBlobClient:
     def upload_blob(self, data: bytes, metadata: dict[str, str], overwrite: bool) -> None:
         if not overwrite and self._blob_name in self._container.blobs:
             raise ValueError("Blob already exists")
-        self._container.blobs[self._blob_name] = _BlobRecord(data=data, metadata=dict(metadata))
+        existing = self._container.blobs.get(self._blob_name)
+        last_modified = (
+            existing.last_modified if existing is not None else _DEFAULT_BLOB_LAST_MODIFIED
+        )
+        self._container.blobs[self._blob_name] = _BlobRecord(
+            data=data, metadata=dict(metadata), last_modified=last_modified
+        )
 
     def download_blob(self) -> _MockDownloadStream:
         record = self._container.blobs.get(self._blob_name)
@@ -140,7 +153,9 @@ class MockContainerClient:
 
     def list_blobs(self, name_starts_with: str = "") -> list[_BlobItem]:
         return [
-            _BlobItem(name=name) for name in sorted(self.blobs) if name.startswith(name_starts_with)
+            _BlobItem(name=name, last_modified=record.last_modified)
+            for name, record in sorted(self.blobs.items())
+            if name.startswith(name_starts_with)
         ]
 
 
@@ -900,8 +915,8 @@ def test_collect_orphaned_values_concurrent_write_protects_blob(
     original_collect = saver._collect_retained_versions  # type: ignore[attr-defined]
     call_count = {"n": 0}
 
-    def patched(thread_id: str, checkpoint_ns: str) -> set[tuple[str, str]]:
-        retained: set[tuple[str, str]] = original_collect(thread_id, checkpoint_ns)
+    def patched(thread_id: str, checkpoint_ns: str) -> set[tuple[str, str]] | None:
+        retained: set[tuple[str, str]] | None = original_collect(thread_id, checkpoint_ns)
         if call_count["n"] == 1:
             saver.put(
                 cfg,
@@ -952,3 +967,201 @@ def test_collect_orphaned_values_sweeps_all_namespaces(
         "threads/t-1/ns/ns-a/values/k/v1.bin",
         "threads/t-1/ns/ns-b/values/k/v1.bin",
     ]
+
+
+def _backdate_value_blobs(container: MockContainerClient, when: datetime) -> None:
+    """Backdate every values/* blob so the grace-period filter does not skip them.
+
+    Tests that exercise the orphan-collection logic on freshly-written
+    blobs need to opt out of the recent-write grace period; bulk-setting
+    last_modified is the cleanest way to do that without plumbing a
+    clock through every test fixture.
+    """
+    for name, record in container.blobs.items():
+        if "/values/" in name:
+            record.last_modified = when
+
+
+def test_collect_orphaned_values_skips_recent_blobs_inside_grace_window(
+    saver_and_container: tuple[_CheckpointSaverProtocol, MockContainerClient],
+) -> None:
+    saver, container = saver_and_container
+    cfg = _config(thread_id="t-1", checkpoint_ns="ns")
+    saver.put(
+        cfg,
+        _checkpoint("cp-001", channel_values={"k": 1}, channel_versions={"k": "v1"}),
+        _metadata(step=1),
+        {"k": "v1"},
+    )
+    saver.put(
+        cfg,
+        _checkpoint("cp-002", channel_values={"k": 2}, channel_versions={"k": "v2"}),
+        _metadata(step=2),
+        {"k": "v2"},
+    )
+    saver.delete_old_checkpoints("t-1", keep_last=1, checkpoint_ns="ns")
+    now = datetime.now(timezone.utc)
+    for record in container.blobs.values():
+        record.last_modified = now
+
+    result = saver.collect_orphaned_values("t-1", checkpoint_ns="ns", dry_run=False)
+
+    assert "threads/t-1/ns/ns/values/k/v1.bin" in result.skipped_recent
+    assert result.would_delete == []
+    assert result.deleted == []
+    assert "threads/t-1/ns/ns/values/k/v1.bin" in container.blobs
+
+
+def test_collect_orphaned_values_grace_period_zero_disables_recent_guard(
+    saver_and_container: tuple[_CheckpointSaverProtocol, MockContainerClient],
+) -> None:
+    saver, container = saver_and_container
+    cfg = _config(thread_id="t-1", checkpoint_ns="ns")
+    saver.put(
+        cfg,
+        _checkpoint("cp-001", channel_values={"k": 1}, channel_versions={"k": "v1"}),
+        _metadata(step=1),
+        {"k": "v1"},
+    )
+    saver.put(
+        cfg,
+        _checkpoint("cp-002", channel_values={"k": 2}, channel_versions={"k": "v2"}),
+        _metadata(step=2),
+        {"k": "v2"},
+    )
+    saver.delete_old_checkpoints("t-1", keep_last=1, checkpoint_ns="ns")
+    now = datetime.now(timezone.utc)
+    for record in container.blobs.values():
+        record.last_modified = now
+
+    result = saver.collect_orphaned_values(
+        "t-1", checkpoint_ns="ns", dry_run=False, grace_period_seconds=0
+    )
+
+    assert result.skipped_recent == []
+    assert "threads/t-1/ns/ns/values/k/v1.bin" in result.deleted
+    assert "threads/t-1/ns/ns/values/k/v1.bin" not in container.blobs
+
+
+def test_collect_orphaned_values_treats_missing_last_modified_as_recent(
+    saver_and_container: tuple[_CheckpointSaverProtocol, MockContainerClient],
+) -> None:
+    """A blob whose backend does not expose last_modified must not be
+    deleted at the default grace period — fail safe rather than guess."""
+    saver, container = saver_and_container
+    cfg = _config(thread_id="t-1", checkpoint_ns="ns")
+    saver.put(
+        cfg,
+        _checkpoint("cp-001", channel_values={"k": 1}, channel_versions={"k": "v1"}),
+        _metadata(step=1),
+        {"k": "v1"},
+    )
+    saver.put(
+        cfg,
+        _checkpoint("cp-002", channel_values={"k": 2}, channel_versions={"k": "v2"}),
+        _metadata(step=2),
+        {"k": "v2"},
+    )
+    saver.delete_old_checkpoints("t-1", keep_last=1, checkpoint_ns="ns")
+    original_list_blobs = container.list_blobs
+
+    def list_without_timestamp(name_starts_with: str = "") -> list[_BlobItem]:
+        return [
+            _BlobItem(name=item.name, last_modified=None)
+            for item in original_list_blobs(name_starts_with=name_starts_with)
+        ]
+
+    container.list_blobs = list_without_timestamp  # type: ignore[method-assign]
+
+    result = saver.collect_orphaned_values("t-1", checkpoint_ns="ns", dry_run=False)
+
+    assert "threads/t-1/ns/ns/values/k/v1.bin" in result.skipped_recent
+    assert result.deleted == []
+
+
+def test_collect_orphaned_values_fails_closed_on_corrupt_survivor(
+    saver_and_container: tuple[_CheckpointSaverProtocol, MockContainerClient],
+) -> None:
+    """A surviving checkpoint blob whose payload cannot be deserialized
+    makes the survivor set untrustworthy — the entire namespace must be
+    skipped rather than risk deleting still-referenced value blobs."""
+    saver, container = saver_and_container
+    cfg = _config(thread_id="t-1", checkpoint_ns="ns")
+    saver.put(
+        cfg,
+        _checkpoint("cp-001", channel_values={"k": 1}, channel_versions={"k": "v1"}),
+        _metadata(step=1),
+        {"k": "v1"},
+    )
+    saver.put(
+        cfg,
+        _checkpoint("cp-002", channel_values={"k": 2}, channel_versions={"k": "v2"}),
+        _metadata(step=2),
+        {"k": "v2"},
+    )
+    saver.delete_old_checkpoints("t-1", keep_last=1, checkpoint_ns="ns")
+    _backdate_value_blobs(container, datetime(2020, 1, 1, tzinfo=timezone.utc))
+    surviving_checkpoint_blob = "threads/t-1/ns/ns/checkpoints/cp-002/checkpoint.bin"
+    assert surviving_checkpoint_blob in container.blobs
+    container.blobs[surviving_checkpoint_blob] = _BlobRecord(
+        data=b"not-a-valid-msgpack-payload",
+        metadata=dict(container.blobs[surviving_checkpoint_blob].metadata),
+        last_modified=container.blobs[surviving_checkpoint_blob].last_modified,
+    )
+
+    result = saver.collect_orphaned_values("t-1", checkpoint_ns="ns", dry_run=False)
+
+    assert ("t-1", "ns") in result.skipped_namespaces
+    assert result.deleted == []
+    assert result.would_delete == []
+    assert "threads/t-1/ns/ns/values/k/v1.bin" in container.blobs
+
+
+def test_collect_orphaned_values_fails_closed_on_missing_serde_metadata(
+    saver_and_container: tuple[_CheckpointSaverProtocol, MockContainerClient],
+) -> None:
+    """When _download_typed_blob returns None for a listed survivor
+    (e.g. serde_type metadata stripped by an out-of-band tool) the
+    namespace must be skipped, not silently treated as 'no references'."""
+    saver, container = saver_and_container
+    cfg = _config(thread_id="t-1", checkpoint_ns="ns")
+    saver.put(
+        cfg,
+        _checkpoint("cp-001", channel_values={"k": 1}, channel_versions={"k": "v1"}),
+        _metadata(step=1),
+        {"k": "v1"},
+    )
+    saver.put(
+        cfg,
+        _checkpoint("cp-002", channel_values={"k": 2}, channel_versions={"k": "v2"}),
+        _metadata(step=2),
+        {"k": "v2"},
+    )
+    saver.delete_old_checkpoints("t-1", keep_last=1, checkpoint_ns="ns")
+    _backdate_value_blobs(container, datetime(2020, 1, 1, tzinfo=timezone.utc))
+    surviving_checkpoint_blob = "threads/t-1/ns/ns/checkpoints/cp-002/checkpoint.bin"
+    record = container.blobs[surviving_checkpoint_blob]
+    stripped_metadata = {k: v for k, v in record.metadata.items() if k != "serde_type"}
+    container.blobs[surviving_checkpoint_blob] = _BlobRecord(
+        data=record.data,
+        metadata=stripped_metadata,
+        last_modified=record.last_modified,
+    )
+
+    result = saver.collect_orphaned_values("t-1", checkpoint_ns="ns", dry_run=False)
+
+    assert ("t-1", "ns") in result.skipped_namespaces
+    assert result.deleted == []
+    assert "threads/t-1/ns/ns/values/k/v1.bin" in container.blobs
+
+
+def test_collect_orphaned_values_result_dataclass_has_skipped_recent_field() -> None:
+    """Public-API contract: callers depend on `skipped_recent` to audit
+    deferred deletions; verify the field is exported and defaults empty."""
+    module = importlib.import_module("azure_functions_langgraph.checkpointers.azure_blob")
+    result_cls = getattr(module, "OrphanedValueCollectionResult")
+    instance = result_cls(dry_run=True)
+    assert hasattr(instance, "skipped_recent")
+    assert instance.skipped_recent == []
+    package_module = importlib.import_module("azure_functions_langgraph.checkpointers")
+    assert getattr(package_module, "OrphanedValueCollectionResult") is result_cls


### PR DESCRIPTION
## Summary

Adds `AzureBlobCheckpointSaver.collect_orphaned_values()` — an opt-in, **dry-run-by-default** helper that closes the loop on the retention story documented in #154/#159: it walks the surviving checkpoints, computes the union of `(channel, version)` pairs they reference, and removes any `values/` blob outside that retained set.

## Public API

```python
audit = saver.collect_orphaned_values(thread_id="t-1")          # dry run by default
result = saver.collect_orphaned_values(thread_id="t-1", dry_run=False)
print(result.deleted, result.would_delete, result.skipped_namespaces)
```

`OrphanedValueCollectionResult` is exported from `azure_functions_langgraph.checkpointers`.

## Safety contract (verified by tests)

- **Per-namespace `latest.json` skip** — if the pointer cannot be loaded the namespace is skipped entirely and recorded in `result.skipped_namespaces` so the helper never deletes live data on a misconfigured store.
- **Set semantics** — a blob is preserved if **any** surviving checkpoint references its `(channel, version)`. Versions shared across checkpoints are never deleted as long as one owner survives.
- **Concurrency** — the survivor list is snapshotted, but each delete is preceded by a fresh per-namespace survivor re-scan, so a checkpoint written mid-collection still protects its referenced values. Such blobs appear in `would_delete` but not in `deleted`.
- **Dry-run parity** — `dry_run=True` returns the same `would_delete` list a `dry_run=False` pass over the same snapshot would attempt to delete, without mutating storage.

## Tests

New cases in `tests/test_checkpointers_azure_blob.py`:

- Single checkpoint → no orphans.
- Two checkpoints sharing `(channel, version)` → shared value preserved when an owner survives.
- Versions referenced only by deleted checkpoints → collected.
- Concurrent checkpoint write referencing a candidate → blob protected, ends up in `would_delete` but not `deleted`.
- `dry_run=True` returns the same list as `dry_run=False` would delete, mutates nothing.
- Sweeps all namespaces under a thread when `checkpoint_ns=None`.
- `latest.json` missing → namespace skipped, nothing deleted.

## Documentation

- README: new *Garbage-collecting orphaned channel values* subsection with dry-run + real-run examples and the concurrency contract.
- Retention helper docstrings (`delete_old_checkpoints`, `delete_checkpoints_before`) cross-link to `collect_orphaned_values` as the second step.

## Out of scope

- Cross-thread shared values (LangGraph checkpoints are per-thread).
- Automatic scheduling — provide the helper, let users wire it into their own Timer Trigger.
- Equivalent helper for Azure Table or other backends.

## Stacking

Branched from `docs/p0-orphan-blob-warning` (PR #159 / issue #154). Merge #159 first; this PR's diff against `main` will then collapse to just the GC implementation and its docs.

## Validation

- `make lint`
- `make typecheck`
- `make test` — 746 passed, coverage 91.92%

Closes #153