### PR TITLE
feat(checkpointers): Cosmos DB integration tests and v0.7.0 release prep

### DIFF
--- a/.github/workflows/ci-cosmos-integration.yml
+++ b/.github/workflows/ci-cosmos-integration.yml
@@ -1,0 +1,46 @@
+name: Cosmos Integration
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  cosmos-integration:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    services:
+      cosmos-emulator:
+        image: mcr.microsoft.com/cosmosdb/linux/azure-cosmos-emulator
+        ports:
+          - 8081:8081
+          - 10250-10255:10250-10255
+        options: >-
+          --health-cmd "curl -fk https://localhost:8081/_explorer/emulator.pem"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 30
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev,cosmos]"
+
+      - name: Run cosmos integration tests
+        env:
+          COSMOS_EMULATOR_ENDPOINT: https://localhost:8081
+          COSMOS_DISABLE_SSL: "true"
+        run: pytest -v -m integration tests/integration/ --no-cov

--- a/.github/workflows/ci-cosmos-integration.yml
+++ b/.github/workflows/ci-cosmos-integration.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   cosmos-integration:
     runs-on: ubuntu-latest
-    continue-on-error: true
+    continue-on-error: true  # experimental: Cosmos Linux emulator can be flaky on GitHub-hosted runners
     services:
       cosmos-emulator:
         image: mcr.microsoft.com/cosmosdb/linux/azure-cosmos-emulator

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,19 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+## 0.7.0
+
 ### ✨ Features
 
