### PR TITLE
fix(handlers): harden native endpoints — configurable type guard, lock cleanup, route normalization

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,8 +87,9 @@ test: ensure-hatch
 
 .PHONY: test-cosmos
 test-cosmos: ensure-hatch
-	docker compose -f docker-compose.cosmos.yml up -d --wait && \
-	trap 'docker compose -f docker-compose.cosmos.yml down' EXIT && \
+	@set -e; \
+	trap 'docker compose -f docker-compose.cosmos.yml down' EXIT; \
+	docker compose -f docker-compose.cosmos.yml up -d --wait; \
 	COSMOS_EMULATOR_ENDPOINT=https://localhost:8081 $(HATCH) run cosmos:test
 
 .PHONY: cov

--- a/README.md
+++ b/README.md
@@ -213,6 +213,11 @@ from azure_functions_langgraph import LangGraphApp
 app = LangGraphApp(auth_level=func.AuthLevel.FUNCTION)
 ```
 
+> **Note:** `health_auth_level` defaults to `ANONYMOUS` independently of `auth_level`.
+> This means the health endpoint remains publicly accessible even when `auth_level=FUNCTION`.
+> Set `health_auth_level=func.AuthLevel.FUNCTION` explicitly if the health endpoint should
+> also require a function key.
+
 ### Streaming behavior
 
 > **Important:** All `/stream` endpoints (both the native `POST /api/graphs/{name}/stream`
@@ -503,6 +508,13 @@ count = thread_store.reset_stale_locks(older_than_seconds=600)
 ```
 
 Each reset uses ETag CAS so a thread that has been legitimately re-acquired since the scan is never stomped. Choose `older_than_seconds` comfortably above your longest expected graph execution time — ETag CAS protects against re-acquire races, but a still-running long job will not update its `updated_at` and could be reclaimed if the threshold is too short. See [`examples/maintenance_timer/`](examples/maintenance_timer/) for a complete Timer Trigger wiring.
+
+#### Native endpoint thread locking
+
+Native invoke/stream endpoints (`POST /api/graphs/{name}/invoke` and `.../stream`) use an **in-process per-thread lock** when the graph has a checkpointer and the request includes `config.configurable.thread_id`. This prevents concurrent writes to single-writer checkpointers (e.g. `AzureBlobCheckpointSaver`) within the same Python worker process.
+
+> **Important:** This is **not** a distributed lock. It does not coordinate across multiple Function App instances, worker processes, or hosts. For distributed run locking, use Platform-compatible runs (`platform_compat=True`) with `AzureTableThreadStore`, which provides ETag-based atomic locking.
+
 
 ### Upgrading
 

