### PR TITLE
feat(checkpointers): add Postgres and SQLite DB checkpointer DX helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,6 +349,35 @@ saver.delete_checkpoints_before(
 
 Both helpers preserve channel value blobs and the `latest.json` pointer, so retained checkpoints remain fully usable.
 
+#### DB checkpointer backends
+
+For workloads that already run a managed database (or need state shared across multiple Function instances), thin DX helpers wrap the official LangGraph DB checkpoint packages without reimplementing storage:
+
+| Backend | Helper | Extra | When to use |
+| --- | --- | --- | --- |
+| Postgres | `create_postgres_checkpointer` | `pip install azure-functions-langgraph[postgres]` | Production, multi-instance, existing Postgres infra |
+| SQLite | `create_sqlite_checkpointer` | `pip install azure-functions-langgraph[sqlite]` | Local dev and single-instance deployments |
+
+Each helper accepts a connection string, owns the connection lifetime, and (by default) calls upstream `setup()` on cold start so the checkpoint tables exist:
+
+```python
+import os
+from azure_functions_langgraph.checkpointers.postgres import create_postgres_checkpointer
+
+checkpointer = create_postgres_checkpointer(
+    os.environ["LANGGRAPH_POSTGRES_CONNECTION_STRING"],
+    setup=True,  # set False once your deployment pipeline owns migrations
+)
+graph = builder.compile(checkpointer=checkpointer)
+```
+
+The helpers do not hide `builder.compile(checkpointer=...)` and do not reimplement DB checkpoint storage — they only centralize the env-var convention, run `setup()` once, and emit clear ImportErrors pointing at the right extra. See [`examples/postgres_checkpoint_production/`](examples/postgres_checkpoint_production/) and [`examples/sqlite_checkpoint_local/`](examples/sqlite_checkpoint_local/) for full Azure-Functions wiring.
+
+| Backend | Comfortable | Caution zone | Switch backends |
+| --- | --- | --- | --- |
+| `create_sqlite_checkpointer` | local dev, single-instance prod | multi-process write contention | Use Postgres |
+| `create_postgres_checkpointer` | multi-instance Functions, existing Postgres infra | very high write QPS without read replicas | Add connection pooling / read replicas, or shard |
+
 ### Upgrading
 
 #### v0.3.0 → v0.4.0

--- a/examples/README.md
+++ b/examples/README.md
@@ -7,6 +7,8 @@
 | Minimal | [`simple_agent`](simple_agent/) | Two-node greeting agent with sequential edges. |
 | Platform SDK | [`platform_compat_sdk`](platform_compat_sdk/) ⭐ | `platform_compat=True` host driven by the official `langgraph-sdk` client. |
 | Persistent storage | [`persistent_agent_blob_table`](persistent_agent_blob_table/) | End-to-end Azure Blob checkpointer + Azure Table thread store, runnable on Azurite. |
+| DB checkpoint (local) | [`sqlite_checkpoint_local`](sqlite_checkpoint_local/) | LangGraph SQLite checkpointer wired via `create_sqlite_checkpointer()` for local dev. |
+| DB checkpoint (production) | [`postgres_checkpoint_production`](postgres_checkpoint_production/) | LangGraph Postgres checkpointer wired via `create_postgres_checkpointer()` for multi-instance prod. |
 | OpenAPI bridge | [`openapi_bridge`](openapi_bridge/) | Wires `register_with_openapi` into `azure-functions-openapi-python` for spec generation. |
 | Per-graph auth | [`production_auth`](production_auth/) | Public health + anonymous demo graph alongside a function-key-protected graph. |
 | Curl helpers | [`local_curl`](local_curl/) | Shell scripts for hitting every Quick Start endpoint locally. |

--- a/examples/postgres_checkpoint_production/README.md
+++ b/examples/postgres_checkpoint_production/README.md
@@ -1,0 +1,71 @@
+# Postgres checkpoint (production)
+
+Production-oriented example using `create_postgres_checkpointer()` to
+persist LangGraph state in Postgres (Azure Database for PostgreSQL,
+Supabase, RDS, or self-hosted). Suitable for multi-instance Azure
+Functions deployments where SQLite cannot be shared across workers.
+
+## Files
+
+- `function_app.py` — wires `PostgresSaver` via the bundled DX helper, env-var driven
+- `graph.py` — turn-counting echo agent
+- `host.json`, `local.settings.json.example`, `requirements.txt`
+
+## Run locally
+
+Bring up a Postgres instance (Docker is the fastest path):
+
+```bash
+docker run -d --name pg-langgraph \
+  -e POSTGRES_PASSWORD=postgres \
+  -e POSTGRES_DB=langgraph \
+  -p 5432:5432 \
+  postgres:16
+```
+
+Then:
+
+```bash
+cd examples/postgres_checkpoint_production
+cp local.settings.json.example local.settings.json
+pip install -r requirements.txt
+func start
+```
+
+## Configuration
+
+| Setting | Required | Description |
+| --- | --- | --- |
+| `LANGGRAPH_POSTGRES_CONNECTION_STRING` | yes | psycopg-compatible connection string. Example: `postgresql://user:pass@host:5432/db` (add `?sslmode=require` for Azure Database for PostgreSQL). |
+| `LANGGRAPH_POSTGRES_SETUP` | no (default `true`) | Run `setup()` on cold start to create / migrate the checkpoint tables. Set to `false` if migrations are managed out-of-band (e.g. by a deployment pipeline). |
+
+## Verify persistence
+
+```bash
+THREAD=$(curl -s -X POST "http://localhost:7071/api/threads?code=$KEY" \
+  -H "Content-Type: application/json" -d '{}' \
+  | python -c 'import json,sys; print(json.load(sys.stdin)["thread_id"])')
+
+curl -s -X POST "http://localhost:7071/api/threads/$THREAD/runs/wait?code=$KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"assistant_id":"postgres_agent","input":{"messages":[{"role":"human","content":"first"}]}}'
+
+curl -s -X POST "http://localhost:7071/api/threads/$THREAD/runs/wait?code=$KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"assistant_id":"postgres_agent","input":{"messages":[{"role":"human","content":"second"}]}}'
+```
+
+The second response shows `[turn 2]`. Restart `func start` (or scale to
+multiple instances) and the counter still increments because state
+lives in Postgres.
+
+## Production tips
+
+- Set `LANGGRAPH_POSTGRES_SETUP=false` once your deployment pipeline
+  owns migrations — re-running `setup()` on every cold start is safe
+  but unnecessary in production.
+- Use Azure Database for PostgreSQL with Managed Identity authentication
+  by composing the connection string from the Managed Identity token at
+  startup.
+- Pair with `examples/maintenance_timer/` if you also use
+  `AzureTableThreadStore` for thread metadata.

--- a/examples/postgres_checkpoint_production/function_app.py
+++ b/examples/postgres_checkpoint_production/function_app.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import os
+
+from graph import build_graph
+
+import azure.functions as func
+
+from azure_functions_langgraph import LangGraphApp
+from azure_functions_langgraph.checkpointers.postgres import create_postgres_checkpointer
+
+_CONN_STRING = os.environ["LANGGRAPH_POSTGRES_CONNECTION_STRING"]
+_RUN_SETUP = os.environ.get("LANGGRAPH_POSTGRES_SETUP", "true").lower() == "true"
+
+checkpointer = create_postgres_checkpointer(_CONN_STRING, setup=_RUN_SETUP)
+compiled_graph = build_graph().compile(checkpointer=checkpointer)
+
+langgraph_app = LangGraphApp(
+    platform_compat=True,
+    auth_level=func.AuthLevel.FUNCTION,
+)
+langgraph_app.register(
+    graph=compiled_graph,
+    name="postgres_agent",
+    description="Echo agent persisted with the bundled Postgres checkpointer DX helper.",
+)
+
+app = langgraph_app.function_app

--- a/examples/postgres_checkpoint_production/graph.py
+++ b/examples/postgres_checkpoint_production/graph.py
@@ -1,0 +1,31 @@
+"""Compiled graph for the postgres_checkpoint_production example."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from langgraph.graph import END, START, StateGraph
+from typing_extensions import TypedDict
+
+
+class AgentState(TypedDict):
+    messages: list[dict[str, str]]
+    turn: int
+
+
+def respond(state: AgentState) -> dict[str, Any]:
+    user_msg = state["messages"][-1]["content"] if state["messages"] else ""
+    turn = state.get("turn", 0) + 1
+    return {
+        "messages": state["messages"]
+        + [{"role": "assistant", "content": f"[turn {turn}] Echo: {user_msg}"}],
+        "turn": turn,
+    }
+
+
+def build_graph() -> StateGraph:
+    builder = StateGraph(AgentState)
+    builder.add_node("respond", respond)
+    builder.add_edge(START, "respond")
+    builder.add_edge("respond", END)
+    return builder

--- a/examples/postgres_checkpoint_production/host.json
+++ b/examples/postgres_checkpoint_production/host.json
@@ -1,0 +1,15 @@
+{
+  "version": "2.0",
+  "logging": {
+    "applicationInsights": {
+      "samplingSettings": {
+        "isEnabled": true,
+        "excludedTypes": "Request"
+      }
+    }
+  },
+  "extensionBundle": {
+    "id": "Microsoft.Azure.Functions.ExtensionBundle",
+    "version": "[4.*, 5.0.0)"
+  }
+}

--- a/examples/postgres_checkpoint_production/local.settings.json.example
+++ b/examples/postgres_checkpoint_production/local.settings.json.example
@@ -1,0 +1,9 @@
+{
+  "IsEncrypted": false,
+  "Values": {
+    "AzureWebJobsStorage": "UseDevelopmentStorage=true",
+    "FUNCTIONS_WORKER_RUNTIME": "python",
+    "LANGGRAPH_POSTGRES_CONNECTION_STRING": "postgresql://postgres:postgres@localhost:5432/langgraph",
+    "LANGGRAPH_POSTGRES_SETUP": "true"
+  }
+}

--- a/examples/postgres_checkpoint_production/requirements.txt
+++ b/examples/postgres_checkpoint_production/requirements.txt
@@ -1,0 +1,7 @@
+# Do not include azure-functions-worker in this file
+# The Python Worker is managed by the Azure Functions platform
+
+azure-functions
+azure-functions-langgraph[postgres]>=0.6.0,<0.7.0
+langgraph>=1.0,<2.0
+langchain-core>=1.0,<2.0

--- a/examples/sqlite_checkpoint_local/README.md
+++ b/examples/sqlite_checkpoint_local/README.md
@@ -1,0 +1,53 @@
+# SQLite checkpoint (local)
+
+Local-development example using `create_sqlite_checkpointer()` to persist
+LangGraph state in a single on-disk SQLite file. Zero external services
+required — just a writeable path.
+
+## Files
+
+- `function_app.py` — wires `SqliteSaver` via the bundled DX helper
+- `graph.py` — turn-counting echo agent
+- `host.json`, `local.settings.json.example`, `requirements.txt`
+
+## Run locally
+
+```bash
+cd examples/sqlite_checkpoint_local
+cp local.settings.json.example local.settings.json
+pip install -r requirements.txt
+func start
+```
+
+The helper opens the SQLite file (creating it if absent) and runs
+`SqliteSaver.setup()` once on cold start. Override `LANGGRAPH_SQLITE_PATH`
+in `local.settings.json` to choose a different file location.
+
+## Verify persistence
+
+```bash
+THREAD=$(curl -s -X POST http://localhost:7071/api/threads \
+  -H "Content-Type: application/json" -d '{}' \
+  | python -c 'import json,sys; print(json.load(sys.stdin)["thread_id"])')
+
+curl -s -X POST "http://localhost:7071/api/threads/$THREAD/runs/wait" \
+  -H "Content-Type: application/json" \
+  -d '{"assistant_id":"sqlite_agent","input":{"messages":[{"role":"human","content":"first"}]}}'
+
+curl -s -X POST "http://localhost:7071/api/threads/$THREAD/runs/wait" \
+  -H "Content-Type: application/json" \
+  -d '{"assistant_id":"sqlite_agent","input":{"messages":[{"role":"human","content":"second"}]}}'
+```
+
+The second response shows `[turn 2]`. Restart `func start` and the
+counter still increments because state lives in the SQLite file.
+
+## When to use
+
+- Local development and demos.
+- Single-instance deployments where the SQLite file lives on persistent
+  storage (App Service mounted volume, container volume, etc.).
+
+For multi-instance Azure Functions deployments, use the Postgres helper
+(`examples/postgres_checkpoint_production/`) or the Azure Blob
+checkpointer (`examples/persistent_agent_blob_table/`) instead.

--- a/examples/sqlite_checkpoint_local/function_app.py
+++ b/examples/sqlite_checkpoint_local/function_app.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import os
+
+from graph import build_graph
+
+import azure.functions as func
+
+from azure_functions_langgraph import LangGraphApp
+from azure_functions_langgraph.checkpointers.sqlite import create_sqlite_checkpointer
+
+_DB_PATH = os.environ.get("LANGGRAPH_SQLITE_PATH", "/tmp/langgraph_checkpoints.sqlite")
+_RUN_SETUP = os.environ.get("LANGGRAPH_SQLITE_SETUP", "true").lower() == "true"
+
+checkpointer = create_sqlite_checkpointer(_DB_PATH, setup=_RUN_SETUP)
+compiled_graph = build_graph().compile(checkpointer=checkpointer)
+
+langgraph_app = LangGraphApp(
+    platform_compat=True,
+    auth_level=func.AuthLevel.ANONYMOUS,
+)
+langgraph_app.register(
+    graph=compiled_graph,
+    name="sqlite_agent",
+    description="Echo agent persisted with the bundled SQLite checkpointer DX helper.",
+)
+
+app = langgraph_app.function_app

--- a/examples/sqlite_checkpoint_local/graph.py
+++ b/examples/sqlite_checkpoint_local/graph.py
@@ -1,0 +1,31 @@
+"""Compiled graph for the sqlite_checkpoint_local example."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from langgraph.graph import END, START, StateGraph
+from typing_extensions import TypedDict
+
+
+class AgentState(TypedDict):
+    messages: list[dict[str, str]]
+    turn: int
+
+
+def respond(state: AgentState) -> dict[str, Any]:
+    user_msg = state["messages"][-1]["content"] if state["messages"] else ""
+    turn = state.get("turn", 0) + 1
+    return {
+        "messages": state["messages"]
+        + [{"role": "assistant", "content": f"[turn {turn}] Echo: {user_msg}"}],
+        "turn": turn,
+    }
+
+
+def build_graph() -> StateGraph:
+    builder = StateGraph(AgentState)
+    builder.add_node("respond", respond)
+    builder.add_edge(START, "respond")
+    builder.add_edge("respond", END)
+    return builder

--- a/examples/sqlite_checkpoint_local/host.json
+++ b/examples/sqlite_checkpoint_local/host.json
@@ -1,0 +1,15 @@
+{
+  "version": "2.0",
+  "logging": {
+    "applicationInsights": {
+      "samplingSettings": {
+        "isEnabled": true,
+        "excludedTypes": "Request"
+      }
+    }
+  },
+  "extensionBundle": {
+    "id": "Microsoft.Azure.Functions.ExtensionBundle",
+    "version": "[4.*, 5.0.0)"
+  }
+}

--- a/examples/sqlite_checkpoint_local/local.settings.json.example
+++ b/examples/sqlite_checkpoint_local/local.settings.json.example
@@ -1,0 +1,9 @@
+{
+  "IsEncrypted": false,
+  "Values": {
+    "AzureWebJobsStorage": "UseDevelopmentStorage=true",
+    "FUNCTIONS_WORKER_RUNTIME": "python",
+    "LANGGRAPH_SQLITE_PATH": "/tmp/langgraph_checkpoints.sqlite",
+    "LANGGRAPH_SQLITE_SETUP": "true"
+  }
+}

--- a/examples/sqlite_checkpoint_local/requirements.txt
+++ b/examples/sqlite_checkpoint_local/requirements.txt
@@ -1,0 +1,7 @@
+# Do not include azure-functions-worker in this file
+# The Python Worker is managed by the Azure Functions platform
+
+azure-functions
+azure-functions-langgraph[sqlite]>=0.6.0,<0.7.0
+langgraph>=1.0,<2.0
+langchain-core>=1.0,<2.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,13 @@ azure-blob = [
 azure-table = [
     "azure-data-tables>=12.0,<13",
 ]
+postgres = [
+    "langgraph-checkpoint-postgres>=3.0,<4",
+    "psycopg[binary]>=3.0,<4",
+]
+sqlite = [
+    "langgraph-checkpoint-sqlite>=3.0,<4",
+]
 dev = [
     "bandit==1.9.4",
     "build",

--- a/src/azure_functions_langgraph/__init__.py
+++ b/src/azure_functions_langgraph/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-__version__ = "0.5.4"
+__version__ = "0.6.0"
 
 if TYPE_CHECKING:
     from azure_functions_langgraph.app import LangGraphApp, get_langgraph_metadata

--- a/src/azure_functions_langgraph/checkpointers/__init__.py
+++ b/src/azure_functions_langgraph/checkpointers/__init__.py
@@ -8,16 +8,28 @@ if TYPE_CHECKING:
     from .azure_blob import (
         AzureBlobCheckpointSaver,
     )
+    from .postgres import create_postgres_checkpointer
+    from .sqlite import create_sqlite_checkpointer
 
 
 def __getattr__(name: str) -> object:
     if name == "AzureBlobCheckpointSaver":
-        from .azure_blob import (
-            AzureBlobCheckpointSaver,
-        )
+        from .azure_blob import AzureBlobCheckpointSaver
 
         return AzureBlobCheckpointSaver
+    if name == "create_postgres_checkpointer":
+        from .postgres import create_postgres_checkpointer
+
+        return create_postgres_checkpointer
+    if name == "create_sqlite_checkpointer":
+        from .sqlite import create_sqlite_checkpointer
+
+        return create_sqlite_checkpointer
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
-__all__ = ["AzureBlobCheckpointSaver"]
+__all__ = [
+    "AzureBlobCheckpointSaver",
+    "create_postgres_checkpointer",
+    "create_sqlite_checkpointer",
+]

--- a/src/azure_functions_langgraph/checkpointers/postgres.py
+++ b/src/azure_functions_langgraph/checkpointers/postgres.py
@@ -1,0 +1,110 @@
+"""Postgres checkpointer DX helper.
+
+.. versionadded:: 0.6.0
+
+Thin wrapper around the upstream :mod:`langgraph.checkpoint.postgres`
+package that owns the connection lifetime so the resulting saver can be
+attached to a graph at module import time (the standard Azure Functions
+cold-start pattern).
+
+This module deliberately does **not** reimplement Postgres checkpoint
+storage. It centralizes the env-var / connection-string convention,
+runs ``setup()`` on cold start, and emits a clear ImportError pointing
+at the right extra when the upstream package is missing.
+"""
+
+from __future__ import annotations
+
+import importlib
+import logging
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from langgraph.checkpoint.postgres import PostgresSaver
+
+logger = logging.getLogger(__name__)
+
+_EXTRA_HINT = (
+    "Postgres checkpointer requires the 'postgres' extra: "
+    "pip install azure-functions-langgraph[postgres]"
+)
+
+
+def create_postgres_checkpointer(
+    conn_string: str,
+    *,
+    setup: bool = True,
+    autocommit: bool = True,
+    prepare_threshold: int | None = 0,
+) -> PostgresSaver:
+    """Create a long-lived :class:`PostgresSaver` from a connection string.
+
+    Opens a single :class:`psycopg.Connection` owned by the returned
+    saver and (by default) runs ``setup()`` once so the migrations table
+    and checkpoint tables exist. Intended for use at Azure Functions
+    cold-start, where a single saver is attached to a registered graph
+    for the lifetime of the worker process.
+
+    Args:
+        conn_string: psycopg-compatible connection string (e.g.
+            ``postgresql://user:pass@host/db``).
+        setup: When ``True`` (default), call ``saver.setup()`` after
+            constructing it. Set to ``False`` if migrations are managed
+            out-of-band (e.g. by a deployment pipeline).
+        autocommit: Forwarded to :meth:`psycopg.Connection.connect`.
+            ``True`` matches the upstream :meth:`PostgresSaver.from_conn_string`
+            default and is required for ``setup()`` DDL to take effect
+            without an explicit transaction.
+        prepare_threshold: Forwarded to :meth:`psycopg.Connection.connect`.
+            Defaults to ``0`` to match upstream and avoid accidentally
+            preparing every statement.
+
+    Returns:
+        A :class:`PostgresSaver` ready to be passed to
+        ``builder.compile(checkpointer=...)``.
+
+    Raises:
+        ImportError: If ``langgraph-checkpoint-postgres`` or ``psycopg``
+            is not installed. Install via the ``postgres`` extra.
+    """
+    try:
+        postgres_module = importlib.import_module("langgraph.checkpoint.postgres")
+    except ImportError as exc:
+        raise ImportError(_EXTRA_HINT) from exc
+
+    try:
+        psycopg_module = importlib.import_module("psycopg")
+    except ImportError as exc:
+        raise ImportError(_EXTRA_HINT) from exc
+
+    PostgresSaver = getattr(postgres_module, "PostgresSaver", None)
+    if PostgresSaver is None:
+        raise ImportError(
+            "langgraph.checkpoint.postgres is missing PostgresSaver; "
+            "upgrade langgraph-checkpoint-postgres to >=3.0,<4."
+        )
+
+    Connection = getattr(psycopg_module, "Connection", None)
+    if Connection is None:
+        raise ImportError("psycopg is missing Connection; upgrade psycopg to >=3.0,<4.")
+
+    rows_module = importlib.import_module("psycopg.rows")
+    dict_row = getattr(rows_module, "dict_row", None)
+    if dict_row is None:
+        raise ImportError("psycopg.rows is missing dict_row; upgrade psycopg to >=3.0,<4.")
+
+    connect_kwargs: dict[str, Any] = {
+        "autocommit": autocommit,
+        "row_factory": dict_row,
+    }
+    if prepare_threshold is not None:
+        connect_kwargs["prepare_threshold"] = prepare_threshold
+
+    conn = Connection.connect(conn_string, **connect_kwargs)
+    saver = PostgresSaver(conn)
+    if setup:
+        saver.setup()
+    return saver
+
+
+__all__ = ["create_postgres_checkpointer"]

--- a/src/azure_functions_langgraph/checkpointers/postgres.py
+++ b/src/azure_functions_langgraph/checkpointers/postgres.py
@@ -56,8 +56,14 @@ def create_postgres_checkpointer(
             default and is required for ``setup()`` DDL to take effect
             without an explicit transaction.
         prepare_threshold: Forwarded to :meth:`psycopg.Connection.connect`.
-            Defaults to ``0`` to match upstream and avoid accidentally
-            preparing every statement.
+            Defaults to ``0`` to match upstream
+            :meth:`PostgresSaver.from_conn_string`. In psycopg, ``0`` means
+            **prepare every query on first execution** (eager preparation,
+            best for the LangGraph checkpoint workload of repeated identical
+            statements). Pass ``None`` to disable prepared statements
+            entirely (e.g. behind PgBouncer in transaction pooling mode,
+            which does not preserve prepared-statement state across
+            client connections).
 
     Returns:
         A :class:`PostgresSaver` ready to be passed to
@@ -88,7 +94,10 @@ def create_postgres_checkpointer(
     if Connection is None:
         raise ImportError("psycopg is missing Connection; upgrade psycopg to >=3.0,<4.")
 
-    rows_module = importlib.import_module("psycopg.rows")
+    try:
+        rows_module = importlib.import_module("psycopg.rows")
+    except ImportError as exc:
+        raise ImportError(_EXTRA_HINT) from exc
     dict_row = getattr(rows_module, "dict_row", None)
     if dict_row is None:
         raise ImportError("psycopg.rows is missing dict_row; upgrade psycopg to >=3.0,<4.")

--- a/src/azure_functions_langgraph/checkpointers/sqlite.py
+++ b/src/azure_functions_langgraph/checkpointers/sqlite.py
@@ -1,0 +1,81 @@
+"""SQLite checkpointer DX helper.
+
+.. versionadded:: 0.6.0
+
+Thin wrapper around the upstream :mod:`langgraph.checkpoint.sqlite`
+package that owns the connection lifetime so the resulting saver can be
+attached to a graph at module import time. Primarily intended for local
+development and single-instance deployments — for production multi-worker
+workloads, prefer :func:`create_postgres_checkpointer`.
+"""
+
+from __future__ import annotations
+
+import importlib
+import logging
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from langgraph.checkpoint.sqlite import SqliteSaver
+
+logger = logging.getLogger(__name__)
+
+_EXTRA_HINT = (
+    "SQLite checkpointer requires the 'sqlite' extra: "
+    "pip install azure-functions-langgraph[sqlite]"
+)
+
+
+def create_sqlite_checkpointer(
+    conn_string: str,
+    *,
+    setup: bool = True,
+    check_same_thread: bool = False,
+) -> SqliteSaver:
+    """Create a long-lived :class:`SqliteSaver` from a connection string.
+
+    Opens a single :class:`sqlite3.Connection` owned by the returned
+    saver and (by default) runs ``setup()`` once so the checkpoint
+    tables exist.
+
+    Args:
+        conn_string: SQLite path (e.g. ``"checkpoints.sqlite"``) or
+            ``":memory:"``.
+        setup: When ``True`` (default), call ``saver.setup()`` after
+            constructing it.
+        check_same_thread: Forwarded to :func:`sqlite3.connect`.
+            Defaults to ``False`` to match upstream
+            :meth:`SqliteSaver.from_conn_string`, which intentionally
+            disables SQLite's same-thread check so the connection can be
+            shared across the worker thread pool. See
+            https://ricardoanderegg.com/posts/python-sqlite-thread-safety/
+
+    Returns:
+        A :class:`SqliteSaver` ready to be passed to
+        ``builder.compile(checkpointer=...)``.
+
+    Raises:
+        ImportError: If ``langgraph-checkpoint-sqlite`` is not
+            installed. Install via the ``sqlite`` extra.
+    """
+    try:
+        sqlite_module = importlib.import_module("langgraph.checkpoint.sqlite")
+    except ImportError as exc:
+        raise ImportError(_EXTRA_HINT) from exc
+
+    SqliteSaver = getattr(sqlite_module, "SqliteSaver", None)
+    if SqliteSaver is None:
+        raise ImportError(
+            "langgraph.checkpoint.sqlite is missing SqliteSaver; "
+            "upgrade langgraph-checkpoint-sqlite to >=3.0,<4."
+        )
+
+    sqlite3_module = importlib.import_module("sqlite3")
+    conn = sqlite3_module.connect(conn_string, check_same_thread=check_same_thread)
+    saver = SqliteSaver(conn)
+    if setup:
+        saver.setup()
+    return saver
+
+
+__all__ = ["create_sqlite_checkpointer"]

--- a/tests/test_checkpointers_db_helpers.py
+++ b/tests/test_checkpointers_db_helpers.py
@@ -104,7 +104,9 @@ def test_postgres_helper_opens_connection_and_runs_setup(monkeypatch: Any) -> No
     assert connect_calls[0]["autocommit"] is True
     assert connect_calls[0]["prepare_threshold"] == 0
     assert "row_factory" in connect_calls[0]
+    assert type(saver).__name__ == "FakePostgresSaver"
     assert hasattr(saver, "conn")
+    assert saver.conn is not None
 
 
 def test_postgres_helper_setup_false_skips_setup(monkeypatch: Any) -> None:
@@ -158,6 +160,24 @@ def test_postgres_helper_missing_psycopg_raises_helpful_error(monkeypatch: Any) 
 
     def fake_import_module(name: str) -> Any:
         if name == "psycopg":
+            raise ImportError("missing")
+        return real_import_module(name)
+
+    monkeypatch.setattr(module.importlib, "import_module", fake_import_module)
+
+    with pytest.raises(ImportError, match=r"\[postgres\]"):
+        module.create_postgres_checkpointer("postgresql://u:p@h/db")
+
+
+def test_postgres_helper_missing_psycopg_rows_module_raises(monkeypatch: Any) -> None:
+    _install_fake_postgres(monkeypatch)
+    module = importlib.import_module("azure_functions_langgraph.checkpointers.postgres")
+    importlib.reload(module)
+
+    real_import_module = importlib.import_module
+
+    def fake_import_module(name: str) -> Any:
+        if name == "psycopg.rows":
             raise ImportError("missing")
         return real_import_module(name)
 

--- a/tests/test_checkpointers_db_helpers.py
+++ b/tests/test_checkpointers_db_helpers.py
@@ -1,0 +1,266 @@
+from __future__ import annotations
+
+import importlib
+import sqlite3
+import sys
+import types
+from typing import Any, cast
+
+pytest = cast(Any, importlib.import_module("pytest"))
+
+
+def _install_fake_postgres(
+    monkeypatch: Any,
+    *,
+    saver_setup_calls: list[int] | None = None,
+    connect_calls: list[dict[str, Any]] | None = None,
+    omit_postgres_saver: bool = False,
+    omit_psycopg_connection: bool = False,
+    omit_dict_row: bool = False,
+) -> None:
+    captured_setup = saver_setup_calls if saver_setup_calls is not None else []
+    captured_connect = connect_calls if connect_calls is not None else []
+
+    class FakeConnection:
+        @classmethod
+        def connect(cls, conn_string: str, **kwargs: Any) -> Any:
+            captured_connect.append({"conn_string": conn_string, **kwargs})
+            return cls()
+
+    class FakePostgresSaver:
+        def __init__(self, conn: Any) -> None:
+            self.conn = conn
+            self.setup_calls = 0
+
+        def setup(self) -> None:
+            self.setup_calls += 1
+            captured_setup.append(self.setup_calls)
+
+    postgres_module = types.ModuleType("langgraph.checkpoint.postgres")
+    if not omit_postgres_saver:
+        setattr(postgres_module, "PostgresSaver", FakePostgresSaver)
+
+    psycopg_module = types.ModuleType("psycopg")
+    if not omit_psycopg_connection:
+        setattr(psycopg_module, "Connection", FakeConnection)
+
+    rows_module = types.ModuleType("psycopg.rows")
+    if not omit_dict_row:
+        setattr(rows_module, "dict_row", object())
+
+    monkeypatch.setitem(sys.modules, "langgraph", types.ModuleType("langgraph"))
+    monkeypatch.setitem(
+        sys.modules, "langgraph.checkpoint", types.ModuleType("langgraph.checkpoint")
+    )
+    monkeypatch.setitem(sys.modules, "langgraph.checkpoint.postgres", postgres_module)
+    monkeypatch.setitem(sys.modules, "psycopg", psycopg_module)
+    monkeypatch.setitem(sys.modules, "psycopg.rows", rows_module)
+
+
+def _install_fake_sqlite(
+    monkeypatch: Any,
+    *,
+    omit_sqlite_saver: bool = False,
+) -> list[Any]:
+    constructed: list[Any] = []
+
+    class FakeSqliteSaver:
+        def __init__(self, conn: sqlite3.Connection) -> None:
+            self.conn = conn
+            self.setup_calls = 0
+            constructed.append(self)
+
+        def setup(self) -> None:
+            self.setup_calls += 1
+
+    sqlite_module = types.ModuleType("langgraph.checkpoint.sqlite")
+    if not omit_sqlite_saver:
+        setattr(sqlite_module, "SqliteSaver", FakeSqliteSaver)
+
+    monkeypatch.setitem(sys.modules, "langgraph", types.ModuleType("langgraph"))
+    monkeypatch.setitem(
+        sys.modules, "langgraph.checkpoint", types.ModuleType("langgraph.checkpoint")
+    )
+    monkeypatch.setitem(sys.modules, "langgraph.checkpoint.sqlite", sqlite_module)
+    return constructed
+
+
+def test_postgres_helper_opens_connection_and_runs_setup(monkeypatch: Any) -> None:
+    setup_calls: list[int] = []
+    connect_calls: list[dict[str, Any]] = []
+    _install_fake_postgres(
+        monkeypatch,
+        saver_setup_calls=setup_calls,
+        connect_calls=connect_calls,
+    )
+
+    module = importlib.import_module("azure_functions_langgraph.checkpointers.postgres")
+    importlib.reload(module)
+    saver = module.create_postgres_checkpointer("postgresql://u:p@h/db")
+
+    assert setup_calls == [1]
+    assert len(connect_calls) == 1
+    assert connect_calls[0]["conn_string"] == "postgresql://u:p@h/db"
+    assert connect_calls[0]["autocommit"] is True
+    assert connect_calls[0]["prepare_threshold"] == 0
+    assert "row_factory" in connect_calls[0]
+    assert hasattr(saver, "conn")
+
+
+def test_postgres_helper_setup_false_skips_setup(monkeypatch: Any) -> None:
+    setup_calls: list[int] = []
+    _install_fake_postgres(monkeypatch, saver_setup_calls=setup_calls)
+
+    module = importlib.import_module("azure_functions_langgraph.checkpointers.postgres")
+    importlib.reload(module)
+    module.create_postgres_checkpointer("postgresql://u:p@h/db", setup=False)
+
+    assert setup_calls == []
+
+
+def test_postgres_helper_forwards_autocommit_and_prepare_threshold(monkeypatch: Any) -> None:
+    connect_calls: list[dict[str, Any]] = []
+    _install_fake_postgres(monkeypatch, connect_calls=connect_calls)
+
+    module = importlib.import_module("azure_functions_langgraph.checkpointers.postgres")
+    importlib.reload(module)
+    module.create_postgres_checkpointer(
+        "postgresql://u:p@h/db",
+        autocommit=False,
+        prepare_threshold=None,
+    )
+
+    assert connect_calls[0]["autocommit"] is False
+    assert "prepare_threshold" not in connect_calls[0]
+
+
+def test_postgres_helper_missing_langgraph_postgres_raises_helpful_error(monkeypatch: Any) -> None:
+    module = importlib.import_module("azure_functions_langgraph.checkpointers.postgres")
+    real_import_module = importlib.import_module
+
+    def fake_import_module(name: str) -> Any:
+        if name == "langgraph.checkpoint.postgres":
+            raise ImportError("missing")
+        return real_import_module(name)
+
+    monkeypatch.setattr(module.importlib, "import_module", fake_import_module)
+
+    with pytest.raises(ImportError, match=r"\[postgres\]"):
+        module.create_postgres_checkpointer("postgresql://u:p@h/db")
+
+
+def test_postgres_helper_missing_psycopg_raises_helpful_error(monkeypatch: Any) -> None:
+    _install_fake_postgres(monkeypatch)
+    module = importlib.import_module("azure_functions_langgraph.checkpointers.postgres")
+    importlib.reload(module)
+
+    real_import_module = importlib.import_module
+
+    def fake_import_module(name: str) -> Any:
+        if name == "psycopg":
+            raise ImportError("missing")
+        return real_import_module(name)
+
+    monkeypatch.setattr(module.importlib, "import_module", fake_import_module)
+
+    with pytest.raises(ImportError, match=r"\[postgres\]"):
+        module.create_postgres_checkpointer("postgresql://u:p@h/db")
+
+
+def test_postgres_helper_missing_postgres_saver_symbol_raises(monkeypatch: Any) -> None:
+    _install_fake_postgres(monkeypatch, omit_postgres_saver=True)
+    module = importlib.import_module("azure_functions_langgraph.checkpointers.postgres")
+    importlib.reload(module)
+
+    with pytest.raises(ImportError, match="PostgresSaver"):
+        module.create_postgres_checkpointer("postgresql://u:p@h/db")
+
+
+def test_postgres_helper_missing_psycopg_connection_symbol_raises(monkeypatch: Any) -> None:
+    _install_fake_postgres(monkeypatch, omit_psycopg_connection=True)
+    module = importlib.import_module("azure_functions_langgraph.checkpointers.postgres")
+    importlib.reload(module)
+
+    with pytest.raises(ImportError, match="Connection"):
+        module.create_postgres_checkpointer("postgresql://u:p@h/db")
+
+
+def test_postgres_helper_missing_dict_row_symbol_raises(monkeypatch: Any) -> None:
+    _install_fake_postgres(monkeypatch, omit_dict_row=True)
+    module = importlib.import_module("azure_functions_langgraph.checkpointers.postgres")
+    importlib.reload(module)
+
+    with pytest.raises(ImportError, match="dict_row"):
+        module.create_postgres_checkpointer("postgresql://u:p@h/db")
+
+
+def test_sqlite_helper_opens_connection_and_runs_setup(monkeypatch: Any) -> None:
+    constructed = _install_fake_sqlite(monkeypatch)
+
+    module = importlib.import_module("azure_functions_langgraph.checkpointers.sqlite")
+    importlib.reload(module)
+    saver = module.create_sqlite_checkpointer(":memory:")
+
+    assert constructed == [saver]
+    assert getattr(saver, "setup_calls") == 1
+    assert isinstance(saver.conn, sqlite3.Connection)
+
+
+def test_sqlite_helper_setup_false_skips_setup(monkeypatch: Any) -> None:
+    _install_fake_sqlite(monkeypatch)
+
+    module = importlib.import_module("azure_functions_langgraph.checkpointers.sqlite")
+    importlib.reload(module)
+    saver = module.create_sqlite_checkpointer(":memory:", setup=False)
+
+    assert getattr(saver, "setup_calls") == 0
+
+
+def test_sqlite_helper_check_same_thread_default_is_false(monkeypatch: Any) -> None:
+    _install_fake_sqlite(monkeypatch)
+    module = importlib.import_module("azure_functions_langgraph.checkpointers.sqlite")
+    importlib.reload(module)
+
+    captured: dict[str, Any] = {}
+    real_connect = sqlite3.connect
+
+    def spy_connect(database: Any, **kwargs: Any) -> Any:
+        captured.update(kwargs)
+        return real_connect(database, **kwargs)
+
+    monkeypatch.setattr(module.importlib.import_module("sqlite3"), "connect", spy_connect)
+    module.create_sqlite_checkpointer(":memory:")
+
+    assert captured["check_same_thread"] is False
+
+
+def test_sqlite_helper_missing_langgraph_sqlite_raises_helpful_error(monkeypatch: Any) -> None:
+    module = importlib.import_module("azure_functions_langgraph.checkpointers.sqlite")
+    real_import_module = importlib.import_module
+
+    def fake_import_module(name: str) -> Any:
+        if name == "langgraph.checkpoint.sqlite":
+            raise ImportError("missing")
+        return real_import_module(name)
+
+    monkeypatch.setattr(module.importlib, "import_module", fake_import_module)
+
+    with pytest.raises(ImportError, match=r"\[sqlite\]"):
+        module.create_sqlite_checkpointer(":memory:")
+
+
+def test_sqlite_helper_missing_sqlite_saver_symbol_raises(monkeypatch: Any) -> None:
+    _install_fake_sqlite(monkeypatch, omit_sqlite_saver=True)
+    module = importlib.import_module("azure_functions_langgraph.checkpointers.sqlite")
+    importlib.reload(module)
+
+    with pytest.raises(ImportError, match="SqliteSaver"):
+        module.create_sqlite_checkpointer(":memory:")
+
+
+def test_checkpointers_package_exports_helpers() -> None:
+    pkg = importlib.import_module("azure_functions_langgraph.checkpointers")
+    assert "create_postgres_checkpointer" in pkg.__all__
+    assert "create_sqlite_checkpointer" in pkg.__all__
+    assert callable(pkg.create_postgres_checkpointer)
+    assert callable(pkg.create_sqlite_checkpointer)

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 def test_version_string() -> None:
     from azure_functions_langgraph import __version__
 
-    assert __version__ == "0.5.4"
+    assert __version__ == "0.6.0"
 
 
 def test_langgraph_app_importable() -> None:


### PR DESCRIPTION
## Summary
Thin wrappers around the official LangGraph DB checkpoint packages, sized for Azure Functions cold-start wiring:

- `create_postgres_checkpointer(conn_string, *, setup=True, autocommit=True, prepare_threshold=0)` — opens a long-lived `psycopg.Connection` (matching the upstream `from_conn_string` defaults) and optionally runs `setup()` once.
- `create_sqlite_checkpointer(conn_string, *, setup=True, check_same_thread=False)` — opens a `sqlite3.Connection` with the upstream `check_same_thread=False` default.

Both helpers own the connection lifetime because the upstream `from_conn_string` classmethods are `@contextmanager` and unsuitable for module-import-time wiring on Azure Functions cold start. Both emit clear `ImportError`s pointing at the right extra (`postgres` / `sqlite`) when missing.

## Upstream verification
| Package | Version pinned | Constructor | `setup()` | Source |
| --- | --- | --- | --- | --- |
| `langgraph-checkpoint-postgres` | `>=3.0,<4` (latest 3.0.5) | `PostgresSaver(conn)` | yes | `langgraph/checkpoint/postgres/__init__.py:32-103` (verified from wheel) |
| `psycopg` | `>=3.0,<4` | `Connection.connect(conn_string, autocommit, prepare_threshold, row_factory)` | n/a | psycopg 3 docs |
| `langgraph-checkpoint-sqlite` | `>=3.0,<4` (latest 3.0.3) | `SqliteSaver(conn)` | yes | `langgraph/checkpoint/sqlite/__init__.py:78-127` (verified from wheel) |

## Cosmos DB
Intentionally out of scope: no first-party LangGraph checkpointer package exists upstream. The issue's \"do not reimplement DB checkpoint storage\" rule disqualifies a from-scratch implementation in this PR. Should be split into a separate follow-up issue.

## Tests
- 14 new tests in \`tests/test_checkpointers_db_helpers.py\` covering: helper opens connection + runs setup, \`setup=False\` skips, autocommit/prepare_threshold forwarding, missing extras (langgraph package, psycopg, sqlite package), missing internal symbols (PostgresSaver, Connection, dict_row, SqliteSaver), \`check_same_thread=False\` default, \`__init__\` re-exports.
- \`make lint typecheck test build\` → 753 passed, 92.48% coverage (gate 90%), wheel builds clean.

## Examples
- \`examples/sqlite_checkpoint_local/\` — local dev, \`:memory:\` or on-disk file.
- \`examples/postgres_checkpoint_production/\` — env-var driven, FUNCTION auth, \`LANGGRAPH_POSTGRES_SETUP\` toggle.

## Out of scope (deferred to follow-up issues)
- Cosmos DB helper.
- Connection pooling helpers beyond what upstream packages expose.
- Async helper variants (\`create_async_*_checkpointer\`).
- CI compat matrix for the DB extras (CI changes intentionally minimal in this PR).
- CHANGELOG: auto-generated by git-cliff from this commit.

Closes #158