+- *(checkpointers)* Add `create_cosmos_checkpointer` DX helper for Cosmos DB (#169)
+- *(checkpointers)* Add `close_cosmos_checkpointer` cleanup helper for Cosmos DB lifecycle management
+- *(checkpointers)* Add safe garbage collection for orphaned Azure Blob channel values (#153) (#160)
 - *(stores)* Add `reset_stale_locks()` to `AzureTableThreadStore` for recovering orphaned run locks (#157)
+
+### 📚 Documentation
+
 - *(docs)* Document best-effort lock release and run lock semantics in README
 - *(examples)* Add `maintenance_timer` example for periodic stale lock recovery
-
 
 ## 0.6.0
 ### 🐛 Bug Fixes

--- a/Makefile
+++ b/Makefile
@@ -85,6 +85,12 @@ test: ensure-hatch
 	@echo "Running tests..."
 	@$(HATCH) run test
 
+.PHONY: test-cosmos
+test-cosmos: ensure-hatch
+	docker compose -f docker-compose.cosmos.yml up -d --wait
+	COSMOS_EMULATOR_ENDPOINT=https://localhost:8081 hatch run pytest -v -m integration tests/integration/ --no-cov || true
+	docker compose -f docker-compose.cosmos.yml down
+
 .PHONY: cov
 cov: ensure-hatch
 	@$(HATCH) run cov

--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ test: ensure-hatch
 .PHONY: test-cosmos
 test-cosmos: ensure-hatch
 	docker compose -f docker-compose.cosmos.yml up -d --wait
-	COSMOS_EMULATOR_ENDPOINT=https://localhost:8081 hatch run pytest -v -m integration tests/integration/ --no-cov || true
+	COSMOS_EMULATOR_ENDPOINT=https://localhost:8081 hatch run pytest -v -m integration tests/integration/ --no-cov
 	docker compose -f docker-compose.cosmos.yml down
 
 .PHONY: cov

--- a/docker-compose.cosmos.yml
+++ b/docker-compose.cosmos.yml
@@ -1,0 +1,14 @@
+services:
+  cosmos-emulator:
+    image: mcr.microsoft.com/cosmosdb/linux/azure-cosmos-emulator
+    ports:
+      - "8081:8081"
+      - "10250-10255:10250-10255"
+    environment:
+      - AZURE_COSMOS_EMULATOR_PARTITION_COUNT=2
+      - AZURE_COSMOS_EMULATOR_ENABLE_DATA_PERSISTENCE=false
+    healthcheck:
+      test: ["CMD", "curl", "-fk", "https://localhost:8081/_explorer/emulator.pem"]
+      interval: 10s
+      timeout: 5s
+      retries: 30

--- a/src/azure_functions_langgraph/__init__.py
+++ b/src/azure_functions_langgraph/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-__version__ = "0.6.0"
+__version__ = "0.7.0"
 
 if TYPE_CHECKING:
     from azure_functions_langgraph.app import LangGraphApp, get_langgraph_metadata

--- a/src/azure_functions_langgraph/checkpointers/__init__.py
+++ b/src/azure_functions_langgraph/checkpointers/__init__.py
@@ -9,7 +9,7 @@ if TYPE_CHECKING:
         AzureBlobCheckpointSaver,
         OrphanedValueCollectionResult,
     )
-    from .cosmos import create_cosmos_checkpointer
+    from .cosmos import close_cosmos_checkpointer, create_cosmos_checkpointer
     from .postgres import create_postgres_checkpointer
     from .sqlite import create_sqlite_checkpointer
 
@@ -35,12 +35,17 @@ def __getattr__(name: str) -> object:
         from .cosmos import create_cosmos_checkpointer
 
         return create_cosmos_checkpointer
+    if name == "close_cosmos_checkpointer":
+        from .cosmos import close_cosmos_checkpointer
+
+        return close_cosmos_checkpointer
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 __all__ = [
     "AzureBlobCheckpointSaver",
     "OrphanedValueCollectionResult",
+    "close_cosmos_checkpointer",
     "create_cosmos_checkpointer",
     "create_postgres_checkpointer",
     "create_sqlite_checkpointer",

--- a/src/azure_functions_langgraph/checkpointers/cosmos.py
+++ b/src/azure_functions_langgraph/checkpointers/cosmos.py
@@ -140,18 +140,25 @@ def close_cosmos_checkpointer(saver: CosmosDBSaver) -> None:
 
     Raises:
         TypeError: If *saver* was not created by
-            :func:`create_cosmos_checkpointer` (missing ``_langgraph_cm``).
+            :func:`create_cosmos_checkpointer` (missing ``_langgraph_cm``
+            on the first call).
     """
     cm = getattr(saver, "_langgraph_cm", None)
     if cm is None:
-        raise TypeError(
-            "saver was not created by create_cosmos_checkpointer "
-            "(missing _langgraph_cm attribute)"
-        )
+        # Already closed or never created by create_cosmos_checkpointer.
+        # Distinguish: if the saver never had _langgraph_cm, it's a usage error.
+        # After a successful close, _langgraph_cm is deleted, so hasattr is False.
+        # We use a second sentinel to tell the two cases apart.
+        if not getattr(saver, "_langgraph_closed", False):
+            raise TypeError(
+                "saver was not created by create_cosmos_checkpointer "
+                "(missing _langgraph_cm attribute)"
+            )
+        return  # already closed — idempotent no-op
     cm.__exit__(None, None, None)
-    # Remove the reference so repeated calls are no-ops and the
-    # CM can be garbage-collected.
+    # Remove the reference so the CM can be garbage-collected.
     del saver._langgraph_cm  # noqa: SLF001
+    saver._langgraph_closed = True  # noqa: SLF001
 
 
 __all__ = ["create_cosmos_checkpointer", "close_cosmos_checkpointer"]

--- a/src/azure_functions_langgraph/checkpointers/cosmos.py
+++ b/src/azure_functions_langgraph/checkpointers/cosmos.py
@@ -128,4 +128,30 @@ def create_cosmos_checkpointer(
     return saver
 
 
-__all__ = ["create_cosmos_checkpointer"]
+def close_cosmos_checkpointer(saver: CosmosDBSaver) -> None:
+    """Close a :class:`CosmosDBSaver` created by :func:`create_cosmos_checkpointer`.
+
+    Calls ``__exit__`` on the stashed context manager to release the
+    underlying Cosmos DB client resources.  Safe to call multiple times;
+    the second and subsequent calls are no-ops.
+
+    Args:
+        saver: A saver returned by :func:`create_cosmos_checkpointer`.
+
+    Raises:
+        TypeError: If *saver* was not created by
+            :func:`create_cosmos_checkpointer` (missing ``_langgraph_cm``).
+    """
+    cm = getattr(saver, "_langgraph_cm", None)
+    if cm is None:
+        raise TypeError(
+            "saver was not created by create_cosmos_checkpointer "
+            "(missing _langgraph_cm attribute)"
+        )
+    cm.__exit__(None, None, None)
+    # Remove the reference so repeated calls are no-ops and the
+    # CM can be garbage-collected.
+    del saver._langgraph_cm  # noqa: SLF001
+
+
+__all__ = ["create_cosmos_checkpointer", "close_cosmos_checkpointer"]

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from collections.abc import Iterable, Iterator
+import importlib
+import os
+from typing import Callable, Protocol, cast
+import uuid
+
+import pytest
+
+EMULATOR_KEY = (
+    "C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw=="
+)
+
+
+@pytest.fixture
+def cosmos_emulator_target() -> Iterator[tuple[str, str, str, str]]:
+    endpoint = os.getenv("COSMOS_EMULATOR_ENDPOINT", "https://localhost:8081")
+    _ = os.environ.setdefault("COSMOS_DISABLE_SSL", "true")
+
+    class _Database(Protocol):
+        def create_container_if_not_exists(self, *, id: str, partition_key: object) -> object: ...
+
+    class _Client(Protocol):
+        def list_databases(self) -> Iterable[object]: ...
+
+        def create_database_if_not_exists(self, *, id: str) -> _Database: ...
+
+        def delete_database(self, database: str) -> object: ...
+
+    try:
+        cosmos_module = importlib.import_module("azure.cosmos")
+        exceptions_module = importlib.import_module("azure.cosmos.exceptions")
+    except Exception as exc:
+        pytest.skip(f"Cosmos dependencies unavailable: {exc}")
+
+    CosmosClient = cast(Callable[..., object], getattr(cosmos_module, "CosmosClient"))
+    PartitionKey = cast(Callable[..., object], getattr(cosmos_module, "PartitionKey"))
+    CosmosHttpResponseError = cast(
+        type[Exception], getattr(exceptions_module, "CosmosHttpResponseError")
+    )
+
+    client: _Client
+    try:
+        client = cast(
+            _Client,
+            CosmosClient(url=endpoint, credential=EMULATOR_KEY, connection_verify=False),
+        )
+        _ = list(client.list_databases())
+    except Exception as exc:
+        pytest.skip(f"Cosmos emulator not available: {exc}")
+
+    database_name = f"aflg-int-{uuid.uuid4().hex[:12]}"
+    container_name = f"checkpoints-{uuid.uuid4().hex[:8]}"
+
+    try:
+        database = client.create_database_if_not_exists(id=database_name)
+        _ = database.create_container_if_not_exists(
+            id=container_name,
+            partition_key=PartitionKey(path="/partition_key"),
+        )
+    except CosmosHttpResponseError as exc:
+        pytest.skip(f"Cosmos emulator not available: {exc}")
+
+    try:
+        yield endpoint, EMULATOR_KEY, database_name, container_name
+    finally:
+        try:
+            _ = client.delete_database(database_name)
+        except Exception:
+            pass

--- a/tests/integration/test_cosmos_integration.py
+++ b/tests/integration/test_cosmos_integration.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+import importlib
+from typing import Callable, Protocol, TypedDict, cast
+
+import pytest
+
+pytest.importorskip("langgraph_checkpoint_cosmos")
+
+cosmos_helper_module = importlib.import_module("azure_functions_langgraph.checkpointers.cosmos")
+create_cosmos_checkpointer = cast(
+    Callable[..., object],
+    getattr(cosmos_helper_module, "create_cosmos_checkpointer"),
+)
+close_cosmos_checkpointer = cast(
+    Callable[[object], None],
+    getattr(cosmos_helper_module, "close_cosmos_checkpointer"),
+)
+
+pytestmark = pytest.mark.integration
+
+
+class Checkpoint(TypedDict):
+    v: int
+    id: str
+    ts: str
+    channel_values: dict[str, list[str]]
+    channel_versions: dict[str, str]
+    versions_seen: dict[str, str]
+    updated_channels: None
+
+
+class CheckpointTuple(Protocol):
+    checkpoint: Checkpoint
+
+
+class CheckpointSaver(Protocol):
+    def put(
+        self,
+        config: dict[str, dict[str, str]],
+        checkpoint: Checkpoint,
+        metadata: dict[str, object],
+        new_versions: dict[str, str],
+    ) -> dict[str, dict[str, str]]: ...
+
+    def get_tuple(self, config: dict[str, dict[str, str]]) -> CheckpointTuple | None: ...
+
+    def list(
+        self,
+        config: dict[str, dict[str, str]] | None,
+        *,
+        filter: dict[str, object] | None = None,
+        before: dict[str, dict[str, str]] | None = None,
+        limit: int | None = None,
+    ) -> Iterator[CheckpointTuple]: ...
+
+
+def _config(
+    thread_id: str, checkpoint_ns: str = "", checkpoint_id: str | None = None
+) -> dict[str, dict[str, str]]:
+    configurable: dict[str, str] = {"thread_id": thread_id, "checkpoint_ns": checkpoint_ns}
+    if checkpoint_id is not None:
+        configurable["checkpoint_id"] = checkpoint_id
+    return {"configurable": configurable}
+
+
+def _checkpoint(checkpoint_id: str, step: int) -> Checkpoint:
+    return {
+        "v": 1,
+        "id": checkpoint_id,
+        "ts": "2026-01-01T00:00:00Z",
+        "channel_values": {"messages": [f"m-{step}"]},
+        "channel_versions": {"messages": f"v{step}"},
+        "versions_seen": {},
+        "updated_channels": None,
+    }
+
+
+def _metadata(step: int) -> dict[str, object]:
+    return {"source": "loop", "step": step, "run_id": f"run-{step}", "parents": {}}
+
+
+def _create_saver(target: tuple[str, str, str, str]) -> CheckpointSaver:
+    endpoint, key, database_name, container_name = target
+    return cast(
+        CheckpointSaver,
+        create_cosmos_checkpointer(
+            endpoint=endpoint,
+            credential=key,
+            database_name=database_name,
+            container_name=container_name,
+        ),
+    )
+
+
+def test_create_cosmos_checkpointer_creates_saver(
+    cosmos_emulator_target: tuple[str, str, str, str],
+) -> None:
+    saver = _create_saver(cosmos_emulator_target)
+    assert hasattr(saver, "_langgraph_cm")
+    close_cosmos_checkpointer(saver)
+
+
+def test_close_cosmos_checkpointer_cleans_up(
+    cosmos_emulator_target: tuple[str, str, str, str],
+) -> None:
+    saver = _create_saver(cosmos_emulator_target)
+    close_cosmos_checkpointer(saver)
+    assert not hasattr(saver, "_langgraph_cm")
+
+
+def test_checkpoint_round_trip_put_get_tuple(
+    cosmos_emulator_target: tuple[str, str, str, str],
+) -> None:
+    saver = _create_saver(cosmos_emulator_target)
+    cfg = _config("integration-thread")
+    saved_cfg = saver.put(cfg, _checkpoint("cp-001", 1), _metadata(1), {"messages": "v1"})
+    result = saver.get_tuple(saved_cfg)
+    assert result is not None
+    assert result.checkpoint["id"] == "cp-001"
+    close_cosmos_checkpointer(saver)
+
+
+def test_list_checkpoints_returns_expected_results(
+    cosmos_emulator_target: tuple[str, str, str, str],
+) -> None:
+    saver = _create_saver(cosmos_emulator_target)
+    cfg = _config("integration-thread-list")
+    _ = saver.put(cfg, _checkpoint("cp-001", 1), _metadata(1), {"messages": "v1"})
+    _ = saver.put(cfg, _checkpoint("cp-002", 2), _metadata(2), {"messages": "v2"})
+    checkpoints = list(saver.list(cfg, limit=10))
+    ids = {item.checkpoint["id"] for item in checkpoints}
+    assert {"cp-001", "cp-002"}.issubset(ids)
+    close_cosmos_checkpointer(saver)
+
+
+def test_python_310_guard_raises_runtime_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    module = cast(object, importlib.import_module("azure_functions_langgraph.checkpointers.cosmos"))
+    module_sys = cast(object, getattr(module, "sys"))
+    create_fn = cast(Callable[..., object], getattr(module, "create_cosmos_checkpointer"))
+    monkeypatch.setattr(module_sys, "version_info", (3, 10, 0))
+    with pytest.raises(RuntimeError, match="Python 3.11"):
+        _ = create_fn(
+            endpoint="https://localhost:8081",
+            credential="x",
+            database_name="db",
+            container_name="container",
+        )

--- a/tests/test_checkpointers_cosmos_helper.py
+++ b/tests/test_checkpointers_cosmos_helper.py
@@ -396,3 +396,77 @@ def test_cosmos_helper_explicit_credential_skips_azure_identity(monkeypatch: Any
     )
 
     assert type(saver).__name__ == "FakeCosmosDBSaver"
+
+
+# ---------------------------------------------------------------------------
+# close_cosmos_checkpointer tests
+# ---------------------------------------------------------------------------
+
+
+def test_close_cosmos_checkpointer_calls_exit(monkeypatch: Any) -> None:
+    """close_cosmos_checkpointer must call __exit__ on the stashed CM."""
+    _install_fake_cosmos(monkeypatch)
+    _install_fake_azure_identity(monkeypatch)
+
+    module = importlib.import_module("azure_functions_langgraph.checkpointers.cosmos")
+    importlib.reload(module)
+    _patch_python_311(monkeypatch)
+    saver = module.create_cosmos_checkpointer(
+        endpoint="https://test.documents.azure.com:443/",
+        database_name="db",
+        container_name="ctr",
+    )
+
+    # Verify CM is stashed
+    assert hasattr(saver, "_langgraph_cm")
+
+    exit_calls: list[tuple[Any, ...]] = []
+    original_exit = saver._langgraph_cm.__exit__
+
+    def tracking_exit(*args: Any) -> None:
+        exit_calls.append(args)
+        original_exit(*args)
+
+    saver._langgraph_cm.__exit__ = tracking_exit
+    module.close_cosmos_checkpointer(saver)
+
+    assert len(exit_calls) == 1
+    assert exit_calls[0] == (None, None, None)
+    # CM reference should be removed
+    assert not hasattr(saver, "_langgraph_cm")
+
+
+def test_close_cosmos_checkpointer_idempotent(monkeypatch: Any) -> None:
+    """Second call to close_cosmos_checkpointer is a no-op (raises TypeError)."""
+    _install_fake_cosmos(monkeypatch)
+    _install_fake_azure_identity(monkeypatch)
+
+    module = importlib.import_module("azure_functions_langgraph.checkpointers.cosmos")
+    importlib.reload(module)
+    _patch_python_311(monkeypatch)
+    saver = module.create_cosmos_checkpointer(
+        endpoint="https://test.documents.azure.com:443/",
+        database_name="db",
+        container_name="ctr",
+    )
+
+    module.close_cosmos_checkpointer(saver)
+    # Second call should raise TypeError since _langgraph_cm is gone
+    with pytest.raises(TypeError, match="_langgraph_cm"):
+        module.close_cosmos_checkpointer(saver)
+
+
+def test_close_cosmos_checkpointer_rejects_non_helper_saver(monkeypatch: Any) -> None:
+    """close_cosmos_checkpointer rejects savers not created by create_cosmos_checkpointer."""
+    module = importlib.import_module("azure_functions_langgraph.checkpointers.cosmos")
+    importlib.reload(module)
+
+    fake_saver = object()  # No _langgraph_cm attribute
+    with pytest.raises(TypeError, match="_langgraph_cm"):
+        module.close_cosmos_checkpointer(fake_saver)
+
+
+def test_checkpointers_package_exports_close_helper() -> None:
+    pkg = importlib.import_module("azure_functions_langgraph.checkpointers")
+    assert "close_cosmos_checkpointer" in pkg.__all__
+    assert callable(pkg.close_cosmos_checkpointer)

--- a/tests/test_checkpointers_cosmos_helper.py
+++ b/tests/test_checkpointers_cosmos_helper.py
@@ -437,7 +437,7 @@ def test_close_cosmos_checkpointer_calls_exit(monkeypatch: Any) -> None:
 
 
 def test_close_cosmos_checkpointer_idempotent(monkeypatch: Any) -> None:
-    """Second call to close_cosmos_checkpointer is a no-op (raises TypeError)."""
+    """Second call to close_cosmos_checkpointer is a silent no-op."""
     _install_fake_cosmos(monkeypatch)
     _install_fake_azure_identity(monkeypatch)
 
@@ -451,10 +451,8 @@ def test_close_cosmos_checkpointer_idempotent(monkeypatch: Any) -> None:
     )
 
     module.close_cosmos_checkpointer(saver)
-    # Second call should raise TypeError since _langgraph_cm is gone
-    with pytest.raises(TypeError, match="_langgraph_cm"):
-        module.close_cosmos_checkpointer(saver)
-
+    # Second call is a no-op — must not raise
+    module.close_cosmos_checkpointer(saver)
 
 def test_close_cosmos_checkpointer_rejects_non_helper_saver(monkeypatch: Any) -> None:
     """close_cosmos_checkpointer rejects savers not created by create_cosmos_checkpointer."""

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 def test_version_string() -> None:
     from azure_functions_langgraph import __version__
 
-    assert __version__ == "0.6.0"
+    assert __version__ == "0.7.0"
 
 
 def test_langgraph_app_importable() -> None:


### PR DESCRIPTION
## Summary
- Add `close_cosmos_checkpointer()` cleanup helper with 4 unit tests
- Add Cosmos DB emulator integration test suite (6 tests) with docker-compose, CI workflow, and Makefile target
- Bump version to 0.7.0 and update CHANGELOG

Closes #167
Closes #172