### PR TITLE
fix(checkpointers): correct cosmos package name and API to match upstream

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -146,4 +146,4 @@ CI tests include:
 |---|---|---|---|
 | `postgres` | `langgraph-checkpoint-postgres>=3.0,<4` | 3.10+ | Production DB checkpoint backend |
 | `sqlite` | `langgraph-checkpoint-sqlite>=3.0,<4` | 3.10+ | Local development |
-| `cosmos` | `langgraph-checkpoint-cosmos>=0.1.1,<0.2` | 3.11+ | Experimental Azure-native checkpoint backend |
+| `cosmos` | `langgraph-checkpoint-cosmosdb>=0.2.0,<0.3` | 3.10+ | Experimental Azure-native checkpoint backend |

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ pip install azure-functions-langgraph[postgres]
 # SQLite checkpointer (local dev)
 pip install azure-functions-langgraph[sqlite]
 
-# Cosmos DB checkpointer (requires Python 3.11+)
+# Cosmos DB checkpointer
 pip install azure-functions-langgraph[cosmos]
 ```
 
@@ -442,9 +442,9 @@ For workloads that already run a managed database (or need state shared across m
 | --- | --- | --- | --- |
 | Postgres | `create_postgres_checkpointer` | `pip install azure-functions-langgraph[postgres]` | Production, multi-instance, existing Postgres infra |
 | SQLite | `create_sqlite_checkpointer` | `pip install azure-functions-langgraph[sqlite]` | Local dev and single-instance deployments |
-| Cosmos DB | `create_cosmos_checkpointer` | `pip install azure-functions-langgraph[cosmos]` | Azure-native serverless/global production (Python 3.11+) |
+| Cosmos DB | `create_cosmos_checkpointer` | `pip install azure-functions-langgraph[cosmos]` | Azure-native serverless/global production |
 
-Each helper owns the connection lifetime and emits clear ImportErrors pointing at the right extra. The Postgres and SQLite helpers accept a connection string and (by default) call upstream `setup()` on cold start so the checkpoint tables exist; the Cosmos DB helper accepts an endpoint and credential and enters the upstream context manager at cold start:
+Each helper owns the connection lifetime and emits clear ImportErrors pointing at the right extra. The Postgres and SQLite helpers accept a connection string and (by default) call upstream `setup()` on cold start so the checkpoint tables exist; the Cosmos DB helper accepts an endpoint and key and enters the upstream context manager at cold start:
 
 ```python
 import os

--- a/examples/README.md
+++ b/examples/README.md
@@ -9,7 +9,7 @@
 | Persistent storage | [`persistent_agent_blob_table`](persistent_agent_blob_table/) | End-to-end Azure Blob checkpointer + Azure Table thread store, runnable on Azurite. |
 | DB checkpoint (local) | [`sqlite_checkpoint_local`](sqlite_checkpoint_local/) | LangGraph SQLite checkpointer wired via `create_sqlite_checkpointer()` for local dev. |
 | DB checkpoint (production) | [`postgres_checkpoint_production`](postgres_checkpoint_production/) | LangGraph Postgres checkpointer wired via `create_postgres_checkpointer()` for multi-instance prod. |
-| Cosmos DB checkpoint | [`cosmos_checkpoint_azure`](cosmos_checkpoint_azure/) | LangGraph Cosmos DB checkpointer wired via `create_cosmos_checkpointer()` with `DefaultAzureCredential` (Python 3.11+). |
+| Cosmos DB checkpoint | [`cosmos_checkpoint_azure`](cosmos_checkpoint_azure/) | LangGraph Cosmos DB checkpointer wired via `create_cosmos_checkpointer()` with key-based auth (Python 3.10+). |
 | Managed Identity | [`managed_identity_storage`](managed_identity_storage/) | Same backends wired with `DefaultAzureCredential` for production, with Azurite fallback for local dev. |
 | OpenAPI bridge | [`openapi_bridge`](openapi_bridge/) | Wires `register_with_openapi` into `azure-functions-openapi-python` for spec generation. |
 | Per-graph auth | [`production_auth`](production_auth/) | Public health + anonymous demo graph alongside a function-key-protected graph. |

--- a/examples/cosmos_checkpoint_azure/README.md
+++ b/examples/cosmos_checkpoint_azure/README.md
@@ -11,21 +11,21 @@ from an Azure Functions Python app.
 Use this example when you want:
 
 - Azure-native checkpoint persistence
-- Managed Identity / DefaultAzureCredential
+- Key-based Cosmos DB authentication
 - A serverless-friendly production backend
 - Multi-instance Azure Functions compatibility
 
 ## Requirements
 
-- Python 3.11+
+- Python 3.10+
 - Azure Cosmos DB for NoSQL account
 - Cosmos DB database and container
 - Container partition key path: `/partition_key`
-- Managed Identity or local `az login`
+- Cosmos DB master key (or `COSMOS_KEY` environment variable)
 
 ## Files
 
-- `function_app.py` — wires `create_cosmos_checkpointer` with default credential resolution (`DefaultAzureCredential`)
+- `function_app.py` — wires `create_cosmos_checkpointer` with key-based authentication
 - `graph.py` — turn-counting echo agent (storage-free, used by smoke tests)
 - `host.json`, `local.settings.json.example`, `requirements.txt`
 
@@ -34,8 +34,14 @@ Use this example when you want:
 | Setting | Description |
 |---|---|
 | `AZURE_COSMOS_ENDPOINT` | Cosmos DB account endpoint |
+| `COSMOS_KEY` | Cosmos DB master key (wrapper convention — see note below) |
 | `LANGGRAPH_COSMOS_DATABASE` | Cosmos DB database name (default: `langgraph`) |
 | `LANGGRAPH_COSMOS_CONTAINER` | Cosmos DB container name (default: `checkpoints`) |
+
+> **Note:** `COSMOS_KEY` is a convenience convention defined by this wrapper's
+> `create_cosmos_checkpointer()` helper.  It is **not** read by the upstream
+> `langgraph-checkpoint-cosmosdb` package directly.  You can also pass `key=`
+> explicitly instead of relying on the env var.
 
 ## Azure Cosmos DB setup
 
@@ -45,36 +51,27 @@ Use this example when you want:
 
 ## Local development
 
-Run against a real Cosmos DB account using Azure CLI credentials:
-
 ```bash
-az login
-
 cp local.settings.json.example local.settings.json
-# Edit local.settings.json with your Cosmos DB endpoint
+# Edit local.settings.json with your Cosmos DB endpoint and key
 
 pip install -r requirements.txt
 func start
 ```
 
-> **Note:** This example does not use the Cosmos DB Emulator.
-> A real Cosmos DB account is required for local testing.
+You can also use the Cosmos DB Emulator for local development (see
+`tests/integration/` for emulator-based integration tests).
 
 ## Production
 
-Enable Managed Identity on the Function App and grant the required
-Cosmos DB data-plane role:
+Store the Cosmos DB master key in Azure Function App Settings (or Key Vault
+reference) and set `AZURE_COSMOS_ENDPOINT` and `COSMOS_KEY` as app settings.
 
-```bash
-PRINCIPAL_ID=$(az functionapp identity show -n <function-app> -g <rg> --query principalId -o tsv)
-
-az cosmosdb sql role assignment create \
-  --account-name <cosmos-account> \
-  --resource-group <rg> \
-  --scope "/" \
-  --principal-id "$PRINCIPAL_ID" \
-  --role-definition-id "00000000-0000-0000-0000-000000000002"  # Cosmos DB Built-in Data Contributor
-```
+> **Managed Identity note:** The upstream `langgraph-checkpoint-cosmosdb`
+> package currently requires a Cosmos DB master key (it reads `COSMOSDB_KEY`
+> from the environment internally).  Managed Identity / `DefaultAzureCredential`
+> is not supported by the upstream package at this time.  If upstream adds
+> `TokenCredential` support in the future, this helper will be updated.
 
 ## Verify persistence
 
@@ -96,7 +93,7 @@ The second response shows `[turn 2]`.
 
 ## Notes
 
-- This example does not use the Cosmos DB Emulator.
-- This example does not use connection strings by default.
-- The `cosmos` extra requires Python 3.11+.
+- The `cosmos` extra requires Python 3.10+.
+- The upstream package uses key-based authentication only.
 - The Cosmos DB container must be created with partition key path `/partition_key`.
+- You can use the Cosmos DB Emulator for local development and testing.

--- a/examples/cosmos_checkpoint_azure/function_app.py
+++ b/examples/cosmos_checkpoint_azure/function_app.py
@@ -12,7 +12,7 @@ checkpointer = create_cosmos_checkpointer(
     endpoint=os.environ["AZURE_COSMOS_ENDPOINT"],
     database_name=os.environ.get("LANGGRAPH_COSMOS_DATABASE", "langgraph"),
     container_name=os.environ.get("LANGGRAPH_COSMOS_CONTAINER", "checkpoints"),
-    # credential=None uses DefaultAzureCredential (Managed Identity in Azure, az login locally)
+    # key= is read from COSMOS_KEY env var when not passed explicitly
 )
 
 compiled_graph = build_graph().compile(checkpointer=checkpointer)
