### PR TITLE
docs(examples): add Managed Identity walkthrough for Blob + Table backends

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,21 +317,49 @@ func_app = app.function_app
 
 Checkpoints and thread metadata survive Azure Functions restarts and scale across instances.
 
-To use Managed Identity (or any other credential), construct a `TableClient` directly and hand it to `AzureTableThreadStore.from_table_client(...)`:
+#### Persistent storage with Managed Identity
+
+The recommended production wiring uses **Managed Identity** instead of connection strings, so no secrets land in App Settings. Install the `azure-identity` extra and pass `DefaultAzureCredential` to both clients:
+
+```bash
+pip install azure-functions-langgraph[azure-blob,azure-table,azure-identity]
+```
 
 ```python
 from azure.data.tables import TableClient
 from azure.identity import DefaultAzureCredential
+from azure.storage.blob import ContainerClient
 
+from azure_functions_langgraph.checkpointers.azure_blob import AzureBlobCheckpointSaver
+from azure_functions_langgraph.stores.azure_table import AzureTableThreadStore
+
+credential = DefaultAzureCredential()
+
+container_client = ContainerClient(
+    account_url="https://<account>.blob.core.windows.net",
+    container_name="langgraph-checkpoints",
+    credential=credential,
+)
 table_client = TableClient(
     endpoint="https://<account>.table.core.windows.net",
-    table_name="threads",
-    credential=DefaultAzureCredential(),
+    table_name="langgraphthreads",
+    credential=credential,
 )
-thread_store = AzureTableThreadStore.from_table_client(table_client)
+
+checkpointer = AzureBlobCheckpointSaver(container_client=container_client)
+thread_store = AzureTableThreadStore.from_table_client(table_client=table_client)
 ```
 