--- a/examples/cosmos_checkpoint_azure/function_app.py
+++ b/examples/cosmos_checkpoint_azure/function_app.py
@@ -20,6 +20,8 @@ compiled_graph = build_graph().compile(checkpointer=checkpointer)
 langgraph_app = LangGraphApp(
     platform_compat=True,
     auth_level=func.AuthLevel.FUNCTION,
+    # Explicitly protect health endpoint in production; defaults to ANONYMOUS
+    health_auth_level=func.AuthLevel.FUNCTION,
 )
 
 langgraph_app.register(

--- a/examples/managed_identity_storage/function_app.py
+++ b/examples/managed_identity_storage/function_app.py
@@ -108,6 +108,8 @@ compiled_graph = build_graph().compile(checkpointer=checkpointer)
 langgraph_app = LangGraphApp(
     platform_compat=True,
     auth_level=func.AuthLevel.FUNCTION,
+    # Explicitly protect health endpoint in production; defaults to ANONYMOUS
+    health_auth_level=func.AuthLevel.FUNCTION,
 )
 langgraph_app.thread_store = thread_store
 langgraph_app.register(

--- a/examples/persistent_agent_blob_table/function_app.py
+++ b/examples/persistent_agent_blob_table/function_app.py
@@ -29,6 +29,7 @@ compiled_graph = build_graph().compile(checkpointer=checkpointer)
 
 langgraph_app = LangGraphApp(
     platform_compat=True,
+    # Local dev: ANONYMOUS; use FUNCTION + health_auth_level=FUNCTION in production
     auth_level=func.AuthLevel.ANONYMOUS,
 )
 langgraph_app.thread_store = thread_store

--- a/examples/postgres_checkpoint_production/function_app.py
+++ b/examples/postgres_checkpoint_production/function_app.py
@@ -18,6 +18,8 @@ compiled_graph = build_graph().compile(checkpointer=checkpointer)
 langgraph_app = LangGraphApp(
     platform_compat=True,
     auth_level=func.AuthLevel.FUNCTION,
+    # Explicitly protect health endpoint in production; defaults to ANONYMOUS
+    health_auth_level=func.AuthLevel.FUNCTION,
 )
 langgraph_app.register(
     graph=compiled_graph,

--- a/examples/production_auth/README.md
+++ b/examples/production_auth/README.md
@@ -4,15 +4,15 @@ Demonstrates the per-graph `auth_level` override pattern: a public, anonymous he
 
 ## Auth model
 
-The app uses `auth_level=AuthLevel.ANONYMOUS` (so `GET /api/health` is reachable without a key), and **overrides per registration**:
+The app uses `auth_level=AuthLevel.FUNCTION` as the default (so all endpoints require a function key), with `health_auth_level=AuthLevel.FUNCTION` to also protect the health endpoint. Individual graphs **override** the default:
 
 | Endpoint | Auth | Why |
 | --- | --- | --- |
-| `GET /api/health` | ANONYMOUS | Liveness probe / public discovery |
+| `GET /api/health` | FUNCTION | Protected; set `health_auth_level=ANONYMOUS` to expose |
 | `POST /api/graphs/public_agent/{invoke,stream}` | ANONYMOUS | Demo / public surface |
 | `POST /api/graphs/private_agent/{invoke,stream}` | FUNCTION | Requires `?code=<FUNCTION_KEY>` |
 
-> **Production tip:** flip the defaults if your service is mostly private. Set `LangGraphApp(auth_level=FUNCTION)` and register only the explicitly public graphs with `auth_level=ANONYMOUS`. Note that the `/api/health` endpoint inherits the app-level auth — protect or expose it accordingly.
+> **Tip:** For a public health endpoint, omit `health_auth_level` (defaults to `ANONYMOUS`). For a mostly-public service, set `LangGraphApp(auth_level=ANONYMOUS)` and protect only specific graphs with `auth_level=FUNCTION`.
 
 ## Files
 
@@ -35,9 +35,10 @@ func start
 ## Verify
 
 ```bash
-# Anonymous: works without a key
-curl -s http://localhost:7071/api/health
+# Health: requires a key (health_auth_level=FUNCTION)
+curl -s "http://localhost:7071/api/health?code=$FUNCTION_KEY"
 
+# Public agent: works without a key (per-graph ANONYMOUS override)
 curl -s -X POST http://localhost:7071/api/graphs/public_agent/invoke \
   -H "Content-Type: application/json" \
   -d '{"input":{"messages":[{"role":"human","content":"hi"}]}}'

--- a/examples/production_auth/function_app.py
+++ b/examples/production_auth/function_app.py
@@ -4,7 +4,12 @@ import azure.functions as func
 
 from azure_functions_langgraph import LangGraphApp
 
-langgraph_app = LangGraphApp(auth_level=func.AuthLevel.ANONYMOUS)
+# Production: default to FUNCTION; override per-graph as needed
+langgraph_app = LangGraphApp(
+    auth_level=func.AuthLevel.FUNCTION,
+    # Explicitly protect health endpoint in production; defaults to ANONYMOUS
+    health_auth_level=func.AuthLevel.FUNCTION,
+)
 
 langgraph_app.register(
     graph=private_graph,

--- a/examples/production_auth/verify.sh
+++ b/examples/production_auth/verify.sh
@@ -4,8 +4,13 @@ set -euo pipefail
 BASE="${BASE:-http://localhost:7071/api}"
 KEY="${FUNCTION_KEY:-}"
 
-echo "== anonymous health =="
-curl -fsS "$BASE/health" && echo
+echo "== health (requires key) =="
+if [[ -n "$KEY" ]]; then
+  curl -fsS "$BASE/health?code=$KEY" && echo
+else
+  status=$(curl -s -o /dev/null -w '%{http_code}' "$BASE/health")
+  echo "  HTTP $status (set FUNCTION_KEY to get 200)"
+fi
 
 echo "== anonymous public_agent =="
 curl -fsS -X POST "$BASE/graphs/public_agent/invoke" \

--- a/src/azure_functions_langgraph/_handlers.py
+++ b/src/azure_functions_langgraph/_handlers.py
@@ -80,7 +80,7 @@ def _acquire_thread_lock(graph_name: str, thread_id: str) -> bool:
     """Try to acquire a per-thread lock. Returns False if already held."""
     with _thread_locks_guard:
         lock = _thread_locks.setdefault((graph_name, thread_id), threading.Lock())
-    return lock.acquire(blocking=False)
+        return lock.acquire(blocking=False)
 
 
 def _release_thread_lock(graph_name: str, thread_id: str) -> None:

--- a/src/azure_functions_langgraph/_handlers.py
+++ b/src/azure_functions_langgraph/_handlers.py
@@ -37,6 +37,24 @@ logger = logging.getLogger(__name__)
 # Shared helper
 # ------------------------------------------------------------------
 
+def _extract_thread_id(config: dict[str, Any]) -> tuple[str | None, str | None]:
+    """Extract thread_id from config, returning (thread_id, error_message).
+
+    Returns ``(None, None)`` when configurable is absent or has no thread_id.
+    Returns ``(None, error_msg)`` when configurable or thread_id has a wrong type.
+    """
+    configurable = config.get("configurable")
+    if configurable is None:
+        return None, None
+    if not isinstance(configurable, dict):
+        return None, "config.configurable must be an object"
+    thread_id = configurable.get("thread_id")
+    if thread_id is None:
+        return None, None
+    if not isinstance(thread_id, str):
+        return None, "config.configurable.thread_id must be a string"
+    return thread_id, None
+
 
 def _error_response(status_code: int, detail: str) -> func.HttpResponse:
     body = ErrorResponse(error="error", detail=detail)
@@ -48,7 +66,12 @@ def _error_response(status_code: int, detail: str) -> func.HttpResponse:
 
 
 # Per-thread in-memory locks for native endpoints with checkpointed graphs.
-# Keyed by (graph_name, thread_id). Protects single-writer checkpointers.
+# Keyed by (graph_name, thread_id). Protects single-writer checkpointers
+# (e.g. AzureBlobCheckpointSaver) from concurrent writes within the SAME
+# Python worker process only.  This is NOT a distributed lock — multiple
+# Function App instances or worker processes are not coordinated.
+# For distributed run locking, use Platform-compatible runs with
+# AzureTableThreadStore (ETag CAS).
 _thread_locks: dict[tuple[str, str], threading.Lock] = {}
 _thread_locks_guard = threading.Lock()
 
@@ -61,11 +84,20 @@ def _acquire_thread_lock(graph_name: str, thread_id: str) -> bool:
 
 
 def _release_thread_lock(graph_name: str, thread_id: str) -> None:
-    """Release a per-thread lock."""
+    """Release a per-thread lock and remove it from the dict if unused."""
+    key = (graph_name, thread_id)
     with _thread_locks_guard:
-        lock = _thread_locks.get((graph_name, thread_id))
-    if lock is not None:
-        lock.release()
+        lock = _thread_locks.get(key)
+    if lock is None:
+        return
+    lock.release()
+    # Clean up to prevent unbounded growth in long-lived workers.
+    # Re-check under guard: only remove if the lock is not currently held
+    # (another request may have acquired it between release and this check).
+    with _thread_locks_guard:
+        current = _thread_locks.get(key)
+        if current is lock and not lock.locked():
+            _thread_locks.pop(key, None)
 
 
 def _serialize_graph_output(result: Any) -> dict[str, Any]:
@@ -150,7 +182,9 @@ def handle_invoke(
             return _error_response(400, config_err)
 
     config = request.config or {}
-    thread_id = config.get("configurable", {}).get("thread_id")
+    thread_id, cfg_err = _extract_thread_id(config)
+    if cfg_err:
+        return _error_response(400, cfg_err)
     has_cp = getattr(reg.graph, "checkpointer", None) is not None
     locked = False
     if has_cp and thread_id:
@@ -166,7 +200,7 @@ def handle_invoke(
         _ = exc
         return _error_response(500, "Graph execution failed")
     finally:
-        if locked:
+        if locked and thread_id is not None:
             _release_thread_lock(reg.name, thread_id)
 
     output = _serialize_graph_output(result)
@@ -239,7 +273,9 @@ def handle_stream(
             return _error_response(400, config_err)
 
     config = request.config or {}
-    thread_id = config.get("configurable", {}).get("thread_id")
+    thread_id, cfg_err = _extract_thread_id(config)
+    if cfg_err:
+        return _error_response(400, cfg_err)
     has_cp = getattr(reg.graph, "checkpointer", None) is not None
     locked = False
     if has_cp and thread_id:
@@ -289,7 +325,7 @@ def handle_stream(
         error_payload = json.dumps({"error": "stream processing failed"})
         _append_chunk(f"event: error\ndata: {error_payload}\n\n")
     finally:
-        if locked:
+        if locked and thread_id is not None:
             _release_thread_lock(reg.name, thread_id)
 
     _append_chunk("event: end\ndata: {}\n\n")

--- a/src/azure_functions_langgraph/_handlers.py
+++ b/src/azure_functions_langgraph/_handlers.py
@@ -53,6 +53,9 @@ def _extract_thread_id(config: dict[str, Any]) -> tuple[str | None, str | None]:
         return None, None
     if not isinstance(thread_id, str):
         return None, "config.configurable.thread_id must be a string"
+    tid_err = validate_thread_id(thread_id)
+    if tid_err:
+        return None, tid_err
     return thread_id, None
 
 

--- a/src/azure_functions_langgraph/app.py
+++ b/src/azure_functions_langgraph/app.py
@@ -127,6 +127,10 @@ class LangGraphApp:
                 "  See the 'Production authentication' section in README.md\n"
                 "Note: The default will change from ANONYMOUS to FUNCTION in v1.0."
             )
+        # Normalize route_prefix: ensure leading slash, strip trailing slashes
+        if not self.route_prefix.startswith("/"):
+            self.route_prefix = "/" + self.route_prefix
+        self.route_prefix = self.route_prefix.rstrip("/") or "/"
         if self.platform_compat and self._thread_store is None:
             from azure_functions_langgraph.platform.stores import InMemoryThreadStore
 

--- a/src/azure_functions_langgraph/app.py
+++ b/src/azure_functions_langgraph/app.py
@@ -335,6 +335,12 @@ class LangGraphApp:
             return reg.auth_level
         return self.auth_level
 
+    def _metadata_path(self, route: str) -> str:
+        """Join route_prefix and route, avoiding double slashes."""
+        if self.route_prefix == "/":
+            return f"/{route}"
+        return f"{self.route_prefix}/{route}"
+
     # ------------------------------------------------------------------
     # Request handlers (thin delegation to _handlers module)
     # ------------------------------------------------------------------
@@ -388,7 +394,7 @@ class LangGraphApp:
             # invoke route
             routes.append(
                 RouteMetadata(
-                    path=f"{self.route_prefix}/{_ROUTE_INVOKE.format(name=reg.name)}",
+                    path=self._metadata_path(_ROUTE_INVOKE.format(name=reg.name)),
                     method="POST",
                     summary=f"Invoke graph '{reg.name}'",
                     request_model=reg.request_model,
@@ -399,7 +405,7 @@ class LangGraphApp:
             if reg.stream_enabled:
                 routes.append(
                     RouteMetadata(
-                        path=f"{self.route_prefix}/{_ROUTE_STREAM.format(name=reg.name)}",
+                        path=self._metadata_path(_ROUTE_STREAM.format(name=reg.name)),
                         method="POST",
                         summary=f"Stream graph '{reg.name}'",
                         request_model=reg.request_model,
@@ -410,7 +416,7 @@ class LangGraphApp:
             if isinstance(reg.graph, StatefulGraph):
                 routes.append(
                     RouteMetadata(
-                        path=f"{self.route_prefix}/{_ROUTE_STATE.format(name=reg.name)}",
+                        path=self._metadata_path(_ROUTE_STATE.format(name=reg.name)),
                         method="GET",
                         summary=f"Get thread state for '{reg.name}'",
                         parameters=(
@@ -434,7 +440,7 @@ class LangGraphApp:
         # App-level routes
         app_routes: tuple[RouteMetadata, ...] = (
             RouteMetadata(
-                path=f"{self.route_prefix}/{_ROUTE_HEALTH}",
+                path=self._metadata_path(_ROUTE_HEALTH),
                 method="GET",
                 summary="Health check",
             ),

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1068,3 +1068,115 @@ class TestNativeEndpointThreadLock:
         req = self._make_request({"input": {"msg": "hi"}})
         resp = app._handle_invoke(req, app._registrations["agent"])
         assert resp.status_code == 200
+
+
+class TestExtractThreadId:
+    """Tests for _extract_thread_id helper."""
+
+    def test_no_configurable(self) -> None:
+        from azure_functions_langgraph._handlers import _extract_thread_id
+        tid, err = _extract_thread_id({})
+        assert tid is None
+        assert err is None
+
+    def test_configurable_none(self) -> None:
+        from azure_functions_langgraph._handlers import _extract_thread_id
+        tid, err = _extract_thread_id({"configurable": None})
+        assert tid is None
+        assert err is None
+
+    def test_configurable_not_dict(self) -> None:
+        from azure_functions_langgraph._handlers import _extract_thread_id
+        tid, err = _extract_thread_id({"configurable": "bad-value"})
+        assert tid is None
+        assert err is not None
+        assert "must be an object" in err
+
+    def test_configurable_no_thread_id(self) -> None:
+        from azure_functions_langgraph._handlers import _extract_thread_id
+        tid, err = _extract_thread_id({"configurable": {"model": "gpt-4"}})
+        assert tid is None
+        assert err is None
+
+    def test_thread_id_not_string(self) -> None:
+        from azure_functions_langgraph._handlers import _extract_thread_id
+        tid, err = _extract_thread_id({"configurable": {"thread_id": 123}})
+        assert tid is None
+        assert err is not None
+        assert "must be a string" in err
+
+    def test_valid_thread_id(self) -> None:
+        from azure_functions_langgraph._handlers import _extract_thread_id
+        tid, err = _extract_thread_id({"configurable": {"thread_id": "t1"}})
+        assert tid == "t1"
+        assert err is None
+
+
+class TestMalformedConfigReturns400:
+    """Malformed config.configurable returns 400 on invoke/stream."""
+
+    def _make_request(self, body: dict[str, Any]) -> func.HttpRequest:
+        return func.HttpRequest(
+            method="POST",
+            body=json.dumps(body).encode(),
+            url="/api/graphs/agent/invoke",
+            headers={"Content-Type": "application/json"},
+        )
+
+    def _make_graph_and_app(self) -> LangGraphApp:
+        class CheckpointedGraph:
+            checkpointer = object()
+
+            def invoke(self, input: dict[str, Any], config: Any = None) -> dict[str, Any]:
+                return {"result": "ok"}
+
+            def stream(
+                self, input: Any, config: Any = None, stream_mode: str = "values",
+            ) -> list[Any]:
+                return []
+
+        app = LangGraphApp()
+        app.register(graph=CheckpointedGraph(), name="agent")
+        return app
+
+    def test_invoke_configurable_not_dict_returns_400(self) -> None:
+        app = self._make_graph_and_app()
+        req = self._make_request({"input": {"msg": "hi"}, "config": {"configurable": "bad"}})
+        resp = app._handle_invoke(req, app._registrations["agent"])
+        assert resp.status_code == 400
+        assert "must be an object" in json.loads(resp.get_body())["detail"]
+
+    def test_invoke_thread_id_not_string_returns_400(self) -> None:
+        app = self._make_graph_and_app()
+        body = {"input": {"msg": "hi"}, "config": {"configurable": {"thread_id": 42}}}
+        req = self._make_request(body)
+        resp = app._handle_invoke(req, app._registrations["agent"])
+        assert resp.status_code == 400
+        assert "must be a string" in json.loads(resp.get_body())["detail"]
+
+    def test_stream_configurable_not_dict_returns_400(self) -> None:
+        app = self._make_graph_and_app()
+        req = self._make_request({"input": {"msg": "hi"}, "config": {"configurable": "bad"}})
+        resp = app._handle_stream(req, app._registrations["agent"])
+        assert resp.status_code == 400
+        assert "must be an object" in json.loads(resp.get_body())["detail"]
+
+
+class TestRouteNormalization:
+    """route_prefix is normalized in __post_init__."""
+
+    def test_no_leading_slash(self) -> None:
+        app = LangGraphApp(route_prefix="api")
+        assert app.route_prefix == "/api"
+
+    def test_trailing_slash_stripped(self) -> None:
+        app = LangGraphApp(route_prefix="/api/")
+        assert app.route_prefix == "/api"
+
+    def test_double_slash_stripped(self) -> None:
+        app = LangGraphApp(route_prefix="/api//")
+        assert app.route_prefix == "/api"
+
+    def test_root_prefix(self) -> None:
+        app = LangGraphApp(route_prefix="/")
+        assert app.route_prefix == "/"

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1069,6 +1069,31 @@ class TestNativeEndpointThreadLock:
         resp = app._handle_invoke(req, app._registrations["agent"])
         assert resp.status_code == 200
 
+    def test_lock_cleanup_after_release(self) -> None:
+        """Lock entry is removed from dict after release."""
+        from azure_functions_langgraph._handlers import (
+            _acquire_thread_lock,
+            _release_thread_lock,
+            _thread_locks,
+        )
+
+        key = ("cleanup_test", "t-cleanup")
+        assert _acquire_thread_lock(*key) is True
+        assert key in _thread_locks
+        _release_thread_lock(*key)
+        assert key not in _thread_locks
+
+    def test_lock_reacquire_after_release(self) -> None:
+        """Lock can be reacquired after release."""
+        from azure_functions_langgraph._handlers import (
+            _acquire_thread_lock,
+            _release_thread_lock,
+        )
+
+        assert _acquire_thread_lock("reacq", "t1") is True
+        _release_thread_lock("reacq", "t1")
+        assert _acquire_thread_lock("reacq", "t1") is True
+        _release_thread_lock("reacq", "t1")
 
 class TestExtractThreadId:
     """Tests for _extract_thread_id helper."""
@@ -1180,3 +1205,14 @@ class TestRouteNormalization:
     def test_root_prefix(self) -> None:
         app = LangGraphApp(route_prefix="/")
         assert app.route_prefix == "/"
+
+    def test_root_prefix_metadata_no_double_slash(self) -> None:
+        """route_prefix='/' should produce /graphs/... not //graphs/..."""
+        app = LangGraphApp(route_prefix="/")
+        app.register(graph=FakeCompiledGraph(), name="agent")
+        metadata = app.get_app_metadata()
+        invoke_path = metadata.graphs["agent"].routes[0].path
+        assert invoke_path == "/graphs/agent/invoke"
+        assert not invoke_path.startswith("//")
+        health_path = metadata.app_routes[0].path
+        assert health_path == "/health"

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1136,6 +1136,13 @@ class TestExtractThreadId:
         assert tid == "t1"
         assert err is None
 
+    def test_empty_thread_id(self) -> None:
+        from azure_functions_langgraph._handlers import _extract_thread_id
+        tid, err = _extract_thread_id({"configurable": {"thread_id": ""}})
+        assert tid is None
+        assert err is not None
+        assert "must not be empty" in err
+
 
 class TestMalformedConfigReturns400:
     """Malformed config.configurable returns 400 on invoke/stream."""


### PR DESCRIPTION
## Summary
- **P0**: Add `_extract_thread_id()` helper that validates `config.configurable` is a dict and `thread_id` is a string, returning 400 on malformed input instead of crashing with `AttributeError` (#195)
- **P1**: Clean up `_thread_locks` dict after lock release to prevent unbounded memory growth in long-lived workers; document that native endpoint locking is in-process only (not distributed) in code comments and README (#196)
- **P2**: Fix Makefile `test-cosmos` trap ordering for partial-start cleanup; normalize `route_prefix` in `__post_init__`; document `health_auth_level` ANONYMOUS default in README (#197)

## Verification
- 865 tests passed, 9 skipped (Cosmos/Table integration — no emulator)
- Coverage: 95.13% (≥ 95% threshold)
- Lint: clean
- Typecheck: clean

Closes #195, closes #196, closes #197