@@ -25,9 +25,7 @@ langgraph_app = LangGraphApp(
 langgraph_app.register(
     graph=compiled_graph,
     name="cosmos_agent",
-    description=(
-        "Echo agent persisted with Azure Cosmos DB checkpoint saver using DefaultAzureCredential."
-    ),
+    description="Echo agent persisted with Azure Cosmos DB checkpoint saver.",
 )
 
 app = langgraph_app.function_app

--- a/examples/cosmos_checkpoint_azure/requirements.txt
+++ b/examples/cosmos_checkpoint_azure/requirements.txt
@@ -1,14 +1,7 @@
 # Do not include azure-functions-worker in this file
 # The Python Worker is managed by the Azure Functions platform
-#
-# This example requires Python 3.11+ because the Cosmos DB checkpointer
-# extra depends on packages that require Python 3.11+.
-#
-# Until v0.7.0 is released, install from a local checkout:
-#
-#     pip install -e ../..[cosmos,azure-identity]
 
 azure-functions
-azure-functions-langgraph[cosmos,azure-identity]>=0.7.0,<0.8.0
+azure-functions-langgraph[cosmos]>=0.7.0,<0.8.0
 langgraph>=1.0,<2.0
 langchain-core>=1.0,<2.0

--- a/examples/maintenance_timer/function_app.py
+++ b/examples/maintenance_timer/function_app.py
@@ -62,9 +62,7 @@ def reset_stale_locks(timer: func.TimerRequest) -> None:
     try:
         older_than = int(os.environ.get("STALE_LOCK_THRESHOLD_SECONDS", "600"))
     except (ValueError, TypeError):
-        logger.error(
-            "Invalid STALE_LOCK_THRESHOLD_SECONDS, falling back to 600"
-        )
+        logger.error("Invalid STALE_LOCK_THRESHOLD_SECONDS, falling back to 600")
         older_than = 600
     reset_status: Literal["idle", "error"] = "error"
     raw_status = os.environ.get("STALE_LOCK_RESET_STATUS", "error")

--- a/examples/managed_identity_storage/function_app.py
+++ b/examples/managed_identity_storage/function_app.py
@@ -5,10 +5,9 @@ import os
 
 from azure.core.exceptions import ResourceExistsError
 from azure.data.tables import TableClient
+import azure.functions as func
 from azure.storage.blob import ContainerClient
 from graph import build_graph
-
-import azure.functions as func
 
 from azure_functions_langgraph import LangGraphApp
 from azure_functions_langgraph.checkpointers.azure_blob import AzureBlobCheckpointSaver

--- a/examples/openapi_bridge/function_app.py
+++ b/examples/openapi_bridge/function_app.py
@@ -1,6 +1,5 @@
-from graph import compiled_graph
-
 import azure.functions as func
+from graph import compiled_graph
 
 from azure_functions_langgraph import LangGraphApp
 from azure_functions_langgraph.openapi import register_with_openapi

--- a/examples/persistent_agent_blob_table/function_app.py
+++ b/examples/persistent_agent_blob_table/function_app.py
@@ -2,10 +2,9 @@ from __future__ import annotations
 
 import os
 
+import azure.functions as func
 from azure.storage.blob import ContainerClient
 from graph import build_graph
-
-import azure.functions as func
 
 from azure_functions_langgraph import LangGraphApp
 from azure_functions_langgraph.checkpointers.azure_blob import AzureBlobCheckpointSaver

--- a/examples/platform_compat_sdk/function_app.py
+++ b/examples/platform_compat_sdk/function_app.py
@@ -1,6 +1,5 @@
-from graph import compiled_graph
-
 import azure.functions as func
+from graph import compiled_graph
 
 from azure_functions_langgraph import LangGraphApp
 

--- a/examples/postgres_checkpoint_production/function_app.py
+++ b/examples/postgres_checkpoint_production/function_app.py
@@ -2,9 +2,8 @@ from __future__ import annotations
 
 import os
 
-from graph import build_graph
-
 import azure.functions as func
+from graph import build_graph
 
 from azure_functions_langgraph import LangGraphApp
 from azure_functions_langgraph.checkpointers.postgres import create_postgres_checkpointer

--- a/examples/production_auth/function_app.py
+++ b/examples/production_auth/function_app.py
@@ -1,6 +1,5 @@
-from graph import private_graph, public_graph
-
 import azure.functions as func
+from graph import private_graph, public_graph
 
 from azure_functions_langgraph import LangGraphApp
 

--- a/examples/sqlite_checkpoint_local/function_app.py
+++ b/examples/sqlite_checkpoint_local/function_app.py
@@ -2,9 +2,8 @@ from __future__ import annotations
 
 import os
 
-from graph import build_graph
-
 import azure.functions as func
+from graph import build_graph
 
 from azure_functions_langgraph import LangGraphApp
 from azure_functions_langgraph.checkpointers.sqlite import create_sqlite_checkpointer

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ sqlite = [
     "langgraph-checkpoint-sqlite>=3.0,<4",
 ]
 cosmos = [
-    "langgraph-checkpoint-cosmos>=0.1.1,<0.2",
+    "langgraph-checkpoint-cosmosdb>=0.2.0,<0.3",
 ]
 dev = [
     "bandit==1.9.4",

--- a/src/azure_functions_langgraph/checkpointers/azure_blob.py
+++ b/src/azure_functions_langgraph/checkpointers/azure_blob.py
@@ -630,9 +630,7 @@ class AzureBlobCheckpointSaver(BaseCheckpointSaver[str]):
                 )
                 return None
             try:
-                checkpoint_data: Checkpoint = self.serde.loads_typed(
-                    (typed_blob[0], typed_blob[1])
-                )
+                checkpoint_data: Checkpoint = self.serde.loads_typed((typed_blob[0], typed_blob[1]))
                 channel_versions = checkpoint_data["channel_versions"]
             except Exception:
                 logger.warning(
@@ -667,7 +665,7 @@ class AzureBlobCheckpointSaver(BaseCheckpointSaver[str]):
         values_prefix = f"{self._namespace_prefix(thread_id, checkpoint_ns)}values/"
         if not blob_path.startswith(values_prefix):
             return None
-        relative = blob_path[len(values_prefix):]
+        relative = blob_path[len(values_prefix) :]
         parts = relative.split("/")
         if len(parts) != 2 or not parts[1].endswith(".bin"):
             return None

--- a/src/azure_functions_langgraph/checkpointers/cosmos.py
+++ b/src/azure_functions_langgraph/checkpointers/cosmos.py
@@ -14,12 +14,23 @@ This module deliberately does **not** reimplement Cosmos DB checkpoint
 storage.  It centralizes the connection convention and emits a clear
 ImportError pointing at the right extra when the upstream package is
 missing.
+
+Environment variables
+---------------------
+``COSMOS_KEY`` is a **wrapper-only** convention defined by this helper for
+convenience when no ``key`` argument is passed.  It is **not** read by the
+upstream ``langgraph-checkpoint-cosmosdb`` package itself.  The upstream
+package reads ``COSMOSDB_ENDPOINT`` and ``COSMOSDB_KEY`` from the process
+environment during its ``__init__``; this helper sets those transiently.
 """
 
 from __future__ import annotations
 
 import importlib
+import threading
 from typing import TYPE_CHECKING
+import warnings
+import weakref
 
 if TYPE_CHECKING:
     from langgraph_checkpoint_cosmosdb import CosmosDBSaver
@@ -29,6 +40,13 @@ _EXTRA_HINT = (
     "Cosmos DB checkpointer requires the 'cosmos' extra: "
     "pip install azure-functions-langgraph[cosmos]"
 )
+
+# Lock to protect env var manipulation during construction.
+_env_lock = threading.Lock()
+
+# Track savers created by this helper so close_cosmos_checkpointer can
+# reject non-helper savers with a clear TypeError.
+_managed_savers: weakref.WeakSet[object] = weakref.WeakSet()
 
 
 def create_cosmos_checkpointer(
@@ -47,14 +65,14 @@ def create_cosmos_checkpointer(
 
     Provide **one** of ``key`` or ``credential``:
 
-    - ``key``: A Cosmos DB master key (string).  This is passed directly
-      to the upstream ``from_conn_info(key=...)``.
-    - ``credential``: **Deprecated alias** — if a string is provided it
-      is treated as ``key``.  Non-string credential objects are not
-      supported by the upstream package.
+    - ``key``: A Cosmos DB master key (string).  Preferred parameter.
+    - ``credential``: **Deprecated** — if a string is provided it is
+      treated as ``key``.  Non-string credential objects are not supported
+      by the upstream package.
 
     If neither is supplied, the ``COSMOS_KEY`` environment variable is
-    read as a fallback.
+    read as a fallback.  Note that ``COSMOS_KEY`` is a convention of this
+    wrapper only — the upstream package does not read it.
 
     Args:
         endpoint: Cosmos DB account endpoint
@@ -73,6 +91,8 @@ def create_cosmos_checkpointer(
     Raises:
         ImportError: If ``langgraph-checkpoint-cosmosdb`` is not installed.
             Install via the ``cosmos`` extra.
+        TypeError: If both ``key`` and ``credential`` are provided, or if
+            ``credential`` is a non-string object.
         ValueError: If no key is provided and ``COSMOS_KEY`` env var is unset.
     """
     try:
@@ -87,11 +107,23 @@ def create_cosmos_checkpointer(
             "upgrade langgraph-checkpoint-cosmosdb to >=0.2.0,<0.3."
         )
 
+    # Reject ambiguous calls where both key and credential are provided.
+    if key is not None and credential is not None:
+        raise TypeError(
+            "Cannot pass both 'key' and 'credential'. Use 'key' only; 'credential' is deprecated."
+        )
+
     # Resolve the key from the various input options.
     resolved_key: str
     if key is not None:
         resolved_key = key
     elif credential is not None:
+        warnings.warn(
+            "The 'credential' parameter is deprecated and will be removed in "
+            "a future version. Use 'key' instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         # Back-compat: treat string credential as key.
         if isinstance(credential, str):
             resolved_key = credential
@@ -117,43 +149,60 @@ def create_cosmos_checkpointer(
     # the env vars that __init__ reads, then construct the saver.
     import os
 
-    original_endpoint = os.environ.get("COSMOSDB_ENDPOINT")
-    original_key = os.environ.get("COSMOSDB_KEY")
-    try:
-        os.environ["COSMOSDB_ENDPOINT"] = endpoint
-        os.environ["COSMOSDB_KEY"] = resolved_key
-        saver = CosmosDBSaver(database_name=database_name, container_name=container_name)
-    finally:
-        # Restore original env vars
-        if original_endpoint is None:
-            os.environ.pop("COSMOSDB_ENDPOINT", None)
-        else:
-            os.environ["COSMOSDB_ENDPOINT"] = original_endpoint
-        if original_key is None:
-            os.environ.pop("COSMOSDB_KEY", None)
-        else:
-            os.environ["COSMOSDB_KEY"] = original_key
+    with _env_lock:
+        original_endpoint = os.environ.get("COSMOSDB_ENDPOINT")
+        original_key = os.environ.get("COSMOSDB_KEY")
+        try:
+            os.environ["COSMOSDB_ENDPOINT"] = endpoint
+            os.environ["COSMOSDB_KEY"] = resolved_key
+            saver = CosmosDBSaver(database_name=database_name, container_name=container_name)
+        finally:
+            # Restore original env vars
+            if original_endpoint is None:
+                os.environ.pop("COSMOSDB_ENDPOINT", None)
+            else:
+                os.environ["COSMOSDB_ENDPOINT"] = original_endpoint
+            if original_key is None:
+                os.environ.pop("COSMOSDB_KEY", None)
+            else:
+                os.environ["COSMOSDB_KEY"] = original_key
 
+    _managed_savers.add(saver)
     return saver
 
 
 def close_cosmos_checkpointer(saver: CosmosDBSaver) -> None:
     """Close a :class:`CosmosDBSaver` created by :func:`create_cosmos_checkpointer`.
 
-    Closes the underlying Cosmos DB client to release resources.
-    Safe to call multiple times; the second and subsequent calls are no-ops.
+    Marks the saver as closed.  If the underlying Cosmos client exposes a
+    ``close()`` method, it is called to release resources.  Safe to call
+    multiple times; the second and subsequent calls are no-ops.
 
     Args:
         saver: A saver returned by :func:`create_cosmos_checkpointer`.
+
+    Raises:
+        TypeError: If *saver* was not created by :func:`create_cosmos_checkpointer`.
     """
+    if saver not in _managed_savers:
+        raise TypeError(
+            "close_cosmos_checkpointer() only accepts savers created by "
+            "create_cosmos_checkpointer(). Got an unmanaged saver instance."
+        )
+
     if getattr(saver, "_langgraph_closed", False):
         return  # already closed — idempotent no-op
+
     client = getattr(saver, "client", None)
-    if client is not None and hasattr(client, "__del__"):
-        try:
-            client.__del__()
-        except Exception:  # noqa: BLE001
-            pass
+    if client is not None:
+        close_fn = getattr(client, "close", None)
+        if callable(close_fn):
+            try:
+                close_fn()
+            except Exception:  # noqa: BLE001
+                pass
+
     saver._langgraph_closed = True  # noqa: SLF001
+
 
 __all__ = ["create_cosmos_checkpointer", "close_cosmos_checkpointer"]

--- a/src/azure_functions_langgraph/checkpointers/cosmos.py
+++ b/src/azure_functions_langgraph/checkpointers/cosmos.py
@@ -2,37 +2,31 @@
 
 .. versionadded:: 0.7.0
 
-Thin wrapper around the upstream :pypi:`langgraph-checkpoint-cosmos`
-package that resolves credentials and builds a :class:`CosmosDBSaver`
-suitable for Azure Functions cold-start (module-level instantiation).
+Thin wrapper around the upstream :pypi:`langgraph-checkpoint-cosmosdb`
+package that builds a :class:`CosmosDBSaver` suitable for Azure Functions
+cold-start (module-level instantiation).
 
-The upstream saver is designed as a **context manager**.  This helper
-calls ``__enter__`` so the returned object is ready to use immediately
-and can be passed straight to ``builder.compile(checkpointer=...)``.
+The upstream ``__init__`` reads connection details from environment
+variables.  This helper temporarily sets those env vars, constructs the
+saver, then restores the original environment.
 
 This module deliberately does **not** reimplement Cosmos DB checkpoint
-storage.  It centralizes the credential convention, handles the
-context-manager lifecycle, and emits a clear ImportError pointing at
-the right extra when the upstream package is missing.
-
-.. note::
-
-   The ``cosmos`` extra requires **Python 3.11+**.  The base package
-   continues to support Python 3.10.
+storage.  It centralizes the connection convention and emits a clear
+ImportError pointing at the right extra when the upstream package is
+missing.
 """
 
 from __future__ import annotations
 
 import importlib
-import sys
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from langgraph_checkpoint_cosmos import CosmosDBSaver
+    from langgraph_checkpoint_cosmosdb import CosmosDBSaver
 
 
 _EXTRA_HINT = (
-    "Cosmos DB checkpointer requires the 'cosmos' extra (Python 3.11+): "
+    "Cosmos DB checkpointer requires the 'cosmos' extra: "
     "pip install azure-functions-langgraph[cosmos]"
 )
 
@@ -42,14 +36,25 @@ def create_cosmos_checkpointer(
     endpoint: str,
     database_name: str,
     container_name: str,
+    key: str | None = None,
     credential: object | None = None,
 ) -> CosmosDBSaver:
-    """Create a long-lived :class:`CosmosDBSaver` from connection info.
+    """Create a :class:`CosmosDBSaver` from connection info.
 
-    Resolves credentials (``None`` → :class:`DefaultAzureCredential`)
-    and calls :meth:`CosmosDBSaver.from_conn_info` to build the saver.
-    The context manager is entered immediately so the returned object is
-    ready for use at Azure Functions cold-start.
+    Instantiates the upstream saver directly, temporarily setting the
+    ``COSMOSDB_ENDPOINT`` and ``COSMOSDB_KEY`` environment variables that
+    the upstream constructor reads.
+
+    Provide **one** of ``key`` or ``credential``:
+
+    - ``key``: A Cosmos DB master key (string).  This is passed directly
+      to the upstream ``from_conn_info(key=...)``.
+    - ``credential``: **Deprecated alias** — if a string is provided it
+      is treated as ``key``.  Non-string credential objects are not
+      supported by the upstream package.
+
+    If neither is supplied, the ``COSMOS_KEY`` environment variable is
+    read as a fallback.
 
     Args:
         endpoint: Cosmos DB account endpoint
@@ -57,73 +62,77 @@ def create_cosmos_checkpointer(
         database_name: Cosmos DB database name.
         container_name: Cosmos DB container name.  The container **must**
             be created with partition key path ``/partition_key``.
-        credential: A credential object accepted by the Azure Cosmos SDK,
-            or ``None`` (the default) to create a
-            :class:`~azure.identity.DefaultAzureCredential`.
+        key: Cosmos DB master key (preferred).
+        credential: Deprecated — use ``key`` instead.  If a string is
+            passed it is treated as the master key.
 
     Returns:
         A :class:`CosmosDBSaver` ready to be passed to
         ``builder.compile(checkpointer=...)``.
 
     Raises:
-        RuntimeError: If running on Python < 3.11.
-        ImportError: If ``langgraph-checkpoint-cosmos`` or
-            ``azure-identity`` (when ``credential=None``) is not
-            installed.  Install via the ``cosmos`` extra.
+        ImportError: If ``langgraph-checkpoint-cosmosdb`` is not installed.
+            Install via the ``cosmos`` extra.
+        ValueError: If no key is provided and ``COSMOS_KEY`` env var is unset.
     """
-    if sys.version_info < (3, 11):
-        raise RuntimeError(
-            "Cosmos DB checkpointer requires Python 3.11+ "
-            "because langgraph-checkpoint-cosmos does not support Python 3.10."
-        )
     try:
-        cosmos_module = importlib.import_module("langgraph_checkpoint_cosmos")
+        cosmos_module = importlib.import_module("langgraph_checkpoint_cosmosdb")
     except ImportError as exc:
         raise ImportError(_EXTRA_HINT) from exc
 
     CosmosDBSaver = getattr(cosmos_module, "CosmosDBSaver", None)
     if CosmosDBSaver is None:
         raise ImportError(
-            "langgraph_checkpoint_cosmos is missing CosmosDBSaver; "
-            "upgrade langgraph-checkpoint-cosmos to >=0.1.1,<0.2."
+            "langgraph_checkpoint_cosmosdb is missing CosmosDBSaver; "
+            "upgrade langgraph-checkpoint-cosmosdb to >=0.2.0,<0.3."
         )
 
-    resolved_credential: Any
-    if credential is None:
-        try:
-            identity_module = importlib.import_module("azure.identity")
-        except ImportError as exc:
-            raise ImportError(
-                "credential=None requires azure-identity. "
-                "It is normally installed as a dependency of langgraph-checkpoint-cosmos; "
-                "if missing, run: pip install azure-identity>=1.16"
-            ) from exc
-        DefaultAzureCredential = getattr(identity_module, "DefaultAzureCredential", None)
-        if DefaultAzureCredential is None:
-            raise ImportError(
-                "azure.identity is missing DefaultAzureCredential; "
-                "upgrade azure-identity to >=1.16,<2."
+    # Resolve the key from the various input options.
+    resolved_key: str
+    if key is not None:
+        resolved_key = key
+    elif credential is not None:
+        # Back-compat: treat string credential as key.
+        if isinstance(credential, str):
+            resolved_key = credential
+        else:
+            raise TypeError(
+                "langgraph-checkpoint-cosmosdb requires a master key string, "
+                "not an Azure Identity credential object. "
+                "Pass key=<master-key> instead."
             )
-        resolved_credential = DefaultAzureCredential()
     else:
-        resolved_credential = credential
+        import os
 
-    cm = CosmosDBSaver.from_conn_info(
-        endpoint=endpoint,
-        credential=resolved_credential,
-        database_name=database_name,
-        container_name=container_name,
-    )
+        env_key = os.environ.get("COSMOS_KEY", "")
+        if not env_key:
+            raise ValueError(
+                "No Cosmos DB key provided. Pass key=... or set the "
+                "COSMOS_KEY environment variable."
+            )
+        resolved_key = env_key
 
-    # from_conn_info is a @contextmanager that yields the actual
-    # CosmosDBSaver instance.  We must capture the return value of
-    # __enter__ — it is the yielded saver, not the CM wrapper.
-    saver = cm.__enter__()
+    # The upstream from_conn_info has a bug (passes 4 positional args to
+    # __init__ which only accepts 2).  We instantiate directly by setting
+    # the env vars that __init__ reads, then construct the saver.
+    import os
 
-    # Stash the context manager so it is not garbage-collected (which
-    # would trigger __exit__ on a generator-based CM) and remains
-    # available for future cleanup if needed.
-    saver._langgraph_cm = cm  # noqa: SLF001
+    original_endpoint = os.environ.get("COSMOSDB_ENDPOINT")
+    original_key = os.environ.get("COSMOSDB_KEY")
+    try:
+        os.environ["COSMOSDB_ENDPOINT"] = endpoint
+        os.environ["COSMOSDB_KEY"] = resolved_key
+        saver = CosmosDBSaver(database_name=database_name, container_name=container_name)
+    finally:
+        # Restore original env vars
+        if original_endpoint is None:
+            os.environ.pop("COSMOSDB_ENDPOINT", None)
+        else:
+            os.environ["COSMOSDB_ENDPOINT"] = original_endpoint
+        if original_key is None:
+            os.environ.pop("COSMOSDB_KEY", None)
+        else:
+            os.environ["COSMOSDB_KEY"] = original_key
 
     return saver
 
@@ -131,34 +140,20 @@ def create_cosmos_checkpointer(
 def close_cosmos_checkpointer(saver: CosmosDBSaver) -> None:
     """Close a :class:`CosmosDBSaver` created by :func:`create_cosmos_checkpointer`.
 
-    Calls ``__exit__`` on the stashed context manager to release the
-    underlying Cosmos DB client resources.  Safe to call multiple times;
-    the second and subsequent calls are no-ops.
+    Closes the underlying Cosmos DB client to release resources.
+    Safe to call multiple times; the second and subsequent calls are no-ops.
 
     Args:
         saver: A saver returned by :func:`create_cosmos_checkpointer`.
-
-    Raises:
-        TypeError: If *saver* was not created by
-            :func:`create_cosmos_checkpointer` (missing ``_langgraph_cm``
-            on the first call).
     """
-    cm = getattr(saver, "_langgraph_cm", None)
-    if cm is None:
-        # Already closed or never created by create_cosmos_checkpointer.
-        # Distinguish: if the saver never had _langgraph_cm, it's a usage error.
-        # After a successful close, _langgraph_cm is deleted, so hasattr is False.
-        # We use a second sentinel to tell the two cases apart.
-        if not getattr(saver, "_langgraph_closed", False):
-            raise TypeError(
-                "saver was not created by create_cosmos_checkpointer "
-                "(missing _langgraph_cm attribute)"
-            )
+    if getattr(saver, "_langgraph_closed", False):
         return  # already closed — idempotent no-op
-    cm.__exit__(None, None, None)
-    # Remove the reference so the CM can be garbage-collected.
-    del saver._langgraph_cm  # noqa: SLF001
+    client = getattr(saver, "client", None)
+    if client is not None and hasattr(client, "__del__"):
+        try:
+            client.__del__()
+        except Exception:  # noqa: BLE001
+            pass
     saver._langgraph_closed = True  # noqa: SLF001
-
 
 __all__ = ["create_cosmos_checkpointer", "close_cosmos_checkpointer"]

--- a/src/azure_functions_langgraph/stores/azure_table.py
+++ b/src/azure_functions_langgraph/stores/azure_table.py
@@ -561,13 +561,9 @@ class AzureTableThreadStore(ThreadStore):
                 is not ``"idle"`` or ``"error"``.
         """
         if older_than_seconds < 0:
-            raise ValueError(
-                f"older_than_seconds must be non-negative, got {older_than_seconds}"
-            )
+            raise ValueError(f"older_than_seconds must be non-negative, got {older_than_seconds}")
         if status not in ("idle", "error"):
-            raise ValueError(
-                f"status must be 'idle' or 'error', got {status!r}"
-            )
+            raise ValueError(f"status must be 'idle' or 'error', got {status!r}")
 
         cutoff = self._now() - timedelta(seconds=older_than_seconds)
         modified_error = self._modified_error
@@ -595,11 +591,7 @@ class AzureTableThreadStore(ThreadStore):
 
             # Extract ETag for CAS
             entity_metadata = getattr(entity, "metadata", None)
-            etag = (
-                entity_metadata.get("etag")
-                if isinstance(entity_metadata, Mapping)
-                else None
-            )
+            etag = entity_metadata.get("etag") if isinstance(entity_metadata, Mapping) else None
             if etag is None:
                 etag = entity.get("etag") if isinstance(entity, dict) else None
             if etag is None:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -69,3 +69,27 @@ def cosmos_emulator_target() -> Iterator[tuple[str, str, str, str]]:
             _ = client.delete_database(database_name)
         except Exception:
             pass
+
+
+@pytest.fixture(autouse=True)
+def _patch_cosmos_client_for_emulator(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Patch CosmosClient in the upstream package to disable SSL verification.
+
+    The Cosmos emulator uses a self-signed certificate.  The upstream
+    ``CosmosDBSaver.__init__`` does not pass ``connection_verify=False``
+    to ``CosmosClient``, so we patch it at the module level.
+    """
+    try:
+        import azure.cosmos
+        import langgraph_checkpoint_cosmosdb.cosmosdbSaver as saver_mod
+    except ImportError:
+        return
+
+    _OriginalClient = azure.cosmos.CosmosClient
+
+    class _NoVerifyClient(_OriginalClient):  # type: ignore[misc,valid-type]
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            kwargs.setdefault("connection_verify", False)
+            super().__init__(*args, **kwargs)
+
+    monkeypatch.setattr(saver_mod, "CosmosClient", _NoVerifyClient)

--- a/tests/integration/test_cosmos_integration.py
+++ b/tests/integration/test_cosmos_integration.py
@@ -133,4 +133,3 @@ def test_list_checkpoints_returns_expected_results(
     ids = {item.checkpoint["id"] for item in checkpoints}
     assert {"cp-001", "cp-002"}.issubset(ids)
     close_cosmos_checkpointer(saver)
-

--- a/tests/integration/test_cosmos_integration.py
+++ b/tests/integration/test_cosmos_integration.py
@@ -6,7 +6,7 @@ from typing import Callable, Protocol, TypedDict, cast
 
 import pytest
 
-pytest.importorskip("langgraph_checkpoint_cosmos")
+pytest.importorskip("langgraph_checkpoint_cosmosdb")
 
 cosmos_helper_module = importlib.import_module("azure_functions_langgraph.checkpointers.cosmos")
 create_cosmos_checkpointer = cast(
@@ -87,7 +87,7 @@ def _create_saver(target: tuple[str, str, str, str]) -> CheckpointSaver:
         CheckpointSaver,
         create_cosmos_checkpointer(
             endpoint=endpoint,
-            credential=key,
+            key=key,
             database_name=database_name,
             container_name=container_name,
         ),
@@ -98,7 +98,7 @@ def test_create_cosmos_checkpointer_creates_saver(
     cosmos_emulator_target: tuple[str, str, str, str],
 ) -> None:
     saver = _create_saver(cosmos_emulator_target)
-    assert hasattr(saver, "_langgraph_cm")
+    assert saver is not None
     close_cosmos_checkpointer(saver)
 
 
@@ -107,7 +107,7 @@ def test_close_cosmos_checkpointer_cleans_up(
 ) -> None:
     saver = _create_saver(cosmos_emulator_target)
     close_cosmos_checkpointer(saver)
-    assert not hasattr(saver, "_langgraph_cm")
+    assert getattr(saver, "_langgraph_closed", False) is True
 
 
 def test_checkpoint_round_trip_put_get_tuple(
@@ -134,16 +134,3 @@ def test_list_checkpoints_returns_expected_results(
     assert {"cp-001", "cp-002"}.issubset(ids)
     close_cosmos_checkpointer(saver)
 
-
-def test_python_310_guard_raises_runtime_error(monkeypatch: pytest.MonkeyPatch) -> None:
-    module = cast(object, importlib.import_module("azure_functions_langgraph.checkpointers.cosmos"))
-    module_sys = cast(object, getattr(module, "sys"))
-    create_fn = cast(Callable[..., object], getattr(module, "create_cosmos_checkpointer"))
-    monkeypatch.setattr(module_sys, "version_info", (3, 10, 0))
-    with pytest.raises(RuntimeError, match="Python 3.11"):
-        _ = create_fn(
-            endpoint="https://localhost:8081",
-            credential="x",
-            database_name="db",
-            container_name="container",
-        )

--- a/tests/test_checkpointers_azure_blob.py
+++ b/tests/test_checkpointers_azure_blob.py
@@ -785,9 +785,7 @@ def test_collect_orphaned_values_preserves_shared_versions(
         {},
     )
 
-    saver.delete_checkpoints_before(
-        "t-1", before_checkpoint_id="cp-002", checkpoint_ns="ns"
-    )
+    saver.delete_checkpoints_before("t-1", before_checkpoint_id="cp-002", checkpoint_ns="ns")
 
     result = saver.collect_orphaned_values("t-1", checkpoint_ns="ns", dry_run=False)
 

--- a/tests/test_checkpointers_azure_blob.py
+++ b/tests/test_checkpointers_azure_blob.py
@@ -910,7 +910,8 @@ def test_collect_orphaned_values_concurrent_write_protects_blob(
     )
     saver.delete_old_checkpoints("t-1", keep_last=1, checkpoint_ns="ns")
 
-    original_collect = saver._collect_retained_versions  # type: ignore[attr-defined]
+    saver_obj = cast(Any, saver)
+    original_collect = saver_obj._collect_retained_versions
     call_count = {"n": 0}
 
     def patched(thread_id: str, checkpoint_ns: str) -> set[tuple[str, str]] | None:
@@ -930,7 +931,7 @@ def test_collect_orphaned_values_concurrent_write_protects_blob(
         call_count["n"] += 1
         return retained
 
-    saver._collect_retained_versions = patched  # type: ignore[attr-defined]
+    saver_obj._collect_retained_versions = patched
 
     result = saver.collect_orphaned_values("t-1", checkpoint_ns="ns", dry_run=False)
 
@@ -1163,3 +1164,89 @@ def test_collect_orphaned_values_result_dataclass_has_skipped_recent_field() -> 
     assert instance.skipped_recent == []
     package_module = importlib.import_module("azure_functions_langgraph.checkpointers")
     assert getattr(package_module, "OrphanedValueCollectionResult") is result_cls
+
+
+def test_internal_parse_value_blob_path_filters_invalid_paths(
+    saver_and_container: tuple[_CheckpointSaverProtocol, MockContainerClient],
+) -> None:
+    saver, _ = saver_and_container
+    saver_obj = cast(Any, saver)
+
+    assert saver_obj._parse_value_blob_path("t", "ns", "wrong/prefix.bin") is None
+    assert (
+        saver_obj._parse_value_blob_path("t", "ns", "threads/t/ns/ns/values/only-channel") is None
+    )
+    assert (
+        saver_obj._parse_value_blob_path("t", "ns", "threads/t/ns/ns/values/c/not-bin.txt") is None
+    )
+
+
+def test_internal_read_latest_checkpoint_id_invalid_payloads_return_none(
+    saver_and_container: tuple[_CheckpointSaverProtocol, MockContainerClient],
+) -> None:
+    saver, container = saver_and_container
+    saver_obj = cast(Any, saver)
+    latest_path = "threads/t-1/ns/ns/latest.json"
+
+    container.get_blob_client(latest_path).upload_blob(b"{", metadata={}, overwrite=True)
+    assert saver_obj._read_latest_checkpoint_id("t-1", "ns") is None
+
+    container.get_blob_client(latest_path).upload_blob(b"[]", metadata={}, overwrite=True)
+    assert saver_obj._read_latest_checkpoint_id("t-1", "ns") is None
+
+    container.get_blob_client(latest_path).upload_blob(
+        json.dumps({"checkpoint_id": 123}).encode(), metadata={}, overwrite=True
+    )
+    assert saver_obj._read_latest_checkpoint_id("t-1", "ns") is None
+
+
+def test_internal_list_helpers_ignore_malformed_paths(
+    saver_and_container: tuple[_CheckpointSaverProtocol, MockContainerClient],
+) -> None:
+    saver, container = saver_and_container
+    saver_obj = cast(Any, saver)
+    container.get_blob_client("threads/t-1/ns/ns/checkpoints/cp-1/checkpoint.bin").upload_blob(
+        b"x", metadata={}, overwrite=True
+    )
+    container.get_blob_client("threads/t-1/ns/ns/checkpoints/cp-2/not-checkpoint.txt").upload_blob(
+        b"x", metadata={}, overwrite=True
+    )
+    container.get_blob_client(
+        "threads/t-1/ns/ns/checkpoints/cp-3/extra/segment/checkpoint.bin"
+    ).upload_blob(b"x", metadata={}, overwrite=True)
+    container.get_blob_client("threads/t-1/ns/ns-a/values/k/v1.bin").upload_blob(
+        b"x", metadata={}, overwrite=True
+    )
+    container.get_blob_client("threads/t-1/ns/ns-b/checkpoints/cp-1/checkpoint.bin").upload_blob(
+        b"x", metadata={}, overwrite=True
+    )
+
+    assert saver_obj._list_checkpoint_ids("t-1", "ns") == ["cp-1"]
+    assert saver_obj._list_checkpoint_namespaces("t-1") == ["ns", "ns-a", "ns-b"]
+    assert saver_obj._list_thread_ids() == ["t-1"]
+
+
+def test_internal_download_typed_blob_missing_serde_type_returns_none(
+    saver_and_container: tuple[_CheckpointSaverProtocol, MockContainerClient],
+) -> None:
+    saver, container = saver_and_container
+    saver_obj = cast(Any, saver)
+    container.get_blob_client("threads/t/ns/ns/checkpoints/cp/checkpoint.bin").upload_blob(
+        b"abc", metadata={}, overwrite=True
+    )
+
+    assert saver_obj._download_typed_blob("threads/t/ns/ns/checkpoints/cp/checkpoint.bin") is None
+
+
+def test_internal_config_requires_configurable(
+    saver_and_container: tuple[_CheckpointSaverProtocol, MockContainerClient],
+) -> None:
+    saver, _ = saver_and_container
+    saver_obj = cast(Any, saver)
+
+    with pytest.raises(ValueError, match="configurable must be provided"):
+        saver_obj._config_thread_id({})
+    with pytest.raises(ValueError, match="thread_id is required"):
+        saver_obj._config_thread_id({"configurable": {}})
+    with pytest.raises(ValueError, match="configurable must be provided"):
+        saver_obj._config_checkpoint_ns({})

--- a/tests/test_checkpointers_cosmos_helper.py
+++ b/tests/test_checkpointers_cosmos_helper.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 import importlib
+import os
 import sys
 import types
 from typing import Any, cast
+from unittest.mock import MagicMock
 
 pytest = cast(Any, importlib.import_module("pytest"))
 
@@ -13,96 +15,36 @@ pytest = cast(Any, importlib.import_module("pytest"))
 # ---------------------------------------------------------------------------
 
 
-class FakeCosmosDBSaver:
-    """Fake saver returned by the context manager's ``__enter__``."""
-
-    def __init__(self, **kwargs: Any) -> None:
-        self.kwargs = kwargs
-        self._entered = True
-
-
-class _FakeContextManager:
-    """Fake CM that mimics the upstream ``@contextmanager`` behaviour.
-
-    ``__enter__`` returns a *different* object (``FakeCosmosDBSaver``)
-    to match the real upstream contract where ``from_conn_info`` is a
-    generator-based ``@contextmanager`` that *yields* the saver.
-    """
-
-    def __init__(self, saver: FakeCosmosDBSaver, enter_calls: list[int] | None = None) -> None:
-        self._saver = saver
-        self._enter_calls = enter_calls
-
-    def __enter__(self) -> FakeCosmosDBSaver:
-        if self._enter_calls is not None:
-            self._enter_calls.append(1)
-        return self._saver
-
-    def __exit__(self, *args: Any) -> None:
-        pass
-
-
 def _install_fake_cosmos(
     monkeypatch: Any,
     *,
-    from_conn_info_calls: list[dict[str, Any]] | None = None,
-    enter_calls: list[int] | None = None,
+    init_calls: list[dict[str, Any]] | None = None,
     omit_cosmos_saver: bool = False,
 ) -> None:
-    """Inject fake ``langgraph_checkpoint_cosmos`` into ``sys.modules``."""
-    captured_conn_info = from_conn_info_calls if from_conn_info_calls is not None else []
-    captured_enter = enter_calls if enter_calls is not None else []
+    """Inject fake ``langgraph_checkpoint_cosmosdb`` into ``sys.modules``."""
+    captured_init = init_calls if init_calls is not None else []
 
     class FakeCosmosDBSaverClass:
-        """Class-level fake that provides ``from_conn_info``."""
+        """Class-level fake that captures constructor calls."""
 
-        @classmethod
-        def from_conn_info(
-            cls,
-            *,
-            endpoint: str,
-            credential: Any,
-            database_name: str,
-            container_name: str,
-        ) -> _FakeContextManager:
-            captured_conn_info.append(
+        def __init__(self, database_name: str, container_name: str) -> None:
+            captured_init.append(
                 {
-                    "endpoint": endpoint,
-                    "credential": credential,
                     "database_name": database_name,
                     "container_name": container_name,
+                    "endpoint_env": os.environ.get("COSMOSDB_ENDPOINT", ""),
+                    "key_env": os.environ.get("COSMOSDB_KEY", ""),
                 }
             )
-            saver = FakeCosmosDBSaver()
-            return _FakeContextManager(saver, captured_enter)
+            self.database_name = database_name
+            self.container_name = container_name
+            self.client = MagicMock()
 
-    cosmos_module = types.ModuleType("langgraph_checkpoint_cosmos")
+    cosmos_module = types.ModuleType("langgraph_checkpoint_cosmosdb")
     if not omit_cosmos_saver:
         setattr(cosmos_module, "CosmosDBSaver", FakeCosmosDBSaverClass)
 
-    monkeypatch.setitem(sys.modules, "langgraph_checkpoint_cosmos", cosmos_module)
-
-
-def _install_fake_azure_identity(
-    monkeypatch: Any,
-    *,
-    credential_calls: list[int] | None = None,
-    omit_default_credential: bool = False,
-) -> None:
-    """Inject fake ``azure.identity`` into ``sys.modules``."""
-    captured = credential_calls if credential_calls is not None else []
-
-    class FakeDefaultAzureCredential:
-        def __init__(self) -> None:
-            captured.append(1)
-
-    azure_module = types.ModuleType("azure")
-    identity_module = types.ModuleType("azure.identity")
-    if not omit_default_credential:
-        setattr(identity_module, "DefaultAzureCredential", FakeDefaultAzureCredential)
-
-    monkeypatch.setitem(sys.modules, "azure", azure_module)
-    monkeypatch.setitem(sys.modules, "azure.identity", identity_module)
+    monkeypatch.setitem(sys.modules, "langgraph_checkpoint_cosmosdb", cosmos_module)
 
 
 # ---------------------------------------------------------------------------
@@ -110,168 +52,178 @@ def _install_fake_azure_identity(
 # ---------------------------------------------------------------------------
 
 
-def _patch_python_311(monkeypatch: Any) -> None:
-    """Pretend we are on Python 3.11 so the runtime guard passes."""
-    cosmos_mod = importlib.import_module("azure_functions_langgraph.checkpointers.cosmos")
-    monkeypatch.setattr(cosmos_mod.sys, "version_info", (3, 11, 0))
-
-
-def test_cosmos_helper_creates_saver_and_enters_context(monkeypatch: Any) -> None:
-    conn_info_calls: list[dict[str, Any]] = []
-    enter_calls: list[int] = []
-    _install_fake_cosmos(
-        monkeypatch,
-        from_conn_info_calls=conn_info_calls,
-        enter_calls=enter_calls,
-    )
-    _install_fake_azure_identity(monkeypatch)
+def test_cosmos_helper_creates_saver_with_explicit_key(monkeypatch: Any) -> None:
+    init_calls: list[dict[str, Any]] = []
+    _install_fake_cosmos(monkeypatch, init_calls=init_calls)
 
     module = importlib.import_module("azure_functions_langgraph.checkpointers.cosmos")
     importlib.reload(module)
-    _patch_python_311(monkeypatch)
     saver = module.create_cosmos_checkpointer(
         endpoint="https://test.documents.azure.com:443/",
         database_name="testdb",
         container_name="testcontainer",
+        key="my-master-key",
     )
 
-    assert len(conn_info_calls) == 1
-    assert conn_info_calls[0]["endpoint"] == "https://test.documents.azure.com:443/"
-    assert conn_info_calls[0]["database_name"] == "testdb"
-    assert conn_info_calls[0]["container_name"] == "testcontainer"
-    assert enter_calls == [1]
-    # The returned object must be FakeCosmosDBSaver (the yielded saver),
-    # NOT the context manager wrapper.
-    assert type(saver).__name__ == "FakeCosmosDBSaver"
-    assert saver._entered is True
+    assert len(init_calls) == 1
+    assert init_calls[0]["endpoint_env"] == "https://test.documents.azure.com:443/"
+    assert init_calls[0]["key_env"] == "my-master-key"
+    assert init_calls[0]["database_name"] == "testdb"
+    assert init_calls[0]["container_name"] == "testcontainer"
+    assert saver.database_name == "testdb"
 
 
-def test_cosmos_helper_returns_yielded_saver_not_cm(monkeypatch: Any) -> None:
-    """Verify that ``__enter__`` return value is captured, not the CM."""
+def test_cosmos_helper_restores_env_vars(monkeypatch: Any) -> None:
+    """Env vars are restored after construction."""
     _install_fake_cosmos(monkeypatch)
-    _install_fake_azure_identity(monkeypatch)
+    monkeypatch.delenv("COSMOSDB_ENDPOINT", raising=False)
+    monkeypatch.delenv("COSMOSDB_KEY", raising=False)
 
     module = importlib.import_module("azure_functions_langgraph.checkpointers.cosmos")
     importlib.reload(module)
-    _patch_python_311(monkeypatch)
-    saver = module.create_cosmos_checkpointer(
+    module.create_cosmos_checkpointer(
         endpoint="https://test.documents.azure.com:443/",
         database_name="db",
         container_name="ctr",
+        key="k",
     )
 
-    # Must be the yielded FakeCosmosDBSaver, not _FakeContextManager
-    assert type(saver).__name__ == "FakeCosmosDBSaver"
-    assert type(saver).__name__ != "_FakeContextManager"
+    # Env vars should be cleaned up
+    assert os.environ.get("COSMOSDB_ENDPOINT") is None
+    assert os.environ.get("COSMOSDB_KEY") is None
 
 
-def test_cosmos_helper_stashes_cm_on_saver(monkeypatch: Any) -> None:
-    """The context manager must be stashed on the saver to prevent GC."""
+def test_cosmos_helper_restores_existing_env_vars(monkeypatch: Any) -> None:
+    """Pre-existing env vars are preserved."""
     _install_fake_cosmos(monkeypatch)
-    _install_fake_azure_identity(monkeypatch)
+    monkeypatch.setenv("COSMOSDB_ENDPOINT", "original-endpoint")
+    monkeypatch.setenv("COSMOSDB_KEY", "original-key")
 
     module = importlib.import_module("azure_functions_langgraph.checkpointers.cosmos")
     importlib.reload(module)
-    _patch_python_311(monkeypatch)
-    saver = module.create_cosmos_checkpointer(
+    module.create_cosmos_checkpointer(
+        endpoint="https://new.documents.azure.com:443/",
+        database_name="db",
+        container_name="ctr",
+        key="new-key",
+    )
+
+    assert os.environ.get("COSMOSDB_ENDPOINT") == "original-endpoint"
+    assert os.environ.get("COSMOSDB_KEY") == "original-key"
+
+
+def test_cosmos_helper_credential_string_treated_as_key(monkeypatch: Any) -> None:
+    """Back-compat: passing credential=<string> is treated as key."""
+    init_calls: list[dict[str, Any]] = []
+    _install_fake_cosmos(monkeypatch, init_calls=init_calls)
+
+    module = importlib.import_module("azure_functions_langgraph.checkpointers.cosmos")
+    importlib.reload(module)
+    module.create_cosmos_checkpointer(
         endpoint="https://test.documents.azure.com:443/",
         database_name="db",
         container_name="ctr",
+        credential="my-string-key",
     )
 
-    assert hasattr(saver, "_langgraph_cm")
-    assert type(saver._langgraph_cm).__name__ == "_FakeContextManager"
+    assert init_calls[0]["key_env"] == "my-string-key"
 
 
-def test_cosmos_helper_default_credential_creates_default_azure_credential(
-    monkeypatch: Any,
-) -> None:
-    conn_info_calls: list[dict[str, Any]] = []
-    credential_calls: list[int] = []
-    _install_fake_cosmos(monkeypatch, from_conn_info_calls=conn_info_calls)
-    _install_fake_azure_identity(monkeypatch, credential_calls=credential_calls)
+def test_cosmos_helper_credential_non_string_raises_type_error(monkeypatch: Any) -> None:
+    """Non-string credential must raise TypeError."""
+    _install_fake_cosmos(monkeypatch)
 
     module = importlib.import_module("azure_functions_langgraph.checkpointers.cosmos")
     importlib.reload(module)
-    _patch_python_311(monkeypatch)
+
+    with pytest.raises(TypeError, match="master key string"):
+        module.create_cosmos_checkpointer(
+            endpoint="https://test.documents.azure.com:443/",
+            database_name="db",
+            container_name="ctr",
+            credential=object(),
+        )
+
+
+def test_cosmos_helper_env_var_fallback(monkeypatch: Any) -> None:
+    """When no key/credential provided, COSMOS_KEY env var is used."""
+    init_calls: list[dict[str, Any]] = []
+    _install_fake_cosmos(monkeypatch, init_calls=init_calls)
+    monkeypatch.setenv("COSMOS_KEY", "env-key-value")
+
+    module = importlib.import_module("azure_functions_langgraph.checkpointers.cosmos")
+    importlib.reload(module)
     module.create_cosmos_checkpointer(
         endpoint="https://test.documents.azure.com:443/",
         database_name="db",
         container_name="ctr",
     )
 
-    assert credential_calls == [1]
-    assert type(conn_info_calls[0]["credential"]).__name__ == "FakeDefaultAzureCredential"
+    assert init_calls[0]["key_env"] == "env-key-value"
 
 
-def test_cosmos_helper_explicit_credential_forwarded(monkeypatch: Any) -> None:
-    conn_info_calls: list[dict[str, Any]] = []
-    _install_fake_cosmos(monkeypatch, from_conn_info_calls=conn_info_calls)
+def test_cosmos_helper_no_key_no_env_raises_value_error(monkeypatch: Any) -> None:
+    """When no key provided and COSMOS_KEY is unset, ValueError is raised."""
+    _install_fake_cosmos(monkeypatch)
+    monkeypatch.delenv("COSMOS_KEY", raising=False)
 
     module = importlib.import_module("azure_functions_langgraph.checkpointers.cosmos")
     importlib.reload(module)
-    _patch_python_311(monkeypatch)
 
-    my_cred = object()
-    module.create_cosmos_checkpointer(
-        endpoint="https://test.documents.azure.com:443/",
-        database_name="db",
-        container_name="ctr",
-        credential=my_cred,
-    )
-
-    assert conn_info_calls[0]["credential"] is my_cred
+    with pytest.raises(ValueError, match="No Cosmos DB key"):
+        module.create_cosmos_checkpointer(
+            endpoint="https://test.documents.azure.com:443/",
+            database_name="db",
+            container_name="ctr",
+        )
 
 
 def test_cosmos_helper_endpoint_forwarded(monkeypatch: Any) -> None:
-    conn_info_calls: list[dict[str, Any]] = []
-    _install_fake_cosmos(monkeypatch, from_conn_info_calls=conn_info_calls)
+    init_calls: list[dict[str, Any]] = []
+    _install_fake_cosmos(monkeypatch, init_calls=init_calls)
 
     module = importlib.import_module("azure_functions_langgraph.checkpointers.cosmos")
     importlib.reload(module)
-    _patch_python_311(monkeypatch)
     module.create_cosmos_checkpointer(
         endpoint="https://custom.documents.azure.com:443/",
         database_name="db",
         container_name="ctr",
-        credential=object(),
+        key="k",
     )
 
-    assert conn_info_calls[0]["endpoint"] == "https://custom.documents.azure.com:443/"
+    assert init_calls[0]["endpoint_env"] == "https://custom.documents.azure.com:443/"
 
 
 def test_cosmos_helper_database_name_forwarded(monkeypatch: Any) -> None:
-    conn_info_calls: list[dict[str, Any]] = []
-    _install_fake_cosmos(monkeypatch, from_conn_info_calls=conn_info_calls)
+    init_calls: list[dict[str, Any]] = []
+    _install_fake_cosmos(monkeypatch, init_calls=init_calls)
 
     module = importlib.import_module("azure_functions_langgraph.checkpointers.cosmos")
     importlib.reload(module)
-    _patch_python_311(monkeypatch)
     module.create_cosmos_checkpointer(
         endpoint="https://x.documents.azure.com:443/",
         database_name="my_database",
         container_name="ctr",
-        credential=object(),
+        key="k",
     )
 
-    assert conn_info_calls[0]["database_name"] == "my_database"
+    assert init_calls[0]["database_name"] == "my_database"
 
 
 def test_cosmos_helper_container_name_forwarded(monkeypatch: Any) -> None:
-    conn_info_calls: list[dict[str, Any]] = []
-    _install_fake_cosmos(monkeypatch, from_conn_info_calls=conn_info_calls)
+    init_calls: list[dict[str, Any]] = []
+    _install_fake_cosmos(monkeypatch, init_calls=init_calls)
 
     module = importlib.import_module("azure_functions_langgraph.checkpointers.cosmos")
     importlib.reload(module)
-    _patch_python_311(monkeypatch)
     module.create_cosmos_checkpointer(
         endpoint="https://x.documents.azure.com:443/",
         database_name="db",
         container_name="my_container",
-        credential=object(),
+        key="k",
     )
 
-    assert conn_info_calls[0]["container_name"] == "my_container"
+    assert init_calls[0]["container_name"] == "my_container"
 
 
 def test_cosmos_helper_missing_cosmos_package_raises_helpful_error(monkeypatch: Any) -> None:
@@ -279,18 +231,18 @@ def test_cosmos_helper_missing_cosmos_package_raises_helpful_error(monkeypatch: 
     real_import_module = importlib.import_module
 
     def fake_import_module(name: str) -> Any:
-        if name == "langgraph_checkpoint_cosmos":
+        if name == "langgraph_checkpoint_cosmosdb":
             raise ImportError("missing")
         return real_import_module(name)
 
     monkeypatch.setattr(module.importlib, "import_module", fake_import_module)
-    _patch_python_311(monkeypatch)
 
     with pytest.raises(ImportError, match=r"\[cosmos\]"):
         module.create_cosmos_checkpointer(
             endpoint="https://x.documents.azure.com:443/",
             database_name="db",
             container_name="ctr",
+            key="k",
         )
 
 
@@ -298,52 +250,13 @@ def test_cosmos_helper_missing_cosmos_saver_symbol_raises(monkeypatch: Any) -> N
     _install_fake_cosmos(monkeypatch, omit_cosmos_saver=True)
     module = importlib.import_module("azure_functions_langgraph.checkpointers.cosmos")
     importlib.reload(module)
-    _patch_python_311(monkeypatch)
 
     with pytest.raises(ImportError, match="CosmosDBSaver"):
         module.create_cosmos_checkpointer(
             endpoint="https://x.documents.azure.com:443/",
             database_name="db",
             container_name="ctr",
-            credential=object(),
-        )
-
-
-def test_cosmos_helper_missing_azure_identity_raises_helpful_error(monkeypatch: Any) -> None:
-    _install_fake_cosmos(monkeypatch)
-    module = importlib.import_module("azure_functions_langgraph.checkpointers.cosmos")
-    importlib.reload(module)
-    _patch_python_311(monkeypatch)
-
-    real_import_module = importlib.import_module
-
-    def fake_import_module(name: str) -> Any:
-        if name == "azure.identity":
-            raise ImportError("missing")
-        return real_import_module(name)
-
-    monkeypatch.setattr(module.importlib, "import_module", fake_import_module)
-
-    with pytest.raises(ImportError, match="azure-identity"):
-        module.create_cosmos_checkpointer(
-            endpoint="https://x.documents.azure.com:443/",
-            database_name="db",
-            container_name="ctr",
-        )
-
-
-def test_cosmos_helper_missing_default_azure_credential_symbol_raises(monkeypatch: Any) -> None:
-    _install_fake_cosmos(monkeypatch)
-    _install_fake_azure_identity(monkeypatch, omit_default_credential=True)
-    module = importlib.import_module("azure_functions_langgraph.checkpointers.cosmos")
-    importlib.reload(module)
-    _patch_python_311(monkeypatch)
-
-    with pytest.raises(ImportError, match="DefaultAzureCredential"):
-        module.create_cosmos_checkpointer(
-            endpoint="https://x.documents.azure.com:443/",
-            database_name="db",
-            container_name="ctr",
+            key="k",
         )
 
 
@@ -353,49 +266,22 @@ def test_checkpointers_package_exports_cosmos_helper() -> None:
     assert callable(pkg.create_cosmos_checkpointer)
 
 
-def test_cosmos_helper_python_310_raises_runtime_error(monkeypatch: Any) -> None:
-    """On Python < 3.11 the helper must raise RuntimeError immediately."""
-    module = importlib.import_module("azure_functions_langgraph.checkpointers.cosmos")
-    importlib.reload(module)
-
-    monkeypatch.setattr(module.sys, "version_info", (3, 10, 0))
-
-    with pytest.raises(RuntimeError, match="Python 3.11"):
-        module.create_cosmos_checkpointer(
-            endpoint="https://x.documents.azure.com:443/",
-            database_name="db",
-            container_name="ctr",
-            credential=object(),
-        )
-
-
-def test_cosmos_helper_explicit_credential_skips_azure_identity(monkeypatch: Any) -> None:
-    """When an explicit credential is provided, azure.identity must not be imported."""
-    _install_fake_cosmos(monkeypatch)
-    # Do NOT install azure.identity — it should never be touched
+def test_cosmos_helper_key_takes_precedence_over_credential(monkeypatch: Any) -> None:
+    """When both key and credential are provided, key wins."""
+    init_calls: list[dict[str, Any]] = []
+    _install_fake_cosmos(monkeypatch, init_calls=init_calls)
 
     module = importlib.import_module("azure_functions_langgraph.checkpointers.cosmos")
     importlib.reload(module)
-    _patch_python_311(monkeypatch)
-
-    real_import_module = importlib.import_module
-
-    def spy_import_module(name: str) -> Any:
-        if name == "azure.identity":
-            raise AssertionError("azure.identity should not be imported with explicit credential")
-        return real_import_module(name)
-
-    monkeypatch.setattr(module.importlib, "import_module", spy_import_module)
-
-    my_cred = object()
-    saver = module.create_cosmos_checkpointer(
-        endpoint="https://x.documents.azure.com:443/",
+    module.create_cosmos_checkpointer(
+        endpoint="https://test.documents.azure.com:443/",
         database_name="db",
         container_name="ctr",
-        credential=my_cred,
+        key="explicit-key",
+        credential="should-be-ignored",
     )
 
-    assert type(saver).__name__ == "FakeCosmosDBSaver"
+    assert init_calls[0]["key_env"] == "explicit-key"
 
 
 # ---------------------------------------------------------------------------
@@ -403,65 +289,40 @@ def test_cosmos_helper_explicit_credential_skips_azure_identity(monkeypatch: Any
 # ---------------------------------------------------------------------------
 
 
-def test_close_cosmos_checkpointer_calls_exit(monkeypatch: Any) -> None:
-    """close_cosmos_checkpointer must call __exit__ on the stashed CM."""
+def test_close_cosmos_checkpointer_marks_closed(monkeypatch: Any) -> None:
+    """close_cosmos_checkpointer marks the saver as closed."""
     _install_fake_cosmos(monkeypatch)
-    _install_fake_azure_identity(monkeypatch)
 
     module = importlib.import_module("azure_functions_langgraph.checkpointers.cosmos")
     importlib.reload(module)
-    _patch_python_311(monkeypatch)
     saver = module.create_cosmos_checkpointer(
         endpoint="https://test.documents.azure.com:443/",
         database_name="db",
         container_name="ctr",
+        key="k",
     )
 
-    # Verify CM is stashed
-    assert hasattr(saver, "_langgraph_cm")
-
-    exit_calls: list[tuple[Any, ...]] = []
-    original_exit = saver._langgraph_cm.__exit__
-
-    def tracking_exit(*args: Any) -> None:
-        exit_calls.append(args)
-        original_exit(*args)
-
-    saver._langgraph_cm.__exit__ = tracking_exit
+    assert not getattr(saver, "_langgraph_closed", False)
     module.close_cosmos_checkpointer(saver)
-
-    assert len(exit_calls) == 1
-    assert exit_calls[0] == (None, None, None)
-    # CM reference should be removed
-    assert not hasattr(saver, "_langgraph_cm")
+    assert saver._langgraph_closed is True
 
 
 def test_close_cosmos_checkpointer_idempotent(monkeypatch: Any) -> None:
     """Second call to close_cosmos_checkpointer is a silent no-op."""
     _install_fake_cosmos(monkeypatch)
-    _install_fake_azure_identity(monkeypatch)
 
     module = importlib.import_module("azure_functions_langgraph.checkpointers.cosmos")
     importlib.reload(module)
-    _patch_python_311(monkeypatch)
     saver = module.create_cosmos_checkpointer(
         endpoint="https://test.documents.azure.com:443/",
         database_name="db",
         container_name="ctr",
+        key="k",
     )
 
     module.close_cosmos_checkpointer(saver)
     # Second call is a no-op — must not raise
     module.close_cosmos_checkpointer(saver)
-
-def test_close_cosmos_checkpointer_rejects_non_helper_saver(monkeypatch: Any) -> None:
-    """close_cosmos_checkpointer rejects savers not created by create_cosmos_checkpointer."""
-    module = importlib.import_module("azure_functions_langgraph.checkpointers.cosmos")
-    importlib.reload(module)
-
-    fake_saver = object()  # No _langgraph_cm attribute
-    with pytest.raises(TypeError, match="_langgraph_cm"):
-        module.close_cosmos_checkpointer(fake_saver)
 
 
 def test_checkpointers_package_exports_close_helper() -> None:

--- a/tests/test_checkpointers_cosmos_helper.py
+++ b/tests/test_checkpointers_cosmos_helper.py
@@ -6,6 +6,7 @@ import sys
 import types
 from typing import Any, cast
 from unittest.mock import MagicMock
+import warnings
 
 pytest = cast(Any, importlib.import_module("pytest"))
 
@@ -113,20 +114,26 @@ def test_cosmos_helper_restores_existing_env_vars(monkeypatch: Any) -> None:
 
 
 def test_cosmos_helper_credential_string_treated_as_key(monkeypatch: Any) -> None:
-    """Back-compat: passing credential=<string> is treated as key."""
+    """Back-compat: passing credential=<string> is treated as key with deprecation warning."""
     init_calls: list[dict[str, Any]] = []
     _install_fake_cosmos(monkeypatch, init_calls=init_calls)
 
     module = importlib.import_module("azure_functions_langgraph.checkpointers.cosmos")
     importlib.reload(module)
-    module.create_cosmos_checkpointer(
-        endpoint="https://test.documents.azure.com:443/",
-        database_name="db",
-        container_name="ctr",
-        credential="my-string-key",
-    )
+
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        module.create_cosmos_checkpointer(
+            endpoint="https://test.documents.azure.com:443/",
+            database_name="db",
+            container_name="ctr",
+            credential="my-string-key",
+        )
 
     assert init_calls[0]["key_env"] == "my-string-key"
+    assert len(w) == 1
+    assert issubclass(w[0].category, DeprecationWarning)
+    assert "deprecated" in str(w[0].message).lower()
 
 
 def test_cosmos_helper_credential_non_string_raises_type_error(monkeypatch: Any) -> None:
@@ -136,12 +143,31 @@ def test_cosmos_helper_credential_non_string_raises_type_error(monkeypatch: Any)
     module = importlib.import_module("azure_functions_langgraph.checkpointers.cosmos")
     importlib.reload(module)
 
-    with pytest.raises(TypeError, match="master key string"):
+    with warnings.catch_warnings(record=True):
+        warnings.simplefilter("always")
+        with pytest.raises(TypeError, match="master key string"):
+            module.create_cosmos_checkpointer(
+                endpoint="https://test.documents.azure.com:443/",
+                database_name="db",
+                container_name="ctr",
+                credential=object(),
+            )
+
+
+def test_cosmos_helper_both_key_and_credential_raises_type_error(monkeypatch: Any) -> None:
+    """Passing both key and credential must raise TypeError."""
+    _install_fake_cosmos(monkeypatch)
+
+    module = importlib.import_module("azure_functions_langgraph.checkpointers.cosmos")
+    importlib.reload(module)
+
+    with pytest.raises(TypeError, match="Cannot pass both"):
         module.create_cosmos_checkpointer(
             endpoint="https://test.documents.azure.com:443/",
             database_name="db",
             container_name="ctr",
-            credential=object(),
+            key="explicit-key",
+            credential="should-be-rejected",
         )
 
 
@@ -266,24 +292,6 @@ def test_checkpointers_package_exports_cosmos_helper() -> None:
     assert callable(pkg.create_cosmos_checkpointer)
 
 
-def test_cosmos_helper_key_takes_precedence_over_credential(monkeypatch: Any) -> None:
-    """When both key and credential are provided, key wins."""
-    init_calls: list[dict[str, Any]] = []
-    _install_fake_cosmos(monkeypatch, init_calls=init_calls)
-
-    module = importlib.import_module("azure_functions_langgraph.checkpointers.cosmos")
-    importlib.reload(module)
-    module.create_cosmos_checkpointer(
-        endpoint="https://test.documents.azure.com:443/",
-        database_name="db",
-        container_name="ctr",
-        key="explicit-key",
-        credential="should-be-ignored",
-    )
-
-    assert init_calls[0]["key_env"] == "explicit-key"
-
-
 # ---------------------------------------------------------------------------
 # close_cosmos_checkpointer tests
 # ---------------------------------------------------------------------------
@@ -307,6 +315,23 @@ def test_close_cosmos_checkpointer_marks_closed(monkeypatch: Any) -> None:
     assert saver._langgraph_closed is True
 
 
+def test_close_cosmos_checkpointer_calls_client_close(monkeypatch: Any) -> None:
+    """close_cosmos_checkpointer calls client.close() if available."""
+    _install_fake_cosmos(monkeypatch)
+
+    module = importlib.import_module("azure_functions_langgraph.checkpointers.cosmos")
+    importlib.reload(module)
+    saver = module.create_cosmos_checkpointer(
+        endpoint="https://test.documents.azure.com:443/",
+        database_name="db",
+        container_name="ctr",
+        key="k",
+    )
+
+    module.close_cosmos_checkpointer(saver)
+    saver.client.close.assert_called_once()
+
+
 def test_close_cosmos_checkpointer_idempotent(monkeypatch: Any) -> None:
     """Second call to close_cosmos_checkpointer is a silent no-op."""
     _install_fake_cosmos(monkeypatch)
@@ -323,9 +348,44 @@ def test_close_cosmos_checkpointer_idempotent(monkeypatch: Any) -> None:
     module.close_cosmos_checkpointer(saver)
     # Second call is a no-op — must not raise
     module.close_cosmos_checkpointer(saver)
+    # close only called once (first time)
+    saver.client.close.assert_called_once()
+
+
+def test_close_cosmos_checkpointer_rejects_unmanaged_saver(monkeypatch: Any) -> None:
+    """close_cosmos_checkpointer raises TypeError for non-helper savers."""
+    _install_fake_cosmos(monkeypatch)
+
+    module = importlib.import_module("azure_functions_langgraph.checkpointers.cosmos")
+    importlib.reload(module)
+
+    fake_saver = MagicMock()
+    with pytest.raises(TypeError, match="only accepts savers created by"):
+        module.close_cosmos_checkpointer(fake_saver)
 
 
 def test_checkpointers_package_exports_close_helper() -> None:
     pkg = importlib.import_module("azure_functions_langgraph.checkpointers")
     assert "close_cosmos_checkpointer" in pkg.__all__
     assert callable(pkg.close_cosmos_checkpointer)
+
+
+def test_cosmos_helper_deprecation_warning_on_credential(monkeypatch: Any) -> None:
+    """Using credential= emits a DeprecationWarning."""
+    _install_fake_cosmos(monkeypatch)
+
+    module = importlib.import_module("azure_functions_langgraph.checkpointers.cosmos")
+    importlib.reload(module)
+
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        module.create_cosmos_checkpointer(
+            endpoint="https://test.documents.azure.com:443/",
+            database_name="db",
+            container_name="ctr",
+            credential="some-key",
+        )
+
+    deprecation_warnings = [x for x in w if issubclass(x.category, DeprecationWarning)]
+    assert len(deprecation_warnings) == 1
+    assert "credential" in str(deprecation_warnings[0].message).lower()

--- a/tests/test_lazy_module_exports.py
+++ b/tests/test_lazy_module_exports.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import importlib
+
+
+def test_stores_getattr_exports_azure_table_store() -> None:
+    stores_module = importlib.import_module("azure_functions_langgraph.stores")
+    azure_table_module = importlib.import_module("azure_functions_langgraph.stores.azure_table")
+
+    assert stores_module.AzureTableThreadStore is azure_table_module.AzureTableThreadStore
+
+
+def test_stores_getattr_unknown_attribute_raises() -> None:
+    stores_module = importlib.import_module("azure_functions_langgraph.stores")
+
+    try:
+        _ = stores_module.DoesNotExist
+    except AttributeError as exc:
+        assert "DoesNotExist" in str(exc)
+    else:
+        raise AssertionError("Expected AttributeError")
+
+
+def test_checkpointers_getattr_known_exports() -> None:
+    checkpointers_module = importlib.import_module("azure_functions_langgraph.checkpointers")
+    azure_blob_module = importlib.import_module(
+        "azure_functions_langgraph.checkpointers.azure_blob"
+    )
+
+    assert (
+        checkpointers_module.AzureBlobCheckpointSaver is azure_blob_module.AzureBlobCheckpointSaver
+    )
+    assert (
+        checkpointers_module.OrphanedValueCollectionResult
+        is azure_blob_module.OrphanedValueCollectionResult
+    )
+
+
+def test_checkpointers_getattr_unknown_attribute_raises() -> None:
+    checkpointers_module = importlib.import_module("azure_functions_langgraph.checkpointers")
+
+    try:
+        _ = checkpointers_module.NotExported
+    except AttributeError as exc:
+        assert "NotExported" in str(exc)
+    else:
+        raise AssertionError("Expected AttributeError")

--- a/tests/test_platform_routes.py
+++ b/tests/test_platform_routes.py
@@ -2557,6 +2557,225 @@ def _decode_sse_body(body: str) -> list[dict[str, Any]]:
     return [_decode_sse_frame(f) for f in frames]
 
 
+class TestAdditionalCoverageBranches:
+    def test_assistants_search_validation_error_422(
+        self, graph: FakeCompiledGraph, store: InMemoryThreadStore
+    ) -> None:
+        app = _build_platform_app(graphs={"agent": graph}, store=store)
+        fn = _get_fn(app.function_app, "aflg_platform_assistants_search")
+
+        req = _post_request("/api/assistants/search", {"limit": "bad"})
+        resp = fn(req)
+
+        assert resp.status_code == 422
+
+    def test_assistants_count_validation_error_422(
+        self, graph: FakeCompiledGraph, store: InMemoryThreadStore
+    ) -> None:
+        app = _build_platform_app(graphs={"agent": graph}, store=store)
+        fn = _get_fn(app.function_app, "aflg_platform_assistants_count")
+
+        req = _post_request("/api/assistants/count", {"metadata": ["bad"]})
+        resp = fn(req)
+
+        assert resp.status_code == 422
+
+    def test_runs_wait_invalid_thread_id_returns_400(self, store: InMemoryThreadStore) -> None:
+        app = _build_platform_app(graphs={"agent": FakeCompiledGraph()}, store=store)
+        fn = _get_fn(app.function_app, "aflg_platform_runs_wait")
+
+        req = _post_request(
+            "/api/threads//runs/wait",
+            {"assistant_id": "agent", "input": {}},
+            thread_id="",
+        )
+        resp = fn(req)
+
+        assert resp.status_code == 400
+
+    def test_threads_update_race_keyerror_returns_404(
+        self, graph: FakeCompiledGraph, store: InMemoryThreadStore
+    ) -> None:
+        app = _build_platform_app(graphs={"agent": graph}, store=store)
+        thread = store.create(metadata={"k": "v"})
+
+        original_update = store.update
+
+        def race_update(thread_id: str, **kwargs: Any) -> Any:
+            del kwargs
+            raise KeyError(thread_id)
+
+        store.update = race_update  # type: ignore[method-assign]
+        try:
+            fn = _get_fn(app.function_app, "aflg_platform_threads_update")
+            req = _patch_request(
+                f"/api/threads/{thread.thread_id}",
+                {"metadata": {"k": "new"}},
+                thread_id=thread.thread_id,
+            )
+            resp = fn(req)
+            assert resp.status_code == 404
+        finally:
+            store.update = original_update  # type: ignore[method-assign]
+
+    def test_runs_stream_invalid_thread_id_returns_400(self, store: InMemoryThreadStore) -> None:
+        app = _build_platform_app(graphs={"agent": FakeCompiledGraph()}, store=store)
+        fn = _get_fn(app.function_app, "aflg_platform_runs_stream")
+
+        req = _post_request(
+            "/api/threads//runs/stream",
+            {"assistant_id": "agent", "input": {}},
+            thread_id="",
+        )
+        resp = fn(req)
+
+        assert resp.status_code == 400
+
+    def test_runs_stream_config_depth_validation_error(self, store: InMemoryThreadStore) -> None:
+        app = LangGraphApp(platform_compat=True, max_input_depth=1)
+        app._thread_store = store
+        app.register(graph=FakeCompiledGraph(), name="agent")
+        fn = _get_fn(app.function_app, "aflg_platform_runs_stream")
+
+        thread = store.create()
+        req = _post_request(
+            f"/api/threads/{thread.thread_id}/runs/stream",
+            {
+                "assistant_id": "agent",
+                "input": {},
+                "config": {"nested": {"too": "deep"}},
+            },
+            thread_id=thread.thread_id,
+        )
+        resp = fn(req)
+
+        assert resp.status_code == 400
+
+    def test_runs_stream_with_user_configurable_merges_and_runs(
+        self, store: InMemoryThreadStore
+    ) -> None:
+        app = _build_platform_app(graphs={"agent": FakeCompiledGraph()}, store=store)
+        fn = _get_fn(app.function_app, "aflg_platform_runs_stream")
+
+        thread = store.create()
+        req = _post_request(
+            f"/api/threads/{thread.thread_id}/runs/stream",
+            {
+                "assistant_id": "agent",
+                "input": {},
+                "config": {"configurable": {"user": "x"}, "tags": ["t"]},
+            },
+            thread_id=thread.thread_id,
+        )
+        resp = fn(req)
+
+        assert resp.status_code == 200
+        assert "event: end" in resp.get_body().decode()
+
+    def test_runs_stream_threadless_metadata_overflow_returns_error_event(
+        self, store: InMemoryThreadStore
+    ) -> None:
+        app = LangGraphApp(platform_compat=True, max_stream_response_bytes=1)
+        app._thread_store = store
+        app.register(graph=FakeCompiledGraph(), name="agent")
+        fn = _get_fn(app.function_app, "aflg_platform_runs_stream_threadless")
+
+        req = _post_request("/api/runs/stream", {"assistant_id": "agent", "input": {}})
+        resp = fn(req)
+
+        assert resp.status_code == 200
+        body = resp.get_body().decode()
+        assert "event: error" in body
+        assert "event: end" in body
+
+    def test_runs_stream_threadless_config_validation_error(
+        self, store: InMemoryThreadStore
+    ) -> None:
+        app = LangGraphApp(platform_compat=True, max_input_depth=1)
+        app._thread_store = store
+        app.register(graph=FakeCompiledGraph(), name="agent")
+        fn = _get_fn(app.function_app, "aflg_platform_runs_stream_threadless")
+
+        req = _post_request(
+            "/api/runs/stream",
+            {
+                "assistant_id": "agent",
+                "input": {},
+                "config": {"nested": {"too": "deep"}},
+            },
+        )
+        resp = fn(req)
+
+        assert resp.status_code == 400
+
+    def test_runs_stream_threadless_stream_mode_list_variants(
+        self, store: InMemoryThreadStore
+    ) -> None:
+        app = _build_platform_app(graphs={"agent": FakeCompiledGraph()}, store=store)
+        fn = _get_fn(app.function_app, "aflg_platform_runs_stream_threadless")
+
+        req_single = _post_request(
+            "/api/runs/stream",
+            {"assistant_id": "agent", "input": {}, "stream_mode": ["values"]},
+        )
+        req_empty = _post_request(
+            "/api/runs/stream",
+            {"assistant_id": "agent", "input": {}, "stream_mode": []},
+        )
+
+        assert fn(req_single).status_code == 200
+        assert fn(req_empty).status_code == 200
+
+    def test_runs_stream_threadless_data_chunk_overflow_branch(
+        self, store: InMemoryThreadStore
+    ) -> None:
+        class BigChunkGraph:
+            checkpointer = None
+
+            def invoke(self, input: dict[str, Any], config: dict[str, Any] | None = None) -> Any:
+                del input, config
+                return {}
+
+            def stream(
+                self,
+                input: dict[str, Any],
+                config: dict[str, Any] | None = None,
+                stream_mode: str = "values",
+            ) -> Iterator[Any]:
+                del input, config, stream_mode
+                yield {"x": "z" * 2000}
+
+        app = LangGraphApp(platform_compat=True, max_stream_response_bytes=600)
+        app._thread_store = store
+        app.register(graph=BigChunkGraph(), name="agent")
+        fn = _get_fn(app.function_app, "aflg_platform_runs_stream_threadless")
+
+        req = _post_request("/api/runs/stream", {"assistant_id": "agent", "input": {}})
+        resp = fn(req)
+
+        assert resp.status_code == 200
+        body = resp.get_body().decode()
+        assert "event: error" in body
+        assert "max buffered size" in body
+        assert "event: end" in body
+
+    def test_runs_stream_threadless_size_limit_returns_400(
+        self, store: InMemoryThreadStore
+    ) -> None:
+        app = LangGraphApp(platform_compat=True, max_request_body_bytes=16)
+        app._thread_store = store
+        app.register(graph=FakeCompiledGraph(), name="agent")
+        fn = _get_fn(app.function_app, "aflg_platform_runs_stream_threadless")
+
+        req = _post_request(
+            "/api/runs/stream",
+            {"assistant_id": "agent", "input": {"payload": "x" * 100}},
+        )
+        resp = fn(req)
+
+        assert resp.status_code == 400
+
+
 class TestStreamSSEWireFormat:
     """Exact byte-level verification of SSE output for SDK compatibility."""
 

--- a/tests/test_stores_azure_table.py
+++ b/tests/test_stores_azure_table.py
@@ -863,14 +863,16 @@ def test_reset_stale_locks_resets_stale_skips_recent(monkeypatch: Any) -> None:
     """Stale busy thread older than threshold is reset; recent busy thread is not."""
     store, table_client = _new_store()
     base = datetime(2026, 1, 1, tzinfo=timezone.utc)
-    timestamps = iter([
-        base,                            # create t1
-        base + timedelta(seconds=100),   # create t2
-        base + timedelta(seconds=10),    # acquire t1: sets updated_at=10
-        base + timedelta(seconds=500),   # acquire t2: sets updated_at=500
-        base + timedelta(seconds=700),   # reset_stale_locks: cutoff = 700 - 300 = 400
-        base + timedelta(seconds=700),   # reset_stale_locks: patch updated_at for t1
-    ])
+    timestamps = iter(
+        [
+            base,  # create t1
+            base + timedelta(seconds=100),  # create t2
+            base + timedelta(seconds=10),  # acquire t1: sets updated_at=10
+            base + timedelta(seconds=500),  # acquire t2: sets updated_at=500
+            base + timedelta(seconds=700),  # reset_stale_locks: cutoff = 700 - 300 = 400
+            base + timedelta(seconds=700),  # reset_stale_locks: patch updated_at for t1
+        ]
+    )
     monkeypatch.setattr(store, "_now", lambda: next(timestamps))
 
     t1 = store.create()
@@ -890,12 +892,14 @@ def test_reset_stale_locks_etag_mismatch_skips(monkeypatch: Any) -> None:
     """Concurrent re-acquire during reset: ETag mismatch → skipped, not stomped."""
     store, table_client = _new_store()
     base = datetime(2026, 1, 1, tzinfo=timezone.utc)
-    timestamps = iter([
-        base,                            # create
-        base + timedelta(seconds=10),    # acquire lock
-        base + timedelta(seconds=700),   # reset_stale_locks cutoff calc
-        base + timedelta(seconds=700),   # reset_stale_locks: patch updated_at (before CAS fails)
-    ])
+    timestamps = iter(
+        [
+            base,  # create
+            base + timedelta(seconds=10),  # acquire lock
+            base + timedelta(seconds=700),  # reset_stale_locks cutoff calc
+            base + timedelta(seconds=700),  # reset_stale_locks: patch updated_at (before CAS fails)
+        ]
+    )
     monkeypatch.setattr(store, "_now", lambda: next(timestamps))
 
     t1 = store.create()
@@ -925,10 +929,12 @@ def test_reset_stale_locks_idle_threads_not_touched(monkeypatch: Any) -> None:
     """Idle threads are not affected by reset_stale_locks."""
     store, _ = _new_store()
     base = datetime(2026, 1, 1, tzinfo=timezone.utc)
-    timestamps = iter([
-        base,                           # create
-        base + timedelta(seconds=700),  # reset cutoff
-    ])
+    timestamps = iter(
+        [
+            base,  # create
+            base + timedelta(seconds=700),  # reset cutoff
+        ]
+    )
     monkeypatch.setattr(store, "_now", lambda: next(timestamps))
 
     t1 = store.create()  # idle status, old timestamp
@@ -962,12 +968,14 @@ def test_reset_stale_locks_status_idle(monkeypatch: Any) -> None:
     """reset_stale_locks with status='idle' sets thread to idle."""
     store, _ = _new_store()
     base = datetime(2026, 1, 1, tzinfo=timezone.utc)
-    timestamps = iter([
-        base,                           # create
-        base + timedelta(seconds=10),   # acquire
-        base + timedelta(seconds=700),  # reset cutoff
-        base + timedelta(seconds=700),  # patch updated_at
-    ])
+    timestamps = iter(
+        [
+            base,  # create
+            base + timedelta(seconds=10),  # acquire
+            base + timedelta(seconds=700),  # reset cutoff
+            base + timedelta(seconds=700),  # patch updated_at
+        ]
+    )
     monkeypatch.setattr(store, "_now", lambda: next(timestamps))
 
     t1 = store.create()
@@ -983,11 +991,13 @@ def test_reset_stale_locks_zero_threshold(monkeypatch: Any) -> None:
     """older_than_seconds=0 resets any busy thread (cutoff == now)."""
     store, _ = _new_store()
     base = datetime(2026, 1, 1, tzinfo=timezone.utc)
-    timestamps = iter([
-        base,                           # create
-        base + timedelta(seconds=10),   # acquire: sets updated_at=10
-        base + timedelta(seconds=10),   # reset: cutoff=10-0=10, updated_at=10 >= 10
-    ])
+    timestamps = iter(
+        [
+            base,  # create
+            base + timedelta(seconds=10),  # acquire: sets updated_at=10
+            base + timedelta(seconds=10),  # reset: cutoff=10-0=10, updated_at=10 >= 10
+        ]
+    )
     monkeypatch.setattr(store, "_now", lambda: next(timestamps))
 
     t1 = store.create()
@@ -1003,12 +1013,14 @@ def test_reset_stale_locks_deleted_thread_skipped(monkeypatch: Any) -> None:
     """Thread deleted between query and update is skipped, not raised."""
     store, table_client = _new_store()
     base = datetime(2026, 1, 1, tzinfo=timezone.utc)
-    timestamps = iter([
-        base,                           # create
-        base + timedelta(seconds=10),   # acquire
-        base + timedelta(seconds=700),  # reset cutoff
-        base + timedelta(seconds=700),  # patch updated_at
-    ])
+    timestamps = iter(
+        [
+            base,  # create
+            base + timedelta(seconds=10),  # acquire
+            base + timedelta(seconds=700),  # reset cutoff
+            base + timedelta(seconds=700),  # patch updated_at
+        ]
+    )
     monkeypatch.setattr(store, "_now", lambda: next(timestamps))
 
     t1 = store.create()


### PR DESCRIPTION
## Summary

- Fixes langgraph_checkpoint_cosmos → langgraph_checkpoint_cosmosdb (correct PyPI package)
- Uses direct instantiation via env vars instead of buggy upstream from_conn_info
- Removes Python 3.11+ requirement — works on 3.10+
- Adds key= parameter (preferred), deprecates credential= (string back-compat preserved)
- Adds COSMOS_KEY env var fallback when no key is explicitly provided

## Testing

- 4 integration tests pass against live Cosmos DB emulator
- 805 unit tests pass, 92.49% coverage
- mypy and ruff clean