### PR TITLE
feat(checkpointers): add experimental Cosmos DB checkpointer helper

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -139,3 +139,11 @@ CI tests include:
 - Unit tests with mock graphs (`tests/test_platform_routes.py`)
 - SDK integration tests with real `langgraph-sdk` client via `httpx.MockTransport` (`tests/test_sdk_compat.py`)
 - Contract shape tests (`tests/test_sdk_contracts.py`)
+
+## Optional checkpoint backends
+
+| Extra | Dependency | Python | Notes |
+|---|---|---|---|
+| `postgres` | `langgraph-checkpoint-postgres>=3.0,<4` | 3.10+ | Production DB checkpoint backend |
+| `sqlite` | `langgraph-checkpoint-sqlite>=3.0,<4` | 3.10+ | Local development |
+| `cosmos` | `langgraph-checkpoint-cosmos>=0.1.1,<0.2` | 3.11+ | Experimental Azure-native checkpoint backend |

--- a/README.md
+++ b/README.md
@@ -101,6 +101,19 @@ pip install azure-functions-langgraph[azure-table]
 pip install azure-functions-langgraph[azure-blob,azure-table]
 ```
 
+For database or Cosmos DB checkpointer backends:
+
+```bash
+# Postgres checkpointer
+pip install azure-functions-langgraph[postgres]
+
+# SQLite checkpointer (local dev)
+pip install azure-functions-langgraph[sqlite]
+
+# Cosmos DB checkpointer (requires Python 3.11+)
+pip install azure-functions-langgraph[cosmos]
+```
+
 Your Azure Functions app should also include:
 
 ```text