-A full Managed Identity walkthrough (Blob + Table) is tracked in [#156](https://github.com/yeongseon/azure-functions-langgraph-python/issues/156).
+Required role assignments on the storage account (or narrower scopes):
+
+| Role | Used by |
+| --- | --- |
+| `Storage Blob Data Contributor` | `AzureBlobCheckpointSaver` |
+| `Storage Table Data Contributor` | `AzureTableThreadStore` |
+
+`DefaultAzureCredential` walks a chain of credentials. In Azure Functions it picks up the Function App's Managed Identity; locally it falls back to `AzureCliCredential` (`az login`) — the same code path works in both environments without conditional wiring.
+
+For a complete runnable example (Managed Identity in prod, Azurite + connection string locally), see [`examples/managed_identity_storage/`](examples/managed_identity_storage/).
 
 ### Scale envelope
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -7,6 +7,7 @@
 | Minimal | [`simple_agent`](simple_agent/) | Two-node greeting agent with sequential edges. |
 | Platform SDK | [`platform_compat_sdk`](platform_compat_sdk/) ⭐ | `platform_compat=True` host driven by the official `langgraph-sdk` client. |
 | Persistent storage | [`persistent_agent_blob_table`](persistent_agent_blob_table/) | End-to-end Azure Blob checkpointer + Azure Table thread store, runnable on Azurite. |
+| Managed Identity | [`managed_identity_storage`](managed_identity_storage/) | Same backends wired with `DefaultAzureCredential` for production, with Azurite fallback for local dev. |
 | OpenAPI bridge | [`openapi_bridge`](openapi_bridge/) | Wires `register_with_openapi` into `azure-functions-openapi-python` for spec generation. |
 | Per-graph auth | [`production_auth`](production_auth/) | Public health + anonymous demo graph alongside a function-key-protected graph. |
 | Curl helpers | [`local_curl`](local_curl/) | Shell scripts for hitting every Quick Start endpoint locally. |
@@ -27,6 +28,7 @@ Every example ships with:
 - **Just want it running?** → `simple_agent`
 - **Switching from LangGraph Cloud / using `langgraph-sdk`?** → `platform_compat_sdk`
 - **Need state to survive restarts and scale-out?** → `persistent_agent_blob_table`
+- **Deploying to Azure with Managed Identity (no secrets in App Settings)?** → `managed_identity_storage`
 - **Want OpenAPI / Swagger UI for your endpoints?** → `openapi_bridge`
 - **Mixing public and private graphs?** → `production_auth`
 - **Verifying a deployed Function App from the terminal?** → `local_curl`

--- a/examples/managed_identity_storage/README.md
+++ b/examples/managed_identity_storage/README.md
@@ -26,9 +26,16 @@ The Table client is then handed to the new
 [`AzureTableThreadStore.from_table_client()`](../../README.md#persistent-storage-v04)
 factory so the credential flows through unchanged.
 
+> The **runnable example** branches on env vars to support both modes from
+> a single `function_app.py`. The standalone snippet in the README's
+> *Persistent storage with Managed Identity* section uses
+> `DefaultAzureCredential` directly — that wiring works in Azure Functions
+> and locally with `az login` without any conditional code.
+
 ## Run locally with Azurite
 
-Start Azurite (Docker):
+Start Azurite (Docker), exposing **all three** ports — port `10002` is
+required for the Table service:
 
 ```bash
 docker run -d --name azurite \
@@ -106,20 +113,37 @@ Do **not** set `AZURE_STORAGE_CONNECTION_STRING` in production — its presence
 would also work, but it puts a credential into App Settings and defeats the
 point of using Managed Identity.
 
-### 4. Pre-create the container (one-time)
+### 4. Pre-create the container and table (recommended)
 
-`function_app.py` calls `container.create_container()` if missing, which
-requires the role assignment above to be already in place. Alternatively,
-create it once via the portal or CLI:
+Pre-creating storage resources avoids cold-start side effects and avoids
+RBAC propagation timing issues:
 
 ```bash
 az storage container create \
   --account-name <storage-account> --name langgraph-checkpoints \
   --auth-mode login
+
+az storage table create \
+  --account-name <storage-account> --name langgraphthreads \
+  --auth-mode login
 ```
 
-The Table is created lazily by the store on first write, so no extra step is
-required for it.
+`AzureTableThreadStore` does **not** create the table on first write —
+calls will fail with `ResourceNotFoundError` if the table is missing,
+so the table must exist before the Function App handles its first
+request. The same applies to `AzureBlobCheckpointSaver` and the
+container.
+
+For local Azurite runs, the example sets
+`LANGGRAPH_AUTO_CREATE_CONTAINER=true` in `local.settings.json.example`
+so it bootstraps both resources at cold start. **Do not set this in
+production** — pre-create instead.
+
+### 5. Note on RBAC propagation
+
+Azure RBAC role assignments can take a few minutes to propagate. If you
+deploy and immediately see `403 Forbidden` from Blob or Table operations,
+wait 1–5 minutes and retry before debugging further.
 
 ## Local-dev fallback to Azure CLI credential
 
@@ -149,8 +173,13 @@ to your `az login` identity as it does to a Function App's Managed Identity.
 
 ## Verify persistence
 
+The example deploys with `auth_level=FUNCTION`, so a function key is
+required when hitting a deployed app. Local `func start` may also accept
+requests without a key depending on host version — supply one if you
+have it:
+
 ```bash
-KEY="<function-key-or-leave-blank-for-anonymous>"
+KEY="<function-key>"   # required for deployed apps; may be optional locally
 THREAD=$(curl -s -X POST "http://localhost:7071/api/threads?code=$KEY" \
   -H "Content-Type: application/json" -d '{}' \
   | python -c 'import json,sys; print(json.load(sys.stdin)["thread_id"])')

--- a/examples/managed_identity_storage/README.md
+++ b/examples/managed_identity_storage/README.md
@@ -135,7 +135,7 @@ request. The same applies to `AzureBlobCheckpointSaver` and the
 container.
 
 For local Azurite runs, the example sets
-`LANGGRAPH_AUTO_CREATE_CONTAINER=true` in `local.settings.json.example`
+`LANGGRAPH_AUTO_CREATE_STORAGE=true` in `local.settings.json.example`
 so it bootstraps both resources at cold start. **Do not set this in
 production** — pre-create instead.
 

--- a/examples/managed_identity_storage/README.md
+++ b/examples/managed_identity_storage/README.md
@@ -1,0 +1,174 @@
+# Managed Identity (Blob + Table)
+
+End-to-end example using **Managed Identity** for `AzureBlobCheckpointSaver`
+and `AzureTableThreadStore` in production, with a connection-string fallback
+for local development against [Azurite](https://learn.microsoft.com/azure/storage/common/storage-use-azurite).
+
+This is the recommended production wiring for the bundled persistent backends:
+no secrets in App Settings, role-based access only.
+
+## Files
+
+- `function_app.py` — switches between `DefaultAzureCredential` (prod) and connection string (Azurite/local)
+- `graph.py` — turn-counting echo agent
+- `host.json`, `local.settings.json.example`, `requirements.txt`
+
+## How the wiring works
+
+`function_app.py` looks at env vars on cold start:
+
+| Mode | Env vars set | Storage clients |
+| --- | --- | --- |
+| Production / Managed Identity | `AZURE_STORAGE_BLOB_ACCOUNT_URL` + `AZURE_TABLE_ENDPOINT` | `ContainerClient(account_url=..., credential=DefaultAzureCredential())` and `TableClient(endpoint=..., credential=DefaultAzureCredential())` |
+| Local dev / CI | `AZURE_STORAGE_CONNECTION_STRING` (e.g. Azurite) | `ContainerClient.from_connection_string(...)` / `TableClient.from_connection_string(...)` |
+
+The Table client is then handed to the new
+[`AzureTableThreadStore.from_table_client()`](../../README.md#persistent-storage-v04)
+factory so the credential flows through unchanged.
+
+## Run locally with Azurite
+
+Start Azurite (Docker):
+
+```bash
+docker run -d --name azurite \
+  -p 10000:10000 -p 10001:10001 -p 10002:10002 \
+  mcr.microsoft.com/azure-storage/azurite
+```
+
+Then:
+
+```bash
+cd examples/managed_identity_storage
+cp local.settings.json.example local.settings.json
+pip install -r requirements.txt
+func start
+```
+
+The example ships `AZURE_STORAGE_CONNECTION_STRING=UseDevelopmentStorage=true`
+in `local.settings.json.example`, so it runs hermetically against Azurite
+without needing real Azure credentials.
+
+## Production deploy with Managed Identity
+
+### 1. Enable a Managed Identity on the Function App
+
+System-assigned (simplest) or user-assigned. Examples below assume
+system-assigned.
+
+```bash
+az functionapp identity assign \
+  --name <function-app-name> \
+  --resource-group <rg>
+```
+
+### 2. Grant role assignments on the storage account
+
+The bundled backends need data-plane access to **both** Blob and Table services:
+
+| Role | Scope | Used by |
+| --- | --- | --- |
+| `Storage Blob Data Contributor` | the storage account (or the container) | `AzureBlobCheckpointSaver` |
+| `Storage Table Data Contributor` | the storage account (or the table) | `AzureTableThreadStore` |
+
+```bash
+PRINCIPAL_ID=$(az functionapp identity show -n <function-app> -g <rg> --query principalId -o tsv)
+STORAGE_ID=$(az storage account show -n <storage-account> -g <rg> --query id -o tsv)
+
+az role assignment create \
+  --role "Storage Blob Data Contributor" \
+  --assignee "$PRINCIPAL_ID" \
+  --scope "$STORAGE_ID"
+
+az role assignment create \
+  --role "Storage Table Data Contributor" \
+  --assignee "$PRINCIPAL_ID" \
+  --scope "$STORAGE_ID"
+```
+
+For tighter scoping, target the container and table individually
+(`/blobServices/default/containers/<name>` and
+`/tableServices/default/tables/<name>`).
+
+### 3. Set App Settings (no secrets)
+
+```bash
+az functionapp config appsettings set \
+  --name <function-app> --resource-group <rg> \
+  --settings \
+    AZURE_STORAGE_BLOB_ACCOUNT_URL="https://<storage-account>.blob.core.windows.net" \
+    AZURE_TABLE_ENDPOINT="https://<storage-account>.table.core.windows.net" \
+    LANGGRAPH_BLOB_CONTAINER="langgraph-checkpoints" \
+    LANGGRAPH_THREADS_TABLE="langgraphthreads"
+```
+
+Do **not** set `AZURE_STORAGE_CONNECTION_STRING` in production — its presence
+would also work, but it puts a credential into App Settings and defeats the
+point of using Managed Identity.
+
+### 4. Pre-create the container (one-time)
+
+`function_app.py` calls `container.create_container()` if missing, which
+requires the role assignment above to be already in place. Alternatively,
+create it once via the portal or CLI:
+
+```bash
+az storage container create \
+  --account-name <storage-account> --name langgraph-checkpoints \
+  --auth-mode login
+```
+
+The Table is created lazily by the store on first write, so no extra step is
+required for it.
+
+## Local-dev fallback to Azure CLI credential
+
+`DefaultAzureCredential` walks a chain of credentials in order. The two
+relevant for local dev are:
+
+1. **Environment variables** (`AZURE_CLIENT_ID` / `AZURE_TENANT_ID` /
+   `AZURE_CLIENT_SECRET`) — only if you set them.
+2. **`AzureCliCredential`** — uses your `az login` session.
+
+To run this example against a real Azure storage account from your
+workstation (instead of Azurite):
+
+```bash
+az login
+
+export AZURE_STORAGE_BLOB_ACCOUNT_URL="https://<storage-account>.blob.core.windows.net"
+export AZURE_TABLE_ENDPOINT="https://<storage-account>.table.core.windows.net"
+unset AZURE_STORAGE_CONNECTION_STRING   # force the MI/credential branch
+
+func start
+```
+
+Make sure your user account has `Storage Blob Data Contributor` and
+`Storage Table Data Contributor` on the account — RBAC applies the same way
+to your `az login` identity as it does to a Function App's Managed Identity.
+
+## Verify persistence
+
+```bash
+KEY="<function-key-or-leave-blank-for-anonymous>"
+THREAD=$(curl -s -X POST "http://localhost:7071/api/threads?code=$KEY" \
+  -H "Content-Type: application/json" -d '{}' \
+  | python -c 'import json,sys; print(json.load(sys.stdin)["thread_id"])')
+
+curl -s -X POST "http://localhost:7071/api/threads/$THREAD/runs/wait?code=$KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"assistant_id":"managed_identity_agent","input":{"messages":[{"role":"human","content":"first"}]}}'
+
+curl -s -X POST "http://localhost:7071/api/threads/$THREAD/runs/wait?code=$KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"assistant_id":"managed_identity_agent","input":{"messages":[{"role":"human","content":"second"}]}}'
+```
+
+The second response shows `[turn 2]`. Restart `func start` and the counter
+still increments because state lives in storage.
+
+## See also
+
+- [`examples/persistent_agent_blob_table/`](../persistent_agent_blob_table/) — same wiring driven by a connection string only.
+- [README → Persistent storage](../../README.md#persistent-storage-v04) — narrative docs and scale envelope.
+- [`docs/production-guide.md`](../../docs/production-guide.md) — Key Vault references and other production concerns.

--- a/examples/managed_identity_storage/function_app.py
+++ b/examples/managed_identity_storage/function_app.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import os
+
+from azure.data.tables import TableClient
+from azure.storage.blob import ContainerClient
+from graph import build_graph
+
+import azure.functions as func
+
+from azure_functions_langgraph import LangGraphApp
+from azure_functions_langgraph.checkpointers.azure_blob import AzureBlobCheckpointSaver
+from azure_functions_langgraph.stores.azure_table import AzureTableThreadStore
+
+_BLOB_CONTAINER = os.environ.get("LANGGRAPH_BLOB_CONTAINER", "langgraph-checkpoints")
+_THREADS_TABLE = os.environ.get("LANGGRAPH_THREADS_TABLE", "langgraphthreads")
+
+_BLOB_ACCOUNT_URL = os.environ.get("AZURE_STORAGE_BLOB_ACCOUNT_URL")
+_TABLE_ENDPOINT = os.environ.get("AZURE_TABLE_ENDPOINT")
+_CONN_STRING = os.environ.get("AZURE_STORAGE_CONNECTION_STRING")
+
+
+def _build_storage_clients() -> tuple[ContainerClient, TableClient]:
+    if _BLOB_ACCOUNT_URL and _TABLE_ENDPOINT:
+        from azure.identity import DefaultAzureCredential
+
+        credential = DefaultAzureCredential()
+        container = ContainerClient(
+            account_url=_BLOB_ACCOUNT_URL,
+            container_name=_BLOB_CONTAINER,
+            credential=credential,
+        )
+        table = TableClient(
+            endpoint=_TABLE_ENDPOINT,
+            table_name=_THREADS_TABLE,
+            credential=credential,
+        )
+        return container, table
+
+    if not _CONN_STRING:
+        raise RuntimeError(
+            "Set AZURE_STORAGE_BLOB_ACCOUNT_URL + AZURE_TABLE_ENDPOINT for Managed "
+            "Identity, or AZURE_STORAGE_CONNECTION_STRING for Azurite/local dev."
+        )
+
+    container = ContainerClient.from_connection_string(_CONN_STRING, _BLOB_CONTAINER)
+    table = TableClient.from_connection_string(_CONN_STRING, _THREADS_TABLE)
+    return container, table
+
+
+container_client, table_client = _build_storage_clients()
+
+if not container_client.exists():
+    container_client.create_container()
+
+checkpointer = AzureBlobCheckpointSaver(container_client=container_client)
+thread_store = AzureTableThreadStore.from_table_client(table_client=table_client)
+
+compiled_graph = build_graph().compile(checkpointer=checkpointer)
+
+langgraph_app = LangGraphApp(
+    platform_compat=True,
+    auth_level=func.AuthLevel.FUNCTION,
+)
+langgraph_app.thread_store = thread_store
+langgraph_app.register(
+    graph=compiled_graph,
+    name="managed_identity_agent",
+    description="Echo agent persisted via DefaultAzureCredential (Managed Identity in prod, AzureCliCredential in dev).",
+)
+
+app = langgraph_app.function_app

--- a/examples/managed_identity_storage/function_app.py
+++ b/examples/managed_identity_storage/function_app.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import logging
 import os
 
+from azure.core.exceptions import ResourceExistsError
 from azure.data.tables import TableClient
 from azure.storage.blob import ContainerClient
 from graph import build_graph
@@ -12,6 +14,10 @@ from azure_functions_langgraph import LangGraphApp
 from azure_functions_langgraph.checkpointers.azure_blob import AzureBlobCheckpointSaver
 from azure_functions_langgraph.stores.azure_table import AzureTableThreadStore
 
+logger = logging.getLogger(__name__)
+
+_TRUTHY = {"1", "true", "yes", "on"}
+
 _BLOB_CONTAINER = os.environ.get("LANGGRAPH_BLOB_CONTAINER", "langgraph-checkpoints")
 _THREADS_TABLE = os.environ.get("LANGGRAPH_THREADS_TABLE", "langgraphthreads")
 
@@ -21,7 +27,18 @@ _CONN_STRING = os.environ.get("AZURE_STORAGE_CONNECTION_STRING")
 
 
 def _build_storage_clients() -> tuple[ContainerClient, TableClient]:
-    if _BLOB_ACCOUNT_URL and _TABLE_ENDPOINT:
+    # SECURITY: reject partial Managed Identity config. Silently falling back to
+    # AZURE_STORAGE_CONNECTION_STRING when only one MI endpoint var is set would
+    # mask a broken production MI rollout and quietly re-enable secret-based auth.
+    if _BLOB_ACCOUNT_URL or _TABLE_ENDPOINT:
+        if not (_BLOB_ACCOUNT_URL and _TABLE_ENDPOINT):
+            raise RuntimeError(
+                "Partial Managed Identity configuration: set BOTH "
+                "AZURE_STORAGE_BLOB_ACCOUNT_URL and AZURE_TABLE_ENDPOINT to use "
+                "Managed Identity, or unset both and use "
+                "AZURE_STORAGE_CONNECTION_STRING for Azurite/local dev."
+            )
+
         from azure.identity import DefaultAzureCredential
 
         credential = DefaultAzureCredential()
@@ -50,27 +67,38 @@ def _build_storage_clients() -> tuple[ContainerClient, TableClient]:
 
 container_client, table_client = _build_storage_clients()
 
-_AUTO_CREATE_CONTAINER = (
-    os.environ.get("LANGGRAPH_AUTO_CREATE_CONTAINER", "false").lower() == "true"
+# LANGGRAPH_AUTO_CREATE_STORAGE bootstraps both the blob container AND the table.
+_AUTO_CREATE_STORAGE = (
+    os.environ.get("LANGGRAPH_AUTO_CREATE_STORAGE", "false").strip().lower() in _TRUTHY
 )
 
-if _AUTO_CREATE_CONTAINER:
+if _AUTO_CREATE_STORAGE:
     try:
         if not container_client.exists():
             container_client.create_container()
     except Exception as exc:
         raise RuntimeError(
             "Failed to verify or create the checkpoint container at cold start. "
-            "Pre-create the container and unset LANGGRAPH_AUTO_CREATE_CONTAINER, "
+            "Pre-create the container and unset LANGGRAPH_AUTO_CREATE_STORAGE, "
             "or check Managed Identity RBAC propagation (Storage Blob Data Contributor)."
         ) from exc
 
     try:
         table_client.create_table()
-    except Exception:
-        # Table already exists, or RBAC is still propagating — defer the error
-        # to the first real operation so RBAC delays do not block cold start.
+    except ResourceExistsError:
         pass
+    except Exception as exc:
+        # Tolerate transient RBAC propagation / DNS / outage at cold start so a
+        # 5-minute role-assignment lag doesn't take down the function. The first
+        # real table operation will surface the underlying error if it persists.
+        # Pre-create the table and unset LANGGRAPH_AUTO_CREATE_STORAGE in
+        # production to fail fast instead.
+        logger.warning(
+            "Table create skipped at cold start (table=%s): %s. "
+            "First real operation may fail if the table is missing.",
+            _THREADS_TABLE,
+            exc,
+        )
 
 checkpointer = AzureBlobCheckpointSaver(container_client=container_client)
 thread_store = AzureTableThreadStore.from_table_client(table_client=table_client)

--- a/examples/managed_identity_storage/function_app.py
+++ b/examples/managed_identity_storage/function_app.py
@@ -50,8 +50,27 @@ def _build_storage_clients() -> tuple[ContainerClient, TableClient]:
 
 container_client, table_client = _build_storage_clients()
 
-if not container_client.exists():
-    container_client.create_container()
+_AUTO_CREATE_CONTAINER = (
+    os.environ.get("LANGGRAPH_AUTO_CREATE_CONTAINER", "false").lower() == "true"
+)
+
+if _AUTO_CREATE_CONTAINER:
+    try:
+        if not container_client.exists():
+            container_client.create_container()
+    except Exception as exc:
+        raise RuntimeError(
+            "Failed to verify or create the checkpoint container at cold start. "
+            "Pre-create the container and unset LANGGRAPH_AUTO_CREATE_CONTAINER, "
+            "or check Managed Identity RBAC propagation (Storage Blob Data Contributor)."
+        ) from exc
+
+    try:
+        table_client.create_table()
+    except Exception:
+        # Table already exists, or RBAC is still propagating — defer the error
+        # to the first real operation so RBAC delays do not block cold start.
+        pass
 
 checkpointer = AzureBlobCheckpointSaver(container_client=container_client)
 thread_store = AzureTableThreadStore.from_table_client(table_client=table_client)

--- a/examples/managed_identity_storage/graph.py
+++ b/examples/managed_identity_storage/graph.py
@@ -1,0 +1,36 @@
+"""Compiled graph for the persistent_agent_blob_table example."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from langgraph.graph import END, START, StateGraph
+from typing_extensions import TypedDict
+
+
+class AgentState(TypedDict):
+    messages: list[dict[str, str]]
+    turn: int
+
+
+def respond(state: AgentState) -> dict[str, Any]:
+    user_msg = state["messages"][-1]["content"] if state["messages"] else ""
+    turn = state.get("turn", 0) + 1
+    return {
+        "messages": state["messages"]
+        + [
+            {
+                "role": "assistant",
+                "content": f"[turn {turn}] Echo: {user_msg}",
+            }
+        ],
+        "turn": turn,
+    }
+
+
+def build_graph() -> StateGraph:
+    builder = StateGraph(AgentState)
+    builder.add_node("respond", respond)
+    builder.add_edge(START, "respond")
+    builder.add_edge("respond", END)
+    return builder

--- a/examples/managed_identity_storage/graph.py
+++ b/examples/managed_identity_storage/graph.py
@@ -34,3 +34,6 @@ def build_graph() -> StateGraph:
     builder.add_edge(START, "respond")
     builder.add_edge("respond", END)
     return builder
+
+
+compiled_graph = build_graph().compile()

--- a/examples/managed_identity_storage/graph.py
+++ b/examples/managed_identity_storage/graph.py
@@ -1,4 +1,4 @@
-"""Compiled graph for the persistent_agent_blob_table example."""
+"""Compiled graph for the managed_identity_storage example."""
 
 from __future__ import annotations
 

--- a/examples/managed_identity_storage/host.json
+++ b/examples/managed_identity_storage/host.json
@@ -1,0 +1,15 @@
+{
+  "version": "2.0",
+  "logging": {
+    "applicationInsights": {
+      "samplingSettings": {
+        "isEnabled": true,
+        "excludedTypes": "Request"
+      }
+    }
+  },
+  "extensionBundle": {
+    "id": "Microsoft.Azure.Functions.ExtensionBundle",
+    "version": "[4.*, 5.0.0)"
+  }
+}

--- a/examples/managed_identity_storage/local.settings.json.example
+++ b/examples/managed_identity_storage/local.settings.json.example
@@ -5,6 +5,7 @@
     "FUNCTIONS_WORKER_RUNTIME": "python",
     "AZURE_STORAGE_CONNECTION_STRING": "UseDevelopmentStorage=true",
     "LANGGRAPH_BLOB_CONTAINER": "langgraph-checkpoints",
-    "LANGGRAPH_THREADS_TABLE": "langgraphthreads"
+    "LANGGRAPH_THREADS_TABLE": "langgraphthreads",
+    "LANGGRAPH_AUTO_CREATE_CONTAINER": "true"
   }
 }

--- a/examples/managed_identity_storage/local.settings.json.example
+++ b/examples/managed_identity_storage/local.settings.json.example
@@ -1,0 +1,10 @@
+{
+  "IsEncrypted": false,
+  "Values": {
+    "AzureWebJobsStorage": "UseDevelopmentStorage=true",
+    "FUNCTIONS_WORKER_RUNTIME": "python",
+    "AZURE_STORAGE_CONNECTION_STRING": "UseDevelopmentStorage=true",
+    "LANGGRAPH_BLOB_CONTAINER": "langgraph-checkpoints",
+    "LANGGRAPH_THREADS_TABLE": "langgraphthreads"
+  }
+}

--- a/examples/managed_identity_storage/local.settings.json.example
+++ b/examples/managed_identity_storage/local.settings.json.example
@@ -6,6 +6,6 @@
     "AZURE_STORAGE_CONNECTION_STRING": "UseDevelopmentStorage=true",
     "LANGGRAPH_BLOB_CONTAINER": "langgraph-checkpoints",
     "LANGGRAPH_THREADS_TABLE": "langgraphthreads",
-    "LANGGRAPH_AUTO_CREATE_CONTAINER": "true"
+    "LANGGRAPH_AUTO_CREATE_STORAGE": "true"
   }
 }

--- a/examples/managed_identity_storage/requirements.txt
+++ b/examples/managed_identity_storage/requirements.txt
@@ -1,5 +1,13 @@
 # Do not include azure-functions-worker in this file
 # The Python Worker is managed by the Azure Functions platform
+#
+# This example uses APIs introduced in v0.6.0 (azure-identity extra,
+# AzureTableThreadStore.from_table_client). Until v0.6.0 is on PyPI,
+# install the package in editable mode from a local checkout:
+#
+#     pip install -e ../..[azure-blob,azure-table,azure-identity]
+#
+# After v0.6.0 is released, the pinned line below is sufficient.
 
 azure-functions
 azure-functions-langgraph[azure-blob,azure-table,azure-identity]>=0.6.0,<0.7.0

--- a/examples/managed_identity_storage/requirements.txt
+++ b/examples/managed_identity_storage/requirements.txt
@@ -1,0 +1,7 @@
+# Do not include azure-functions-worker in this file
+# The Python Worker is managed by the Azure Functions platform
+
+azure-functions
+azure-functions-langgraph[azure-blob,azure-table,azure-identity]>=0.6.0,<0.7.0
+langgraph>=1.0,<2.0
+langchain-core>=1.0,<2.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,9 @@ azure-blob = [
 azure-table = [
     "azure-data-tables>=12.0,<13",
 ]
+azure-identity = [
+    "azure-identity>=1.16,<2",
+]
 dev = [
     "bandit==1.9.4",
     "build",

--- a/tests/test_examples_smoke.py
+++ b/tests/test_examples_smoke.py
@@ -57,6 +57,7 @@ EXAMPLE_DIRS = (
     "simple_agent",
     "platform_compat_sdk",
     "persistent_agent_blob_table",
+    "managed_identity_storage",
     "openapi_bridge",
     "production_auth",
 )

--- a/tests/test_examples_smoke.py
+++ b/tests/test_examples_smoke.py
@@ -14,6 +14,7 @@ GRAPH_EXAMPLES: tuple[tuple[str, str], ...] = (
     ("openapi_bridge", "compiled_graph"),
     ("production_auth", "private_graph"),
     ("production_auth", "public_graph"),
+    ("managed_identity_storage", "compiled_graph"),
 )
 
 


### PR DESCRIPTION
## Summary
- Stacks on **#161** (which adds `AzureTableThreadStore.from_table_client()`).
- Adds the production-recommended wiring: `DefaultAzureCredential` for both `ContainerClient` and `TableClient`, no secrets in App Settings.
- Keeps local dev/CI hermetic via a connection-string fallback against Azurite.

## What's in
- `pyproject.toml`: new `azure-identity` optional extra (Option A from the issue — opt-in, doesn't disturb existing per-service extras).
- `examples/managed_identity_storage/`: full Function App. `function_app.py` picks the credential branch when `AZURE_STORAGE_BLOB_ACCOUNT_URL` + `AZURE_TABLE_ENDPOINT` are set, otherwise falls back to `AZURE_STORAGE_CONNECTION_STRING` (works against Azurite out of the box).
- `examples/README.md`: index row + decision-tree pointer ("Deploying to Azure with Managed Identity?").
- `tests/test_examples_smoke.py`: includes the new example in the required-files smoke test.
- `README.md`: replaces the small `from_table_client` snippet with a proper **Persistent storage with Managed Identity** subsection — `azure-identity` extra, full Blob + Table wiring, required RBAC roles (`Storage Blob Data Contributor` + `Storage Table Data Contributor`), and pointer to the example.

## Acceptance checklist (from #156)
- [x] Add `azure-identity` optional dependency — chose Option A (`azure-identity = ["azure-identity>=1.16,<2"]`).
- [x] README *Persistent storage with Managed Identity* subsection.
- [x] `examples/managed_identity_storage/` mirroring `persistent_agent_blob_table/` with `DefaultAzureCredential`.
- [x] Local-dev fallback via Azurite + connection string (and `AzureCliCredential` documented for real-storage local runs).
- [x] Production env vars documented (`AZURE_STORAGE_BLOB_ACCOUNT_URL`, `AZURE_TABLE_ENDPOINT`).
- [x] `tests/test_examples_smoke.py` updated.
- [x] `examples/README.md` updated.
- [n/a] CHANGELOG: auto-generated by git-cliff from this commit.

## Validation
- `make lint typecheck test` → 744 passed, 92.24% coverage (gate 90%).

Closes #156

> Note: base branch is `feat/p1-table-from-client` because this example uses the new `from_table_client` factory shipped in #161. Re-target to `main` once #161 merges.