### PR TITLE
feat(stores): add reset_stale_locks() to AzureTableThreadStore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ All notable changes to this project will be documented in this file.
 - *(docs)* Document best-effort lock release and run lock semantics in README
 - *(examples)* Add `maintenance_timer` example for periodic stale lock recovery
 
+
+## 0.6.0
 ### 🐛 Bug Fixes
 
 - *(packaging)* Rename PyPI distribution back to azure-functions-langgraph 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+### ✨ Features
+
+- *(stores)* Add `reset_stale_locks()` to `AzureTableThreadStore` for recovering orphaned run locks (#157)
+- *(docs)* Document best-effort lock release and run lock semantics in README
+- *(examples)* Add `maintenance_timer` example for periodic stale lock recovery
+
 ### 🐛 Bug Fixes
 
 - *(packaging)* Rename PyPI distribution back to azure-functions-langgraph 

--- a/README.md
+++ b/README.md
@@ -442,6 +442,27 @@ The helpers do not hide `builder.compile(checkpointer=...)` and do not reimpleme
 | `create_postgres_checkpointer` | multi-instance Functions, existing Postgres infra | very high write QPS without read replicas | Add connection pooling / read replicas, or shard |
 | `create_cosmos_checkpointer` | Azure-native serverless, global distribution | high RU cost with large checkpoints | Tune RU allocation, use provisioned throughput |
 
+
+#### Run lock semantics
+
+When using `AzureTableThreadStore` with Platform-compatible runs, each graph execution acquires an **atomic run lock** (ETag compare-and-swap) on the thread before invoking the graph. On completion — success or failure — the lock is released via a best-effort merge update.
+
+| Operation | Concurrency | Mechanism |
+| --- | --- | --- |
+| Lock acquisition (`try_acquire_run_lock`) | Atomic — exactly one caller wins | ETag CAS |
+| Lock release (`release_run_lock`) | Best-effort — no ETag | Merge update |
+
+**What can go wrong:** If a Function host instance is terminated during graph execution (scale-in, deployment, crash), the thread remains in `busy` status indefinitely because the release never fires.
+
+**Recovery:** Use `reset_stale_locks()` from a periodic Timer Trigger to reclaim orphaned locks:
+
+```python
+# Reset threads stuck in 'busy' for more than 10 minutes
+count = thread_store.reset_stale_locks(older_than_seconds=600)
+```
+
+Each reset uses ETag CAS so a thread that has been legitimately re-acquired since the scan is never stomped. Choose `older_than_seconds` comfortably above your longest expected graph execution time — ETag CAS protects against re-acquire races, but a still-running long job will not update its `updated_at` and could be reclaimed if the threshold is too short. See [`examples/maintenance_timer/`](examples/maintenance_timer/) for a complete Timer Trigger wiring.
+
 ### Upgrading
 
 #### v0.3.0 → v0.4.0

--- a/examples/README.md
+++ b/examples/README.md
@@ -14,10 +14,11 @@
 | OpenAPI bridge | [`openapi_bridge`](openapi_bridge/) | Wires `register_with_openapi` into `azure-functions-openapi-python` for spec generation. |
 | Per-graph auth | [`production_auth`](production_auth/) | Public health + anonymous demo graph alongside a function-key-protected graph. |
 | Curl helpers | [`local_curl`](local_curl/) | Shell scripts for hitting every Quick Start endpoint locally. |
+| Maintenance timer | [`maintenance_timer`](maintenance_timer/) | Timer Trigger that resets stale run locks on `AzureTableThreadStore`. |
 
 ## Conventions
 
-Every example ships with:
+Every graph-hosting example ships with:
 
 - `README.md` — copy-pasteable `func start` + verification curl
 - `function_app.py` — the LangGraph wiring
@@ -25,6 +26,8 @@ Every example ships with:
 - `host.json` — the standard Azure Functions host config
 - `local.settings.json.example` — copy to `local.settings.json` before running
 - `requirements.txt` — pinned to a tested package version range
+
+Utility examples (e.g. `maintenance_timer`, `local_curl`) may omit `graph.py` when they do not host a graph.
 
 ## Picking an example
 
@@ -36,3 +39,4 @@ Every example ships with:
 - **Want OpenAPI / Swagger UI for your endpoints?** → `openapi_bridge`
 - **Mixing public and private graphs?** → `production_auth`
 - **Verifying a deployed Function App from the terminal?** → `local_curl`
+- **Recovering orphaned run locks automatically?** → `maintenance_timer`

--- a/examples/maintenance_timer/README.md
+++ b/examples/maintenance_timer/README.md
@@ -1,0 +1,60 @@
+# Maintenance Timer — Stale Lock Recovery
+
+This example runs a **Timer Trigger** that periodically calls
+`AzureTableThreadStore.reset_stale_locks()` to reclaim threads stuck in
+`busy` status after a host crash or scale-in event.
+
+## When to use this example
+
+Use this when you deploy `AzureTableThreadStore` with Platform-compatible
+runs and want automatic recovery from orphaned run locks.
+
+## Files
+
+- `function_app.py` — Timer Trigger wired to `reset_stale_locks()`
+- `host.json`, `local.settings.json.example`, `requirements.txt`
+
+## App Settings
+
+| Setting | Description | Default |
+|---|---|---|
+| `AZURE_TABLE_CONNECTION_STRING` | Table Storage connection string (local dev) | — |
+| `AZURE_TABLE_ENDPOINT` | Table Storage endpoint (Managed Identity) | — |
+| `LANGGRAPH_TABLE_NAME` | Table name | `langgraphthreads` |
+| `STALE_LOCK_THRESHOLD_SECONDS` | Minimum age (seconds) before a busy thread is considered stale | `600` |
+| `STALE_LOCK_RESET_STATUS` | Status to assign (`idle` or `error`) | `error` |
+
+Provide **either** `AZURE_TABLE_CONNECTION_STRING` (connection string path)
+or `AZURE_TABLE_ENDPOINT` (Managed Identity path). The timer function tries
+the connection string first, then falls back to `DefaultAzureCredential`.
+
+## Local development
+
+```bash
+cp local.settings.json.example local.settings.json
+
+pip install -r requirements.txt
+func start
+```
+
+The timer fires every 5 minutes by default (`0 */5 * * * *`). Adjust the
+CRON expression in `function_app.py` to suit your workload.
+
+## Production
+
+Deploy alongside your main LangGraph Function App (or as a separate app
+sharing the same Table Storage account). Grant the Function App's Managed
+Identity the `Storage Table Data Contributor` role on the storage account.
+
+## How it works
+
+1. Timer fires on schedule.
+2. `reset_stale_locks(older_than_seconds=600)` queries all `busy` threads.
+3. Threads whose `updated_at` is older than the threshold are reset via
+   ETag CAS — threads legitimately re-acquired since the scan are skipped.
+4. Count of reset threads is logged as a warning for monitoring/alerting.
+
+**Important:** Set `STALE_LOCK_THRESHOLD_SECONDS` comfortably above your
+longest expected graph execution time. ETag CAS protects against re-acquire
+races, but a still-running long job will not update its `updated_at` and
+could be reclaimed if the threshold is too short.

--- a/examples/maintenance_timer/README.md
+++ b/examples/maintenance_timer/README.md
@@ -28,6 +28,13 @@ Provide **either** `AZURE_TABLE_CONNECTION_STRING` (connection string path)
 or `AZURE_TABLE_ENDPOINT` (Managed Identity path). The timer function tries
 the connection string first, then falls back to `DefaultAzureCredential`.
 
+
+> **Pre-release:** `reset_stale_locks()` ships in a future release. Until
+> then, install from a local checkout:
+>
+> ```bash
+> pip install -e ../..[azure-table,azure-identity]
+> ```
 ## Local development
 
 ```bash

--- a/examples/maintenance_timer/function_app.py
+++ b/examples/maintenance_timer/function_app.py
@@ -1,0 +1,81 @@
+"""Timer Trigger that resets stale run locks on AzureTableThreadStore.
+
+Threads stuck in ``busy`` status (e.g. due to host crashes during graph
+execution) are reclaimed so new runs can proceed.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Literal
+
+import azure.functions as func
+
+app = func.FunctionApp()
+
+logger = logging.getLogger(__name__)
+
+
+def _build_thread_store():  # type: ignore[no-untyped-def]
+    """Build an AzureTableThreadStore from environment variables."""
+    from azure_functions_langgraph.stores.azure_table import AzureTableThreadStore
+
+    conn_str = os.environ.get("AZURE_TABLE_CONNECTION_STRING")
+    table_name = os.environ.get("LANGGRAPH_TABLE_NAME", "langgraphthreads")
+
+    if conn_str:
+        return AzureTableThreadStore.from_connection_string(
+            connection_string=conn_str,
+            table_name=table_name,
+        )
+
+    # Managed Identity path
+    from azure.data.tables import TableClient
+    from azure.identity import DefaultAzureCredential
+
+    endpoint = os.environ["AZURE_TABLE_ENDPOINT"]
+    credential = DefaultAzureCredential()
+    table_client = TableClient(
+        endpoint=endpoint,
+        table_name=table_name,
+        credential=credential,
+    )
+    return AzureTableThreadStore.from_table_client(table_client)
+
+
+# Lazy singleton — built on first timer invocation
+_thread_store = None
+
+
+@app.timer_trigger(
+    schedule="0 */5 * * * *",  # every 5 minutes
+    arg_name="timer",
+    run_on_startup=False,
+)
+def reset_stale_locks(timer: func.TimerRequest) -> None:
+    """Reset busy threads whose lock is older than the configured threshold."""
+    global _thread_store  # noqa: PLW0603
+    if _thread_store is None:
+        _thread_store = _build_thread_store()
+
+    older_than = int(os.environ.get("STALE_LOCK_THRESHOLD_SECONDS", "600"))
+    reset_status: Literal["idle", "error"] = "error"
+    raw_status = os.environ.get("STALE_LOCK_RESET_STATUS", "error")
+    if raw_status in ("idle", "error"):
+        reset_status = raw_status  # type: ignore[assignment]
+    else:
+        logger.error("Invalid STALE_LOCK_RESET_STATUS=%r, falling back to 'error'", raw_status)
+
+    count = _thread_store.reset_stale_locks(
+        older_than_seconds=older_than,
+        status=reset_status,
+    )
+
+    if count:
+        logger.warning("Reset %d stale thread lock(s)", count)
+    else:
+        logger.info("No stale locks found")
+
+    if timer.past_due:
+        logger.info("Timer is past due — execution was delayed")

--- a/examples/maintenance_timer/function_app.py
+++ b/examples/maintenance_timer/function_app.py
@@ -59,7 +59,13 @@ def reset_stale_locks(timer: func.TimerRequest) -> None:
     if _thread_store is None:
         _thread_store = _build_thread_store()
 
-    older_than = int(os.environ.get("STALE_LOCK_THRESHOLD_SECONDS", "600"))
+    try:
+        older_than = int(os.environ.get("STALE_LOCK_THRESHOLD_SECONDS", "600"))
+    except (ValueError, TypeError):
+        logger.error(
+            "Invalid STALE_LOCK_THRESHOLD_SECONDS, falling back to 600"
+        )
+        older_than = 600
     reset_status: Literal["idle", "error"] = "error"
     raw_status = os.environ.get("STALE_LOCK_RESET_STATUS", "error")
     if raw_status in ("idle", "error"):

--- a/examples/maintenance_timer/host.json
+++ b/examples/maintenance_timer/host.json
@@ -1,0 +1,15 @@
+{
+  "version": "2.0",
+  "logging": {
+    "applicationInsights": {
+      "samplingSettings": {
+        "isEnabled": true,
+        "excludedTypes": "Request"
+      }
+    }
+  },
+  "extensionBundle": {
+    "id": "Microsoft.Azure.Functions.ExtensionBundle",
+    "version": "[4.*, 5.0.0)"
+  }
+}

--- a/examples/maintenance_timer/local.settings.json.example
+++ b/examples/maintenance_timer/local.settings.json.example
@@ -1,0 +1,11 @@
+{
+  "IsEncrypted": false,
+  "Values": {
+    "AzureWebJobsStorage": "UseDevelopmentStorage=true",
+    "FUNCTIONS_WORKER_RUNTIME": "python",
+    "AZURE_TABLE_CONNECTION_STRING": "UseDevelopmentStorage=true",
+    "LANGGRAPH_TABLE_NAME": "langgraphthreads",
+    "STALE_LOCK_THRESHOLD_SECONDS": "600",
+    "STALE_LOCK_RESET_STATUS": "error"
+  }
+}

--- a/examples/maintenance_timer/requirements.txt
+++ b/examples/maintenance_timer/requirements.txt
@@ -1,5 +1,9 @@
 # Do not include azure-functions-worker in this file
 # The Python Worker is managed by the Azure Functions platform
+#
+# Until v0.7.0 is released, install from a local checkout:
+#
+#     pip install -e ../..[azure-table,azure-identity]
 
 azure-functions
 azure-functions-langgraph[azure-table,azure-identity]>=0.7.0,<0.8.0

--- a/examples/maintenance_timer/requirements.txt
+++ b/examples/maintenance_timer/requirements.txt
@@ -1,0 +1,5 @@
+# Do not include azure-functions-worker in this file
+# The Python Worker is managed by the Azure Functions platform
+
+azure-functions
+azure-functions-langgraph[azure-table,azure-identity]>=0.7.0,<0.8.0

--- a/src/azure_functions_langgraph/stores/azure_table.py
+++ b/src/azure_functions_langgraph/stores/azure_table.py
@@ -5,11 +5,11 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 import importlib
 import json
 import logging
-from typing import Any, Mapping, Protocol, cast
+from typing import Any, Literal, Mapping, Protocol, cast
 import uuid
 
 from ..platform.contracts import Interrupt, Thread, ThreadStatus
@@ -414,7 +414,18 @@ class AzureTableThreadStore(ThreadStore):
         *,
         assistant_id: str | None = None,
     ) -> Thread | None:
-        """Atomically acquire the per-thread run lock with ETag CAS."""
+        """Atomically acquire the per-thread run lock with ETag CAS.
+
+        Lock acquisition is **atomic**: the update uses an ETag
+        compare-and-swap so that exactly one concurrent caller wins.
+        ``updated_at`` is set on success and serves as the lock-acquired
+        timestamp for staleness detection (see :meth:`reset_stale_locks`).
+
+        If the Function host is terminated during graph execution, the
+        thread may remain in ``busy`` status indefinitely.  Use
+        :meth:`reset_stale_locks` from a periodic Timer Trigger to
+        reclaim such threads.
+        """
         not_found_error = self._not_found_exception()
         modified_error = self._modified_error
         match_conditions = self._match_conditions
@@ -493,7 +504,15 @@ class AzureTableThreadStore(ThreadStore):
         status: ThreadStatus,
         values: dict[str, Any] | None = None,
     ) -> Thread:
-        """Release the per-thread run lock without ETag concurrency."""
+        """Release the per-thread run lock without ETag concurrency.
+
+        Lock release is **best-effort**: the merge update does *not*
+        use ETag concurrency because failing to release a lock is
+        operationally worse than a rare race.  If the Function host
+        is killed mid-execution, the lock is *not* released and the
+        thread remains ``busy`` until :meth:`reset_stale_locks` reclaims
+        it.
+        """
         if status == "busy":
             raise ValueError("release_run_lock cannot set status to 'busy'")
         not_found_error = self._not_found_exception()
@@ -515,6 +534,105 @@ class AzureTableThreadStore(ThreadStore):
             row_key=thread_id,
         )
         return self._entity_to_thread(merged)
+
+    def reset_stale_locks(
+        self,
+        older_than_seconds: int,
+        status: Literal["idle", "error"] = "error",
+    ) -> int:
+        """Reset busy threads whose lock is older than *older_than_seconds*.
+
+        Scans threads in ``busy`` status and conditionally resets those
+        whose ``updated_at`` (set by :meth:`try_acquire_run_lock`) is older
+        than the threshold.  Each reset uses **ETag CAS** so a thread that
+        has been legitimately re-acquired since the query is never stomped.
+
+        Args:
+            older_than_seconds: Minimum age in seconds for a busy thread
+                to be considered stale.
+            status: Terminal status to assign.  Must be ``"idle"`` or
+                ``"error"`` (default ``"error"``).
+
+        Returns:
+            Number of threads successfully reset.
+
+        Raises:
+            ValueError: If *older_than_seconds* is negative or *status*
+                is not ``"idle"`` or ``"error"``.
+        """
+        if older_than_seconds < 0:
+            raise ValueError(
+                f"older_than_seconds must be non-negative, got {older_than_seconds}"
+            )
+        if status not in ("idle", "error"):
+            raise ValueError(
+                f"status must be 'idle' or 'error', got {status!r}"
+            )
+
+        cutoff = self._now() - timedelta(seconds=older_than_seconds)
+        modified_error = self._modified_error
+        not_found_error = self._not_found_exception()
+        match_conditions = self._match_conditions
+
+        pk = self._partition_key().replace("'", "''")
+        query_filter = f"PartitionKey eq '{pk}' and status eq 'busy'"
+        entities = self._table_client.query_entities(query_filter=query_filter)
+
+        reset_count = 0
+        for entity in entities:
+            updated_at = entity.get("updated_at")
+            if updated_at is None:
+                continue
+            if isinstance(updated_at, datetime):
+                normalized = self._normalize_datetime(updated_at)
+            else:
+                continue
+            if normalized >= cutoff:
+                continue
+
+            # Extract ETag for CAS
+            entity_metadata = getattr(entity, "metadata", None)
+            etag = (
+                entity_metadata.get("etag")
+                if isinstance(entity_metadata, Mapping)
+                else None
+            )
+            if etag is None:
+                etag = entity.get("etag") if isinstance(entity, dict) else None
+
+            row_key = str(entity["RowKey"])
+            patch: dict[str, Any] = {
+                "PartitionKey": self._partition_key(),
+                "RowKey": row_key,
+                "status": status,
+                "updated_at": self._now(),
+            }
+
+            try:
+                self._table_client.update_entity(
+                    patch,
+                    mode="merge",
+                    etag=etag,
+                    match_condition=match_conditions.IfNotModified,
+                )
+                reset_count += 1
+            except modified_error:
+                # Thread was re-acquired or modified since our query —
+                # skip it rather than stomping a legitimate lock.
+                logger.debug(
+                    "Skipped stale lock reset for thread %s (ETag mismatch)",
+                    row_key,
+                )
+                continue
+            except not_found_error:
+                # Thread was deleted between query and update — skip.
+                logger.debug(
+                    "Skipped stale lock reset for thread %s (deleted)",
+                    row_key,
+                )
+                continue
+
+        return reset_count
 
     def search(
         self,

--- a/src/azure_functions_langgraph/stores/azure_table.py
+++ b/src/azure_functions_langgraph/stores/azure_table.py
@@ -602,6 +602,13 @@ class AzureTableThreadStore(ThreadStore):
             )
             if etag is None:
                 etag = entity.get("etag") if isinstance(entity, dict) else None
+            if etag is None:
+                # Without ETag, CAS update cannot guarantee safety — skip.
+                logger.debug(
+                    "Skipping stale thread %s: no ETag available",
+                    entity.get("RowKey"),
+                )
+                continue
 
             row_key = str(entity["RowKey"])
             patch: dict[str, Any] = {

--- a/src/azure_functions_langgraph/stores/azure_table.py
+++ b/src/azure_functions_langgraph/stores/azure_table.py
@@ -418,8 +418,8 @@ class AzureTableThreadStore(ThreadStore):
 
         Lock acquisition is **atomic**: the update uses an ETag
         compare-and-swap so that exactly one concurrent caller wins.
-        ``updated_at`` is set on success and serves as the lock-acquired
-        timestamp for staleness detection (see :meth:`reset_stale_locks`).
+        ``updated_at`` is updated on lock acquire and used for staleness
+        detection while status is ``busy`` (see :meth:`reset_stale_locks`).
 
         If the Function host is terminated during graph execution, the
         thread may remain in ``busy`` status indefinitely.  Use
@@ -576,7 +576,10 @@ class AzureTableThreadStore(ThreadStore):
 
         pk = self._partition_key().replace("'", "''")
         query_filter = f"PartitionKey eq '{pk}' and status eq 'busy'"
-        entities = self._table_client.query_entities(query_filter=query_filter)
+        entities = self._table_client.query_entities(
+            query_filter=query_filter,
+            select=["RowKey", "updated_at"],
+        )
 
         reset_count = 0
         for entity in entities:

--- a/tests/test_stores_azure_table.py
+++ b/tests/test_stores_azure_table.py
@@ -854,3 +854,169 @@ def test_from_connection_string_does_not_leak_class_state(monkeypatch: Any) -> N
     # Constructing a new instance without not_found_error should still fail
     with pytest.raises(TypeError):
         AzureTableThreadStore(table_client=MockTableClient())
+
+
+# ── reset_stale_locks tests ──────────────────────────────────────────────
+
+
+def test_reset_stale_locks_resets_stale_skips_recent(monkeypatch: Any) -> None:
+    """Stale busy thread older than threshold is reset; recent busy thread is not."""
+    store, table_client = _new_store()
+    base = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    timestamps = iter([
+        base,                            # create t1
+        base + timedelta(seconds=100),   # create t2
+        base + timedelta(seconds=10),    # acquire t1: sets updated_at=10
+        base + timedelta(seconds=500),   # acquire t2: sets updated_at=500
+        base + timedelta(seconds=700),   # reset_stale_locks: cutoff = 700 - 300 = 400
+        base + timedelta(seconds=700),   # reset_stale_locks: patch updated_at for t1
+    ])
+    monkeypatch.setattr(store, "_now", lambda: next(timestamps))
+
+    t1 = store.create()
+    t2 = store.create()
+    store.try_acquire_run_lock(t1.thread_id)
+    store.try_acquire_run_lock(t2.thread_id)
+
+    # cutoff = 700 - 300 = 400.  t1 updated_at=10 < 400 → stale.  t2 updated_at=500 >= 400 → recent.
+    count = store.reset_stale_locks(older_than_seconds=300)
+
+    assert count == 1
+    assert store.get(t1.thread_id).status == "error"
+    assert store.get(t2.thread_id).status == "busy"
+
+
+def test_reset_stale_locks_etag_mismatch_skips(monkeypatch: Any) -> None:
+    """Concurrent re-acquire during reset: ETag mismatch → skipped, not stomped."""
+    store, table_client = _new_store()
+    base = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    timestamps = iter([
+        base,                            # create
+        base + timedelta(seconds=10),    # acquire lock
+        base + timedelta(seconds=700),   # reset_stale_locks cutoff calc
+        base + timedelta(seconds=700),   # reset_stale_locks: patch updated_at (before CAS fails)
+    ])
+    monkeypatch.setattr(store, "_now", lambda: next(timestamps))
+
+    t1 = store.create()
+    store.try_acquire_run_lock(t1.thread_id)
+
+    # Force all CAS updates to fail with ETag mismatch
+    table_client.always_modified_error = True
+
+    count = store.reset_stale_locks(older_than_seconds=300)
+
+    assert count == 0
+    # Thread status unchanged (still busy)
+    table_client.always_modified_error = False  # allow get_entity to work
+    assert store.get(t1.thread_id).status == "busy"
+
+
+def test_reset_stale_locks_empty_store_returns_zero() -> None:
+    """No threads at all → returns 0, no errors."""
+    store, _ = _new_store()
+
+    count = store.reset_stale_locks(older_than_seconds=600)
+
+    assert count == 0
+
+
+def test_reset_stale_locks_idle_threads_not_touched(monkeypatch: Any) -> None:
+    """Idle threads are not affected by reset_stale_locks."""
+    store, _ = _new_store()
+    base = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    timestamps = iter([
+        base,                           # create
+        base + timedelta(seconds=700),  # reset cutoff
+    ])
+    monkeypatch.setattr(store, "_now", lambda: next(timestamps))
+
+    t1 = store.create()  # idle status, old timestamp
+
+    count = store.reset_stale_locks(older_than_seconds=300)
+
+    assert count == 0
+    assert store.get(t1.thread_id).status == "idle"
+
+
+def test_reset_stale_locks_negative_older_than_raises() -> None:
+    """Negative older_than_seconds → ValueError."""
+    store, _ = _new_store()
+
+    with pytest.raises(ValueError, match="non-negative"):
+        store.reset_stale_locks(older_than_seconds=-1)
+
+
+def test_reset_stale_locks_invalid_status_raises() -> None:
+    """Invalid status param → ValueError."""
+    store, _ = _new_store()
+
+    with pytest.raises(ValueError, match="must be 'idle' or 'error'"):
+        store.reset_stale_locks(older_than_seconds=600, status="busy")
+
+    with pytest.raises(ValueError, match="must be 'idle' or 'error'"):
+        store.reset_stale_locks(older_than_seconds=600, status="interrupted")
+
+
+def test_reset_stale_locks_status_idle(monkeypatch: Any) -> None:
+    """reset_stale_locks with status='idle' sets thread to idle."""
+    store, _ = _new_store()
+    base = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    timestamps = iter([
+        base,                           # create
+        base + timedelta(seconds=10),   # acquire
+        base + timedelta(seconds=700),  # reset cutoff
+        base + timedelta(seconds=700),  # patch updated_at
+    ])
+    monkeypatch.setattr(store, "_now", lambda: next(timestamps))
+
+    t1 = store.create()
+    store.try_acquire_run_lock(t1.thread_id)
+
+    count = store.reset_stale_locks(older_than_seconds=300, status="idle")
+
+    assert count == 1
+    assert store.get(t1.thread_id).status == "idle"
+
+
+def test_reset_stale_locks_zero_threshold(monkeypatch: Any) -> None:
+    """older_than_seconds=0 resets any busy thread (cutoff == now)."""
+    store, _ = _new_store()
+    base = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    timestamps = iter([
+        base,                           # create
+        base + timedelta(seconds=10),   # acquire: sets updated_at=10
+        base + timedelta(seconds=10),   # reset: cutoff=10-0=10, updated_at=10 >= 10
+    ])
+    monkeypatch.setattr(store, "_now", lambda: next(timestamps))
+
+    t1 = store.create()
+    store.try_acquire_run_lock(t1.thread_id)
+
+    # cutoff equals updated_at exactly → not stale (normalized >= cutoff)
+    count = store.reset_stale_locks(older_than_seconds=0)
+
+    assert count == 0
+
+
+def test_reset_stale_locks_deleted_thread_skipped(monkeypatch: Any) -> None:
+    """Thread deleted between query and update is skipped, not raised."""
+    store, table_client = _new_store()
+    base = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    timestamps = iter([
+        base,                           # create
+        base + timedelta(seconds=10),   # acquire
+        base + timedelta(seconds=700),  # reset cutoff
+        base + timedelta(seconds=700),  # patch updated_at
+    ])
+    monkeypatch.setattr(store, "_now", lambda: next(timestamps))
+
+    t1 = store.create()
+    store.try_acquire_run_lock(t1.thread_id)
+
+    # Simulate deletion between query_entities and update_entity
+    table_client.raise_not_found_on_update = True
+
+    count = store.reset_stale_locks(older_than_seconds=300)
+
+    assert count == 0


### PR DESCRIPTION
## Summary

- Add `reset_stale_locks(older_than_seconds, status)` method to `AzureTableThreadStore` that reclaims busy threads stuck after host crashes, using ETag CAS to avoid stomping legitimately re-acquired locks
- Add 9 new tests covering stale vs recent, ETag mismatch, delete-during-reset race, empty store, idle untouched, invalid args, alternate status, and threshold boundary
- Add `examples/maintenance_timer/` with Timer Trigger wiring for periodic stale lock recovery
- Document run lock semantics in README with threshold safety guidance

## Validation

- `make lint` ✅
- `make typecheck` ✅
- `make test` ✅ (790 passed, 92.59% overall coverage, 96% on azure_table.py)
- `make build` ✅
- Oracle review: 97% (Correctness 97%, Test quality 97%, Documentation 98%, Code quality 96%)

Closes #157