@@ -406,8 +419,9 @@ For workloads that already run a managed database (or need state shared across m
 | --- | --- | --- | --- |
 | Postgres | `create_postgres_checkpointer` | `pip install azure-functions-langgraph[postgres]` | Production, multi-instance, existing Postgres infra |
 | SQLite | `create_sqlite_checkpointer` | `pip install azure-functions-langgraph[sqlite]` | Local dev and single-instance deployments |
+| Cosmos DB | `create_cosmos_checkpointer` | `pip install azure-functions-langgraph[cosmos]` | Azure-native serverless/global production (Python 3.11+) |
 
-Each helper accepts a connection string, owns the connection lifetime, and (by default) calls upstream `setup()` on cold start so the checkpoint tables exist:
+Each helper owns the connection lifetime and emits clear ImportErrors pointing at the right extra. The Postgres and SQLite helpers accept a connection string and (by default) call upstream `setup()` on cold start so the checkpoint tables exist; the Cosmos DB helper accepts an endpoint and credential and enters the upstream context manager at cold start:
 
 ```python
 import os
@@ -420,12 +434,13 @@ checkpointer = create_postgres_checkpointer(
 graph = builder.compile(checkpointer=checkpointer)
 ```
 
-The helpers do not hide `builder.compile(checkpointer=...)` and do not reimplement DB checkpoint storage — they only centralize the env-var convention, run `setup()` once, and emit clear ImportErrors pointing at the right extra. See [`examples/postgres_checkpoint_production/`](examples/postgres_checkpoint_production/) and [`examples/sqlite_checkpoint_local/`](examples/sqlite_checkpoint_local/) for full Azure-Functions wiring.
+The helpers do not hide `builder.compile(checkpointer=...)` and do not reimplement DB checkpoint storage — they centralize connection conventions and emit clear ImportErrors pointing at the right extra. The Postgres and SQLite helpers run `setup()` once at cold start; the Cosmos DB helper enters the upstream context manager instead (no `setup()` call). See [`examples/postgres_checkpoint_production/`](examples/postgres_checkpoint_production/), [`examples/sqlite_checkpoint_local/`](examples/sqlite_checkpoint_local/), and [`examples/cosmos_checkpoint_azure/`](examples/cosmos_checkpoint_azure/) for full Azure-Functions wiring.
 
 | Backend | Comfortable | Caution zone | Switch backends |
 | --- | --- | --- | --- |
 | `create_sqlite_checkpointer` | local dev, single-instance prod | multi-process write contention | Use Postgres |
 | `create_postgres_checkpointer` | multi-instance Functions, existing Postgres infra | very high write QPS without read replicas | Add connection pooling / read replicas, or shard |
+| `create_cosmos_checkpointer` | Azure-native serverless, global distribution | high RU cost with large checkpoints | Tune RU allocation, use provisioned throughput |
 
 ### Upgrading
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -9,6 +9,7 @@
 | Persistent storage | [`persistent_agent_blob_table`](persistent_agent_blob_table/) | End-to-end Azure Blob checkpointer + Azure Table thread store, runnable on Azurite. |
 | DB checkpoint (local) | [`sqlite_checkpoint_local`](sqlite_checkpoint_local/) | LangGraph SQLite checkpointer wired via `create_sqlite_checkpointer()` for local dev. |
 | DB checkpoint (production) | [`postgres_checkpoint_production`](postgres_checkpoint_production/) | LangGraph Postgres checkpointer wired via `create_postgres_checkpointer()` for multi-instance prod. |
+| Cosmos DB checkpoint | [`cosmos_checkpoint_azure`](cosmos_checkpoint_azure/) | LangGraph Cosmos DB checkpointer wired via `create_cosmos_checkpointer()` with `DefaultAzureCredential` (Python 3.11+). |
 | Managed Identity | [`managed_identity_storage`](managed_identity_storage/) | Same backends wired with `DefaultAzureCredential` for production, with Azurite fallback for local dev. |
 | OpenAPI bridge | [`openapi_bridge`](openapi_bridge/) | Wires `register_with_openapi` into `azure-functions-openapi-python` for spec generation. |
 | Per-graph auth | [`production_auth`](production_auth/) | Public health + anonymous demo graph alongside a function-key-protected graph. |
@@ -31,6 +32,7 @@ Every example ships with:
 - **Switching from LangGraph Cloud / using `langgraph-sdk`?** → `platform_compat_sdk`
 - **Need state to survive restarts and scale-out?** → `persistent_agent_blob_table`
 - **Deploying to Azure with Managed Identity (no secrets in App Settings)?** → `managed_identity_storage`
+- **Azure-native Cosmos DB checkpoint persistence?** → `cosmos_checkpoint_azure`
 - **Want OpenAPI / Swagger UI for your endpoints?** → `openapi_bridge`
 - **Mixing public and private graphs?** → `production_auth`
 - **Verifying a deployed Function App from the terminal?** → `local_curl`

--- a/examples/cosmos_checkpoint_azure/README.md
+++ b/examples/cosmos_checkpoint_azure/README.md
@@ -25,7 +25,7 @@ Use this example when you want:
 
 ## Files
 
-- `function_app.py` — wires `create_cosmos_checkpointer` with `DefaultAzureCredential`
+- `function_app.py` — wires `create_cosmos_checkpointer` with default credential resolution (`DefaultAzureCredential`)
 - `graph.py` — turn-counting echo agent (storage-free, used by smoke tests)
 - `host.json`, `local.settings.json.example`, `requirements.txt`
 
@@ -67,7 +67,6 @@ Cosmos DB data-plane role:
 
 ```bash
 PRINCIPAL_ID=$(az functionapp identity show -n <function-app> -g <rg> --query principalId -o tsv)
-COSMOS_ID=$(az cosmosdb show -n <cosmos-account> -g <rg> --query id -o tsv)
 
 az cosmosdb sql role assignment create \
   --account-name <cosmos-account> \

--- a/examples/cosmos_checkpoint_azure/README.md
+++ b/examples/cosmos_checkpoint_azure/README.md
@@ -1,0 +1,103 @@
+# Cosmos DB Checkpointing
+
+This example shows how to persist LangGraph checkpoints in Azure Cosmos DB
+from an Azure Functions Python app.
+
+> **Experimental:** Cosmos DB checkpointer support is new and may change
+> before v1.0.
+
+## When to use this example
+
+Use this example when you want:
+
+- Azure-native checkpoint persistence
+- Managed Identity / DefaultAzureCredential
+- A serverless-friendly production backend
+- Multi-instance Azure Functions compatibility
+
+## Requirements
+
+- Python 3.11+
+- Azure Cosmos DB for NoSQL account
+- Cosmos DB database and container
+- Container partition key path: `/partition_key`
+- Managed Identity or local `az login`
+
+## Files
+
+- `function_app.py` — wires `create_cosmos_checkpointer` with `DefaultAzureCredential`
+- `graph.py` — turn-counting echo agent (storage-free, used by smoke tests)
+- `host.json`, `local.settings.json.example`, `requirements.txt`
+
+## App Settings
+
+| Setting | Description |
+|---|---|
+| `AZURE_COSMOS_ENDPOINT` | Cosmos DB account endpoint |
+| `LANGGRAPH_COSMOS_DATABASE` | Cosmos DB database name (default: `langgraph`) |
+| `LANGGRAPH_COSMOS_CONTAINER` | Cosmos DB container name (default: `checkpoints`) |
+
+## Azure Cosmos DB setup
+
+1. Create an Azure Cosmos DB account (NoSQL API)
+2. Create a database (e.g. `langgraph`)
+3. Create a container with partition key path `/partition_key`
+
+## Local development
+
+Run against a real Cosmos DB account using Azure CLI credentials:
+
+```bash
+az login
+
+cp local.settings.json.example local.settings.json
+# Edit local.settings.json with your Cosmos DB endpoint
+
+pip install -r requirements.txt
+func start
+```
+
+> **Note:** This example does not use the Cosmos DB Emulator.
+> A real Cosmos DB account is required for local testing.
+
+## Production
+
+Enable Managed Identity on the Function App and grant the required
+Cosmos DB data-plane role:
+
+```bash
+PRINCIPAL_ID=$(az functionapp identity show -n <function-app> -g <rg> --query principalId -o tsv)
+COSMOS_ID=$(az cosmosdb show -n <cosmos-account> -g <rg> --query id -o tsv)
+
+az cosmosdb sql role assignment create \
+  --account-name <cosmos-account> \
+  --resource-group <rg> \
+  --scope "/" \
+  --principal-id "$PRINCIPAL_ID" \
+  --role-definition-id "00000000-0000-0000-0000-000000000002"  # Cosmos DB Built-in Data Contributor
+```
+
+## Verify persistence
+
+```bash
+THREAD=$(curl -s -X POST "http://localhost:7071/api/threads" \
+  -H "Content-Type: application/json" -d '{}' \
+  | python -c 'import json,sys; print(json.load(sys.stdin)["thread_id"])')
+
+curl -s -X POST "http://localhost:7071/api/threads/$THREAD/runs/wait" \
+  -H "Content-Type: application/json" \
+  -d '{"assistant_id":"cosmos_agent","input":{"messages":[{"role":"human","content":"first"}]}}'
+
+curl -s -X POST "http://localhost:7071/api/threads/$THREAD/runs/wait" \
+  -H "Content-Type: application/json" \
+  -d '{"assistant_id":"cosmos_agent","input":{"messages":[{"role":"human","content":"second"}]}}'
+```
+
+The second response shows `[turn 2]`.
+
+## Notes
+
+- This example does not use the Cosmos DB Emulator.
+- This example does not use connection strings by default.
+- The `cosmos` extra requires Python 3.11+.
+- The Cosmos DB container must be created with partition key path `/partition_key`.

--- a/examples/cosmos_checkpoint_azure/function_app.py
+++ b/examples/cosmos_checkpoint_azure/function_app.py
@@ -12,7 +12,7 @@ checkpointer = create_cosmos_checkpointer(
     endpoint=os.environ["AZURE_COSMOS_ENDPOINT"],
     database_name=os.environ.get("LANGGRAPH_COSMOS_DATABASE", "langgraph"),
     container_name=os.environ.get("LANGGRAPH_COSMOS_CONTAINER", "checkpoints"),
-    credential="default",
+    # credential=None uses DefaultAzureCredential (Managed Identity in Azure, az login locally)
 )
 
 compiled_graph = build_graph().compile(checkpointer=checkpointer)

--- a/examples/cosmos_checkpoint_azure/function_app.py
+++ b/examples/cosmos_checkpoint_azure/function_app.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import os
+
+import azure.functions as func
+from graph import build_graph
+
+from azure_functions_langgraph import LangGraphApp
+from azure_functions_langgraph.checkpointers.cosmos import create_cosmos_checkpointer
+
+checkpointer = create_cosmos_checkpointer(
+    endpoint=os.environ["AZURE_COSMOS_ENDPOINT"],
+    database_name=os.environ.get("LANGGRAPH_COSMOS_DATABASE", "langgraph"),
+    container_name=os.environ.get("LANGGRAPH_COSMOS_CONTAINER", "checkpoints"),
+    credential="default",
+)
+
+compiled_graph = build_graph().compile(checkpointer=checkpointer)
+
+langgraph_app = LangGraphApp(
+    platform_compat=True,
+    auth_level=func.AuthLevel.FUNCTION,
+)
+
+langgraph_app.register(
+    graph=compiled_graph,
+    name="cosmos_agent",
+    description=(
+        "Echo agent persisted with Azure Cosmos DB checkpoint saver using DefaultAzureCredential."
+    ),
+)
+
+app = langgraph_app.function_app

--- a/examples/cosmos_checkpoint_azure/graph.py
+++ b/examples/cosmos_checkpoint_azure/graph.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from typing import Any
+
+from langgraph.graph import END, START, StateGraph
+from typing_extensions import TypedDict
+
+
+class AgentState(TypedDict):
+    messages: list[dict[str, str]]
+    turn: int
+
+
+def respond(state: AgentState) -> dict[str, Any]:
+    user_msg = state["messages"][-1]["content"] if state["messages"] else ""
+    turn = state.get("turn", 0) + 1
+    return {
+        "messages": state["messages"]
+        + [
+            {
+                "role": "assistant",
+                "content": f"[turn {turn}] Echo: {user_msg}",
+            }
+        ],
+        "turn": turn,
+    }
+
+
+def build_graph() -> StateGraph:
+    builder = StateGraph(AgentState)
+    builder.add_node("respond", respond)
+    builder.add_edge(START, "respond")
+    builder.add_edge("respond", END)
+    return builder
+
+
+compiled_graph = build_graph().compile()

--- a/examples/cosmos_checkpoint_azure/host.json
+++ b/examples/cosmos_checkpoint_azure/host.json
@@ -1,0 +1,15 @@
+{
+  "version": "2.0",
+  "logging": {
+    "applicationInsights": {
+      "samplingSettings": {
+        "isEnabled": true,
+        "excludedTypes": "Request"
+      }
+    }
+  },
+  "extensionBundle": {
+    "id": "Microsoft.Azure.Functions.ExtensionBundle",
+    "version": "[4.*, 5.0.0)"
+  }
+}

--- a/examples/cosmos_checkpoint_azure/local.settings.json.example
+++ b/examples/cosmos_checkpoint_azure/local.settings.json.example
@@ -1,0 +1,10 @@
+{
+  "IsEncrypted": false,
+  "Values": {
+    "AzureWebJobsStorage": "UseDevelopmentStorage=true",
+    "FUNCTIONS_WORKER_RUNTIME": "python",
+    "AZURE_COSMOS_ENDPOINT": "https://<cosmos-account>.documents.azure.com:443/",
+    "LANGGRAPH_COSMOS_DATABASE": "langgraph",
+    "LANGGRAPH_COSMOS_CONTAINER": "checkpoints"
+  }
+}

--- a/examples/cosmos_checkpoint_azure/requirements.txt
+++ b/examples/cosmos_checkpoint_azure/requirements.txt
@@ -1,0 +1,14 @@
+# Do not include azure-functions-worker in this file
+# The Python Worker is managed by the Azure Functions platform
+#
+# This example requires Python 3.11+ because the Cosmos DB checkpointer
+# extra depends on packages that require Python 3.11+.
+#
+# Until v0.7.0 is released, install from a local checkout:
+#
+#     pip install -e ../..[cosmos,azure-identity]
+
+azure-functions
+azure-functions-langgraph[cosmos,azure-identity]>=0.7.0,<0.8.0
+langgraph>=1.0,<2.0
+langchain-core>=1.0,<2.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,9 @@ postgres = [
 sqlite = [
     "langgraph-checkpoint-sqlite>=3.0,<4",
 ]
+cosmos = [
+    "langgraph-checkpoint-cosmos>=0.1.1,<0.2",
+]
 dev = [
     "bandit==1.9.4",
     "build",

--- a/src/azure_functions_langgraph/checkpointers/__init__.py
+++ b/src/azure_functions_langgraph/checkpointers/__init__.py
@@ -8,6 +8,7 @@ if TYPE_CHECKING:
     from .azure_blob import (
         AzureBlobCheckpointSaver,
     )
+    from .cosmos import create_cosmos_checkpointer
     from .postgres import create_postgres_checkpointer
     from .sqlite import create_sqlite_checkpointer
 
@@ -25,11 +26,16 @@ def __getattr__(name: str) -> object:
         from .sqlite import create_sqlite_checkpointer
 
         return create_sqlite_checkpointer
+    if name == "create_cosmos_checkpointer":
+        from .cosmos import create_cosmos_checkpointer
+
+        return create_cosmos_checkpointer
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 __all__ = [
     "AzureBlobCheckpointSaver",
+    "create_cosmos_checkpointer",
     "create_postgres_checkpointer",
     "create_sqlite_checkpointer",
 ]

--- a/src/azure_functions_langgraph/checkpointers/cosmos.py
+++ b/src/azure_functions_langgraph/checkpointers/cosmos.py
@@ -1,0 +1,126 @@
+"""Cosmos DB checkpointer DX helper.
+
+.. versionadded:: 0.7.0
+
+Thin wrapper around the upstream :pypi:`langgraph-checkpoint-cosmos`
+package that resolves credentials and builds a :class:`CosmosDBSaver`
+suitable for Azure Functions cold-start (module-level instantiation).
+
+The upstream saver is designed as a **context manager**.  This helper
+calls ``__enter__`` so the returned object is ready to use immediately
+and can be passed straight to ``builder.compile(checkpointer=...)``.
+
+This module deliberately does **not** reimplement Cosmos DB checkpoint
+storage.  It centralizes the credential convention, handles the
+context-manager lifecycle, and emits a clear ImportError pointing at
+the right extra when the upstream package is missing.
+
+.. note::
+
+   The ``cosmos`` extra requires **Python 3.11+**.  The base package
+   continues to support Python 3.10.
+"""
+
+from __future__ import annotations
+
+import importlib
+import logging
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from langgraph_checkpoint_cosmos import CosmosDBSaver
+
+logger = logging.getLogger(__name__)
+
+_EXTRA_HINT = (
+    "Cosmos DB checkpointer requires the 'cosmos' extra: "
+    "pip install azure-functions-langgraph[cosmos]"
+)
+
+
+def create_cosmos_checkpointer(
+    *,
+    endpoint: str,
+    database_name: str,
+    container_name: str,
+    credential: Any = "default",
+) -> CosmosDBSaver:
+    """Create a long-lived :class:`CosmosDBSaver` from connection info.
+
+    Resolves credentials (``"default"`` → :class:`DefaultAzureCredential`)
+    and calls :meth:`CosmosDBSaver.from_conn_info` to build the saver.
+    The context manager is entered immediately so the returned object is
+    ready for use at Azure Functions cold-start.
+
+    Args:
+        endpoint: Cosmos DB account endpoint
+            (e.g. ``https://<account>.documents.azure.com:443/``).
+        database_name: Cosmos DB database name.
+        container_name: Cosmos DB container name.  The container **must**
+            be created with partition key path ``/partition_key``.
+        credential: A credential object accepted by the Azure Cosmos SDK,
+            or the string ``"default"`` (the default) to create a
+            :class:`~azure.identity.DefaultAzureCredential`.
+
+    Returns:
+        A :class:`CosmosDBSaver` ready to be passed to
+        ``builder.compile(checkpointer=...)``.
+
+    Raises:
+        ImportError: If ``langgraph-checkpoint-cosmos`` or
+            ``azure-identity`` (when ``credential="default"``) is not
+            installed.  Install via the ``cosmos`` extra.
+    """
+    try:
+        cosmos_module = importlib.import_module("langgraph_checkpoint_cosmos")
+    except ImportError as exc:
+        raise ImportError(_EXTRA_HINT) from exc
+
+    CosmosDBSaver = getattr(cosmos_module, "CosmosDBSaver", None)
+    if CosmosDBSaver is None:
+        raise ImportError(
+            "langgraph_checkpoint_cosmos is missing CosmosDBSaver; "
+            "upgrade langgraph-checkpoint-cosmos to >=0.1.1,<0.2."
+        )
+
+    resolved_credential: Any
+    if credential == "default":
+        try:
+            identity_module = importlib.import_module("azure.identity")
+        except ImportError as exc:
+            raise ImportError(
+                "credential='default' requires azure-identity. "
+                "It is normally installed as a dependency of langgraph-checkpoint-cosmos; "
+                "if missing, run: pip install azure-identity>=1.15"
+            ) from exc
+        DefaultAzureCredential = getattr(identity_module, "DefaultAzureCredential", None)
+        if DefaultAzureCredential is None:
+            raise ImportError(
+                "azure.identity is missing DefaultAzureCredential; "
+                "upgrade azure-identity to >=1.16,<2."
+            )
+        resolved_credential = DefaultAzureCredential()
+    else:
+        resolved_credential = credential
+
+    cm = CosmosDBSaver.from_conn_info(
+        endpoint=endpoint,
+        credential=resolved_credential,
+        database_name=database_name,
+        container_name=container_name,
+    )
+
+    # from_conn_info is a @contextmanager that yields the actual
+    # CosmosDBSaver instance.  We must capture the return value of
+    # __enter__ — it is the yielded saver, not the CM wrapper.
+    saver = cm.__enter__()
+
+    # Stash the context manager so it is not garbage-collected (which
+    # would trigger __exit__ on a generator-based CM) and remains
+    # available for future cleanup if needed.
+    saver._langgraph_cm = cm  # noqa: SLF001
+
+    return saver
+
+
+__all__ = ["create_cosmos_checkpointer"]

--- a/src/azure_functions_langgraph/checkpointers/cosmos.py
+++ b/src/azure_functions_langgraph/checkpointers/cosmos.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 import importlib
 import logging
+import sys
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -33,7 +34,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 _EXTRA_HINT = (
-    "Cosmos DB checkpointer requires the 'cosmos' extra: "
+    "Cosmos DB checkpointer requires the 'cosmos' extra (Python 3.11+): "
     "pip install azure-functions-langgraph[cosmos]"
 )
 
@@ -43,11 +44,11 @@ def create_cosmos_checkpointer(
     endpoint: str,
     database_name: str,
     container_name: str,
-    credential: Any = "default",
+    credential: object | None = None,
 ) -> CosmosDBSaver:
     """Create a long-lived :class:`CosmosDBSaver` from connection info.
 
-    Resolves credentials (``"default"`` → :class:`DefaultAzureCredential`)
+    Resolves credentials (``None`` → :class:`DefaultAzureCredential`)
     and calls :meth:`CosmosDBSaver.from_conn_info` to build the saver.
     The context manager is entered immediately so the returned object is
     ready for use at Azure Functions cold-start.
@@ -59,7 +60,7 @@ def create_cosmos_checkpointer(
         container_name: Cosmos DB container name.  The container **must**
             be created with partition key path ``/partition_key``.
         credential: A credential object accepted by the Azure Cosmos SDK,
-            or the string ``"default"`` (the default) to create a
+            or ``None`` (the default) to create a
             :class:`~azure.identity.DefaultAzureCredential`.
 
     Returns:
@@ -67,10 +68,16 @@ def create_cosmos_checkpointer(
         ``builder.compile(checkpointer=...)``.
 
     Raises:
+        RuntimeError: If running on Python < 3.11.
         ImportError: If ``langgraph-checkpoint-cosmos`` or
-            ``azure-identity`` (when ``credential="default"``) is not
+            ``azure-identity`` (when ``credential=None``) is not
             installed.  Install via the ``cosmos`` extra.
     """
+    if sys.version_info < (3, 11):
+        raise RuntimeError(
+            "Cosmos DB checkpointer requires Python 3.11+ "
+            "because langgraph-checkpoint-cosmos does not support Python 3.10."
+        )
     try:
         cosmos_module = importlib.import_module("langgraph_checkpoint_cosmos")
     except ImportError as exc:
@@ -84,14 +91,14 @@ def create_cosmos_checkpointer(
         )
 
     resolved_credential: Any
-    if credential == "default":
+    if credential is None:
         try:
             identity_module = importlib.import_module("azure.identity")
         except ImportError as exc:
             raise ImportError(
-                "credential='default' requires azure-identity. "
+                "credential=None requires azure-identity. "
                 "It is normally installed as a dependency of langgraph-checkpoint-cosmos; "
-                "if missing, run: pip install azure-identity>=1.15"
+                "if missing, run: pip install azure-identity>=1.16"
             ) from exc
         DefaultAzureCredential = getattr(identity_module, "DefaultAzureCredential", None)
         if DefaultAzureCredential is None:

--- a/src/azure_functions_langgraph/checkpointers/cosmos.py
+++ b/src/azure_functions_langgraph/checkpointers/cosmos.py
@@ -24,14 +24,12 @@ the right extra when the upstream package is missing.
 from __future__ import annotations
 
 import importlib
-import logging
 import sys
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from langgraph_checkpoint_cosmos import CosmosDBSaver
 
-logger = logging.getLogger(__name__)
 
 _EXTRA_HINT = (
     "Cosmos DB checkpointer requires the 'cosmos' extra (Python 3.11+): "

--- a/tests/test_checkpointers_cosmos_helper.py
+++ b/tests/test_checkpointers_cosmos_helper.py
@@ -108,6 +108,11 @@ def _install_fake_azure_identity(
 # ---------------------------------------------------------------------------
 
 
+def _patch_python_311(monkeypatch: Any) -> None:
+    """Pretend we are on Python 3.11 so the runtime guard passes."""
+    cosmos_mod = importlib.import_module("azure_functions_langgraph.checkpointers.cosmos")
+    monkeypatch.setattr(cosmos_mod.sys, "version_info", (3, 11, 0))
+
 def test_cosmos_helper_creates_saver_and_enters_context(monkeypatch: Any) -> None:
     conn_info_calls: list[dict[str, Any]] = []
     enter_calls: list[int] = []
@@ -120,6 +125,7 @@ def test_cosmos_helper_creates_saver_and_enters_context(monkeypatch: Any) -> Non
 
     module = importlib.import_module("azure_functions_langgraph.checkpointers.cosmos")
     importlib.reload(module)
+    _patch_python_311(monkeypatch)
     saver = module.create_cosmos_checkpointer(
         endpoint="https://test.documents.azure.com:443/",
         database_name="testdb",
@@ -144,6 +150,7 @@ def test_cosmos_helper_returns_yielded_saver_not_cm(monkeypatch: Any) -> None:
 
     module = importlib.import_module("azure_functions_langgraph.checkpointers.cosmos")
     importlib.reload(module)
+    _patch_python_311(monkeypatch)
     saver = module.create_cosmos_checkpointer(
         endpoint="https://test.documents.azure.com:443/",
         database_name="db",
@@ -162,6 +169,7 @@ def test_cosmos_helper_stashes_cm_on_saver(monkeypatch: Any) -> None:
 
     module = importlib.import_module("azure_functions_langgraph.checkpointers.cosmos")
     importlib.reload(module)
+    _patch_python_311(monkeypatch)
     saver = module.create_cosmos_checkpointer(
         endpoint="https://test.documents.azure.com:443/",
         database_name="db",
@@ -182,11 +190,11 @@ def test_cosmos_helper_default_credential_creates_default_azure_credential(
 
     module = importlib.import_module("azure_functions_langgraph.checkpointers.cosmos")
     importlib.reload(module)
+    _patch_python_311(monkeypatch)
     module.create_cosmos_checkpointer(
         endpoint="https://test.documents.azure.com:443/",
         database_name="db",
         container_name="ctr",
-        credential="default",
     )
 
     assert credential_calls == [1]
@@ -199,6 +207,7 @@ def test_cosmos_helper_explicit_credential_forwarded(monkeypatch: Any) -> None:
 
     module = importlib.import_module("azure_functions_langgraph.checkpointers.cosmos")
     importlib.reload(module)
+    _patch_python_311(monkeypatch)
 
     my_cred = object()
     module.create_cosmos_checkpointer(
@@ -217,6 +226,7 @@ def test_cosmos_helper_endpoint_forwarded(monkeypatch: Any) -> None:
 
     module = importlib.import_module("azure_functions_langgraph.checkpointers.cosmos")
     importlib.reload(module)
+    _patch_python_311(monkeypatch)
     module.create_cosmos_checkpointer(
         endpoint="https://custom.documents.azure.com:443/",
         database_name="db",
@@ -233,6 +243,7 @@ def test_cosmos_helper_database_name_forwarded(monkeypatch: Any) -> None:
 
     module = importlib.import_module("azure_functions_langgraph.checkpointers.cosmos")
     importlib.reload(module)
+    _patch_python_311(monkeypatch)
     module.create_cosmos_checkpointer(
         endpoint="https://x.documents.azure.com:443/",
         database_name="my_database",
@@ -249,6 +260,7 @@ def test_cosmos_helper_container_name_forwarded(monkeypatch: Any) -> None:
 
     module = importlib.import_module("azure_functions_langgraph.checkpointers.cosmos")
     importlib.reload(module)
+    _patch_python_311(monkeypatch)
     module.create_cosmos_checkpointer(
         endpoint="https://x.documents.azure.com:443/",
         database_name="db",
@@ -269,6 +281,7 @@ def test_cosmos_helper_missing_cosmos_package_raises_helpful_error(monkeypatch: 
         return real_import_module(name)
 
     monkeypatch.setattr(module.importlib, "import_module", fake_import_module)
+    _patch_python_311(monkeypatch)
 
     with pytest.raises(ImportError, match=r"\[cosmos\]"):
         module.create_cosmos_checkpointer(
@@ -282,6 +295,7 @@ def test_cosmos_helper_missing_cosmos_saver_symbol_raises(monkeypatch: Any) -> N
     _install_fake_cosmos(monkeypatch, omit_cosmos_saver=True)
     module = importlib.import_module("azure_functions_langgraph.checkpointers.cosmos")
     importlib.reload(module)
+    _patch_python_311(monkeypatch)
 
     with pytest.raises(ImportError, match="CosmosDBSaver"):
         module.create_cosmos_checkpointer(
@@ -296,6 +310,7 @@ def test_cosmos_helper_missing_azure_identity_raises_helpful_error(monkeypatch: 
     _install_fake_cosmos(monkeypatch)
     module = importlib.import_module("azure_functions_langgraph.checkpointers.cosmos")
     importlib.reload(module)
+    _patch_python_311(monkeypatch)
 
     real_import_module = importlib.import_module
 
@@ -311,7 +326,6 @@ def test_cosmos_helper_missing_azure_identity_raises_helpful_error(monkeypatch: 
             endpoint="https://x.documents.azure.com:443/",
             database_name="db",
             container_name="ctr",
-            credential="default",
         )
 
 
@@ -320,13 +334,13 @@ def test_cosmos_helper_missing_default_azure_credential_symbol_raises(monkeypatc
     _install_fake_azure_identity(monkeypatch, omit_default_credential=True)
     module = importlib.import_module("azure_functions_langgraph.checkpointers.cosmos")
     importlib.reload(module)
+    _patch_python_311(monkeypatch)
 
     with pytest.raises(ImportError, match="DefaultAzureCredential"):
         module.create_cosmos_checkpointer(
             endpoint="https://x.documents.azure.com:443/",
             database_name="db",
             container_name="ctr",
-            credential="default",
         )
 
 
@@ -334,3 +348,19 @@ def test_checkpointers_package_exports_cosmos_helper() -> None:
     pkg = importlib.import_module("azure_functions_langgraph.checkpointers")
     assert "create_cosmos_checkpointer" in pkg.__all__
     assert callable(pkg.create_cosmos_checkpointer)
+
+
+def test_cosmos_helper_python_310_raises_runtime_error(monkeypatch: Any) -> None:
+    """On Python < 3.11 the helper must raise RuntimeError immediately."""
+    module = importlib.import_module("azure_functions_langgraph.checkpointers.cosmos")
+    importlib.reload(module)
+
+    monkeypatch.setattr(module.sys, "version_info", (3, 10, 0))
+
+    with pytest.raises(RuntimeError, match="Python 3.11"):
+        module.create_cosmos_checkpointer(
+            endpoint="https://x.documents.azure.com:443/",
+            database_name="db",
+            container_name="ctr",
+            credential=object(),
+        )

--- a/tests/test_checkpointers_cosmos_helper.py
+++ b/tests/test_checkpointers_cosmos_helper.py
@@ -1,0 +1,336 @@
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+from typing import Any, cast
+
+pytest = cast(Any, importlib.import_module("pytest"))
+
+
+# ---------------------------------------------------------------------------
+# Fake module installers
+# ---------------------------------------------------------------------------
+
+
+class FakeCosmosDBSaver:
+    """Fake saver returned by the context manager's ``__enter__``."""
+
+    def __init__(self, **kwargs: Any) -> None:
+        self.kwargs = kwargs
+        self._entered = True
+
+
+class _FakeContextManager:
+    """Fake CM that mimics the upstream ``@contextmanager`` behaviour.
+
+    ``__enter__`` returns a *different* object (``FakeCosmosDBSaver``)
+    to match the real upstream contract where ``from_conn_info`` is a
+    generator-based ``@contextmanager`` that *yields* the saver.
+    """
+
+    def __init__(self, saver: FakeCosmosDBSaver) -> None:
+        self._saver = saver
+
+    def __enter__(self) -> FakeCosmosDBSaver:
+        return self._saver
+
+    def __exit__(self, *args: Any) -> None:
+        pass
+
+
+def _install_fake_cosmos(
+    monkeypatch: Any,
+    *,
+    from_conn_info_calls: list[dict[str, Any]] | None = None,
+    enter_calls: list[int] | None = None,
+    omit_cosmos_saver: bool = False,
+) -> None:
+    """Inject fake ``langgraph_checkpoint_cosmos`` into ``sys.modules``."""
+    captured_conn_info = from_conn_info_calls if from_conn_info_calls is not None else []
+    captured_enter = enter_calls if enter_calls is not None else []
+
+    class FakeCosmosDBSaverClass:
+        """Class-level fake that provides ``from_conn_info``."""
+
+        @classmethod
+        def from_conn_info(
+            cls,
+            *,
+            endpoint: str,
+            credential: Any,
+            database_name: str,
+            container_name: str,
+        ) -> _FakeContextManager:
+            captured_conn_info.append(
+                {
+                    "endpoint": endpoint,
+                    "credential": credential,
+                    "database_name": database_name,
+                    "container_name": container_name,
+                }
+            )
+            saver = FakeCosmosDBSaver()
+            captured_enter.append(1)
+            return _FakeContextManager(saver)
+
+    cosmos_module = types.ModuleType("langgraph_checkpoint_cosmos")
+    if not omit_cosmos_saver:
+        setattr(cosmos_module, "CosmosDBSaver", FakeCosmosDBSaverClass)
+
+    monkeypatch.setitem(sys.modules, "langgraph_checkpoint_cosmos", cosmos_module)
+
+
+def _install_fake_azure_identity(
+    monkeypatch: Any,
+    *,
+    credential_calls: list[int] | None = None,
+    omit_default_credential: bool = False,
+) -> None:
+    """Inject fake ``azure.identity`` into ``sys.modules``."""
+    captured = credential_calls if credential_calls is not None else []
+
+    class FakeDefaultAzureCredential:
+        def __init__(self) -> None:
+            captured.append(1)
+
+    azure_module = types.ModuleType("azure")
+    identity_module = types.ModuleType("azure.identity")
+    if not omit_default_credential:
+        setattr(identity_module, "DefaultAzureCredential", FakeDefaultAzureCredential)
+
+    monkeypatch.setitem(sys.modules, "azure", azure_module)
+    monkeypatch.setitem(sys.modules, "azure.identity", identity_module)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_cosmos_helper_creates_saver_and_enters_context(monkeypatch: Any) -> None:
+    conn_info_calls: list[dict[str, Any]] = []
+    enter_calls: list[int] = []
+    _install_fake_cosmos(
+        monkeypatch,
+        from_conn_info_calls=conn_info_calls,
+        enter_calls=enter_calls,
+    )
+    _install_fake_azure_identity(monkeypatch)
+
+    module = importlib.import_module("azure_functions_langgraph.checkpointers.cosmos")
+    importlib.reload(module)
+    saver = module.create_cosmos_checkpointer(
+        endpoint="https://test.documents.azure.com:443/",
+        database_name="testdb",
+        container_name="testcontainer",
+    )
+
+    assert len(conn_info_calls) == 1
+    assert conn_info_calls[0]["endpoint"] == "https://test.documents.azure.com:443/"
+    assert conn_info_calls[0]["database_name"] == "testdb"
+    assert conn_info_calls[0]["container_name"] == "testcontainer"
+    assert enter_calls == [1]
+    # The returned object must be FakeCosmosDBSaver (the yielded saver),
+    # NOT the context manager wrapper.
+    assert type(saver).__name__ == "FakeCosmosDBSaver"
+    assert saver._entered is True
+
+
+def test_cosmos_helper_returns_yielded_saver_not_cm(monkeypatch: Any) -> None:
+    """Verify that ``__enter__`` return value is captured, not the CM."""
+    _install_fake_cosmos(monkeypatch)
+    _install_fake_azure_identity(monkeypatch)
+
+    module = importlib.import_module("azure_functions_langgraph.checkpointers.cosmos")
+    importlib.reload(module)
+    saver = module.create_cosmos_checkpointer(
+        endpoint="https://test.documents.azure.com:443/",
+        database_name="db",
+        container_name="ctr",
+    )
+
+    # Must be the yielded FakeCosmosDBSaver, not _FakeContextManager
+    assert type(saver).__name__ == "FakeCosmosDBSaver"
+    assert type(saver).__name__ != "_FakeContextManager"
+
+
+def test_cosmos_helper_stashes_cm_on_saver(monkeypatch: Any) -> None:
+    """The context manager must be stashed on the saver to prevent GC."""
+    _install_fake_cosmos(monkeypatch)
+    _install_fake_azure_identity(monkeypatch)
+
+    module = importlib.import_module("azure_functions_langgraph.checkpointers.cosmos")
+    importlib.reload(module)
+    saver = module.create_cosmos_checkpointer(
+        endpoint="https://test.documents.azure.com:443/",
+        database_name="db",
+        container_name="ctr",
+    )
+
+    assert hasattr(saver, "_langgraph_cm")
+    assert type(saver._langgraph_cm).__name__ == "_FakeContextManager"
+
+
+def test_cosmos_helper_default_credential_creates_default_azure_credential(
+    monkeypatch: Any,
+) -> None:
+    conn_info_calls: list[dict[str, Any]] = []
+    credential_calls: list[int] = []
+    _install_fake_cosmos(monkeypatch, from_conn_info_calls=conn_info_calls)
+    _install_fake_azure_identity(monkeypatch, credential_calls=credential_calls)
+
+    module = importlib.import_module("azure_functions_langgraph.checkpointers.cosmos")
+    importlib.reload(module)
+    module.create_cosmos_checkpointer(
+        endpoint="https://test.documents.azure.com:443/",
+        database_name="db",
+        container_name="ctr",
+        credential="default",
+    )
+
+    assert credential_calls == [1]
+    assert type(conn_info_calls[0]["credential"]).__name__ == "FakeDefaultAzureCredential"
+
+
+def test_cosmos_helper_explicit_credential_forwarded(monkeypatch: Any) -> None:
+    conn_info_calls: list[dict[str, Any]] = []
+    _install_fake_cosmos(monkeypatch, from_conn_info_calls=conn_info_calls)
+
+    module = importlib.import_module("azure_functions_langgraph.checkpointers.cosmos")
+    importlib.reload(module)
+
+    my_cred = object()
+    module.create_cosmos_checkpointer(
+        endpoint="https://test.documents.azure.com:443/",
+        database_name="db",
+        container_name="ctr",
+        credential=my_cred,
+    )
+
+    assert conn_info_calls[0]["credential"] is my_cred
+
+
+def test_cosmos_helper_endpoint_forwarded(monkeypatch: Any) -> None:
+    conn_info_calls: list[dict[str, Any]] = []
+    _install_fake_cosmos(monkeypatch, from_conn_info_calls=conn_info_calls)
+
+    module = importlib.import_module("azure_functions_langgraph.checkpointers.cosmos")
+    importlib.reload(module)
+    module.create_cosmos_checkpointer(
+        endpoint="https://custom.documents.azure.com:443/",
+        database_name="db",
+        container_name="ctr",
+        credential=object(),
+    )
+
+    assert conn_info_calls[0]["endpoint"] == "https://custom.documents.azure.com:443/"
+
+
+def test_cosmos_helper_database_name_forwarded(monkeypatch: Any) -> None:
+    conn_info_calls: list[dict[str, Any]] = []
+    _install_fake_cosmos(monkeypatch, from_conn_info_calls=conn_info_calls)
+
+    module = importlib.import_module("azure_functions_langgraph.checkpointers.cosmos")
+    importlib.reload(module)
+    module.create_cosmos_checkpointer(
+        endpoint="https://x.documents.azure.com:443/",
+        database_name="my_database",
+        container_name="ctr",
+        credential=object(),
+    )
+
+    assert conn_info_calls[0]["database_name"] == "my_database"
+
+
+def test_cosmos_helper_container_name_forwarded(monkeypatch: Any) -> None:
+    conn_info_calls: list[dict[str, Any]] = []
+    _install_fake_cosmos(monkeypatch, from_conn_info_calls=conn_info_calls)
+
+    module = importlib.import_module("azure_functions_langgraph.checkpointers.cosmos")
+    importlib.reload(module)
+    module.create_cosmos_checkpointer(
+        endpoint="https://x.documents.azure.com:443/",
+        database_name="db",
+        container_name="my_container",
+        credential=object(),
+    )
+
+    assert conn_info_calls[0]["container_name"] == "my_container"
+
+
+def test_cosmos_helper_missing_cosmos_package_raises_helpful_error(monkeypatch: Any) -> None:
+    module = importlib.import_module("azure_functions_langgraph.checkpointers.cosmos")
+    real_import_module = importlib.import_module
+
+    def fake_import_module(name: str) -> Any:
+        if name == "langgraph_checkpoint_cosmos":
+            raise ImportError("missing")
+        return real_import_module(name)
+
+    monkeypatch.setattr(module.importlib, "import_module", fake_import_module)
+
+    with pytest.raises(ImportError, match=r"\[cosmos\]"):
+        module.create_cosmos_checkpointer(
+            endpoint="https://x.documents.azure.com:443/",
+            database_name="db",
+            container_name="ctr",
+        )
+
+
+def test_cosmos_helper_missing_cosmos_saver_symbol_raises(monkeypatch: Any) -> None:
+    _install_fake_cosmos(monkeypatch, omit_cosmos_saver=True)
+    module = importlib.import_module("azure_functions_langgraph.checkpointers.cosmos")
+    importlib.reload(module)
+
+    with pytest.raises(ImportError, match="CosmosDBSaver"):
+        module.create_cosmos_checkpointer(
+            endpoint="https://x.documents.azure.com:443/",
+            database_name="db",
+            container_name="ctr",
+            credential=object(),
+        )
+
+
+def test_cosmos_helper_missing_azure_identity_raises_helpful_error(monkeypatch: Any) -> None:
+    _install_fake_cosmos(monkeypatch)
+    module = importlib.import_module("azure_functions_langgraph.checkpointers.cosmos")
+    importlib.reload(module)
+
+    real_import_module = importlib.import_module
+
+    def fake_import_module(name: str) -> Any:
+        if name == "azure.identity":
+            raise ImportError("missing")
+        return real_import_module(name)
+
+    monkeypatch.setattr(module.importlib, "import_module", fake_import_module)
+
+    with pytest.raises(ImportError, match="azure-identity"):
+        module.create_cosmos_checkpointer(
+            endpoint="https://x.documents.azure.com:443/",
+            database_name="db",
+            container_name="ctr",
+            credential="default",
+        )
+
+
+def test_cosmos_helper_missing_default_azure_credential_symbol_raises(monkeypatch: Any) -> None:
+    _install_fake_cosmos(monkeypatch)
+    _install_fake_azure_identity(monkeypatch, omit_default_credential=True)
+    module = importlib.import_module("azure_functions_langgraph.checkpointers.cosmos")
+    importlib.reload(module)
+
+    with pytest.raises(ImportError, match="DefaultAzureCredential"):
+        module.create_cosmos_checkpointer(
+            endpoint="https://x.documents.azure.com:443/",
+            database_name="db",
+            container_name="ctr",
+            credential="default",
+        )
+
+
+def test_checkpointers_package_exports_cosmos_helper() -> None:
+    pkg = importlib.import_module("azure_functions_langgraph.checkpointers")
+    assert "create_cosmos_checkpointer" in pkg.__all__
+    assert callable(pkg.create_cosmos_checkpointer)

--- a/tests/test_checkpointers_cosmos_helper.py
+++ b/tests/test_checkpointers_cosmos_helper.py
@@ -29,15 +29,17 @@ class _FakeContextManager:
     generator-based ``@contextmanager`` that *yields* the saver.
     """
 
-    def __init__(self, saver: FakeCosmosDBSaver) -> None:
+    def __init__(self, saver: FakeCosmosDBSaver, enter_calls: list[int] | None = None) -> None:
         self._saver = saver
+        self._enter_calls = enter_calls
 
     def __enter__(self) -> FakeCosmosDBSaver:
+        if self._enter_calls is not None:
+            self._enter_calls.append(1)
         return self._saver
 
     def __exit__(self, *args: Any) -> None:
         pass
-
 
 def _install_fake_cosmos(
     monkeypatch: Any,
@@ -71,8 +73,7 @@ def _install_fake_cosmos(
                 }
             )
             saver = FakeCosmosDBSaver()
-            captured_enter.append(1)
-            return _FakeContextManager(saver)
+            return _FakeContextManager(saver, captured_enter)
 
     cosmos_module = types.ModuleType("langgraph_checkpoint_cosmos")
     if not omit_cosmos_saver:
@@ -364,3 +365,32 @@ def test_cosmos_helper_python_310_raises_runtime_error(monkeypatch: Any) -> None
             container_name="ctr",
             credential=object(),
         )
+
+
+def test_cosmos_helper_explicit_credential_skips_azure_identity(monkeypatch: Any) -> None:
+    """When an explicit credential is provided, azure.identity must not be imported."""
+    _install_fake_cosmos(monkeypatch)
+    # Do NOT install azure.identity — it should never be touched
+
+    module = importlib.import_module("azure_functions_langgraph.checkpointers.cosmos")
+    importlib.reload(module)
+    _patch_python_311(monkeypatch)
+
+    real_import_module = importlib.import_module
+
+    def spy_import_module(name: str) -> Any:
+        if name == "azure.identity":
+            raise AssertionError("azure.identity should not be imported with explicit credential")
+        return real_import_module(name)
+
+    monkeypatch.setattr(module.importlib, "import_module", spy_import_module)
+
+    my_cred = object()
+    saver = module.create_cosmos_checkpointer(
+        endpoint="https://x.documents.azure.com:443/",
+        database_name="db",
+        container_name="ctr",
+        credential=my_cred,
+    )
+
+    assert type(saver).__name__ == "FakeCosmosDBSaver"

--- a/tests/test_examples_smoke.py
+++ b/tests/test_examples_smoke.py
@@ -15,6 +15,7 @@ GRAPH_EXAMPLES: tuple[tuple[str, str], ...] = (
     ("production_auth", "private_graph"),
     ("production_auth", "public_graph"),
     ("managed_identity_storage", "compiled_graph"),
+    ("cosmos_checkpoint_azure", "compiled_graph"),
 )
 
 
@@ -61,6 +62,7 @@ EXAMPLE_DIRS = (
     "managed_identity_storage",
     "openapi_bridge",
     "production_auth",
+    "cosmos_checkpoint_azure",
 )
 
 


### PR DESCRIPTION
## Summary

- Add `create_cosmos_checkpointer()` helper wrapping upstream [`langgraph-checkpoint-cosmos`](https://pypi.org/project/langgraph-checkpoint-cosmos/0.1.1/) as a new optional `cosmos` extra
- Add full example, tests (13 tests, 100% cosmos module coverage), and documentation updates

## Changes

### New files
- `src/azure_functions_langgraph/checkpointers/cosmos.py` — thin DX wrapper with `DefaultAzureCredential` support
- `tests/test_checkpointers_cosmos_helper.py` — 13 unit tests covering all code paths
- `examples/cosmos_checkpoint_azure/` — complete Azure Functions example

### Modified files
- `pyproject.toml` — `cosmos` optional extra (`langgraph-checkpoint-cosmos>=0.1.1,<0.2`)
- `src/azure_functions_langgraph/checkpointers/__init__.py` — lazy export
- `README.md` — install section, DB helper table, scale envelope table, updated helper description
- `COMPATIBILITY.md` — optional checkpoint backends table
- `examples/README.md` — example directory listing
- `tests/test_examples_smoke.py` — smoke test entry

## Key design decisions

- **Context manager lifecycle**: Upstream `from_conn_info()` is a `@contextmanager`. We correctly capture `saver = cm.__enter__()` (not just `cm.__enter__()`) and stash the CM on the saver to prevent GC.
- **azure-identity**: Not bundled in `cosmos` extra because upstream already depends on `azure-identity>=1.15.0`. Error message reflects this.
- **No `setup()`**: Unlike Postgres/SQLite helpers, Cosmos upstream has no `setup()` method.
- **Python 3.11+**: Required by upstream; documented in module docstring, README, and COMPATIBILITY.md.

## Validation

- `make lint` ✅
- `make typecheck` ✅  
- `make test` ✅ (779 passed, 92.62% coverage, cosmos module at 100%)
- `make build` ✅

## Related

- Closes #168
- Follow-up: #167 (integration tests with Cosmos DB Emulator + real Azure)