### PR TITLE
ci(table): Azurite-backed integration tests + route_prefix docstring

### DIFF
--- a/.github/workflows/ci-table-integration.yml
+++ b/.github/workflows/ci-table-integration.yml
@@ -1,0 +1,43 @@
+name: Table Integration
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  table-integration:
+    runs-on: ubuntu-latest
+    services:
+      azurite:
+        image: mcr.microsoft.com/azure-storage/azurite
+        ports:
+          - 10000:10000
+          - 10001:10001
+          - 10002:10002
+        options: >-
+          --health-cmd "nc -z 127.0.0.1 10002 || exit 1"
+          --health-interval 5s
+          --health-timeout 3s
+          --health-retries 20
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev,azure-table]"
+
+      - name: Run table integration tests
+        run: pytest -v -m integration tests/integration/test_table_store_integration.py --no-cov

--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,14 @@ test-cosmos: ensure-hatch
 	@set -e; \
 	trap 'docker compose -f docker-compose.cosmos.yml down' EXIT; \
 	docker compose -f docker-compose.cosmos.yml up -d --wait; \
-	COSMOS_EMULATOR_ENDPOINT=https://localhost:8081 $(HATCH) run cosmos:test
+	COSMOS_EMULATOR_ENDPOINT=https://localhost:8081 COSMOS_DISABLE_SSL=true $(HATCH) run cosmos:test
+
+.PHONY: test-table
+test-table: ensure-hatch
+	@set -e; \
+	trap 'docker compose -f docker-compose.azurite.yml down' EXIT; \
+	docker compose -f docker-compose.azurite.yml up -d --wait; \
+	$(HATCH) run table:test
 
 .PHONY: cov
 cov: ensure-hatch

--- a/docker-compose.azurite.yml
+++ b/docker-compose.azurite.yml
@@ -1,0 +1,13 @@
+services:
+  azurite:
+    image: mcr.microsoft.com/azure-storage/azurite
+    command: "azurite --blobHost 0.0.0.0 --queueHost 0.0.0.0 --tableHost 0.0.0.0 --skipApiVersionCheck"
+    ports:
+      - "10000:10000"
+      - "10001:10001"
+      - "10002:10002"
+    healthcheck:
+      test: ["CMD-SHELL", "nc -z 127.0.0.1 10002 || exit 1"]
+      interval: 5s
+      timeout: 3s
+      retries: 20

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,6 +122,13 @@ features = ["dev", "cosmos"]
 [tool.hatch.envs.cosmos.scripts]
 test = "pytest -v -m integration tests/integration/ --no-cov"
 
+[tool.hatch.envs.table]
+python = "3.10"
+features = ["dev", "azure-table"]
+
+[tool.hatch.envs.table.scripts]
+test = "pytest -v -m integration tests/integration/test_table_store_integration.py --no-cov"
+
 [tool.ruff]
 line-length = 100
 target-version = "py310"

--- a/src/azure_functions_langgraph/_handlers.py
+++ b/src/azure_functions_langgraph/_handlers.py
@@ -120,15 +120,15 @@ def _serialize_graph_output(result: Any) -> dict[str, Any]:
     if callable(model_dump):
         try:
             return model_dump(mode="json")  # type: ignore[no-any-return]
-        except Exception:
-            pass
+        except Exception as exc:  # pragma: no cover - defensive fallback
+            logger.debug("model_dump failed: %s", exc)
 
     # dataclass
     if dataclasses.is_dataclass(result) and not isinstance(result, type):
         try:
             return dataclasses.asdict(result)
-        except Exception:
-            pass
+        except Exception as exc:  # pragma: no cover - defensive fallback
+            logger.debug("dataclasses.asdict failed: %s", exc)
 
     # Fallback
     logger.warning(

--- a/src/azure_functions_langgraph/app.py
+++ b/src/azure_functions_langgraph/app.py
@@ -385,8 +385,9 @@ class LangGraphApp:
         the ``azure-functions-openapi-python`` bridge use this to generate specs.
 
         Note:
-            Route paths use the default Azure Functions ``/api`` prefix.
             Route paths use the configured ``route_prefix`` (default ``/api``).
+            This metadata-only prefix should match the Azure Functions
+            ``host.json`` ``routePrefix`` setting.
         """
         graphs: dict[str, RegisteredGraphMetadata] = {}
         for reg in self._registrations.values():

--- a/tests/integration/test_table_store_integration.py
+++ b/tests/integration/test_table_store_integration.py
@@ -65,11 +65,8 @@ def azurite_table_client() -> Iterator[_TableClientProtocol]:
             pass
 
 
-def _new_store(table_name: str) -> AzureTableThreadStore:
-    return AzureTableThreadStore.from_connection_string(
-        connection_string=AZURITE_TABLE_CONNECTION_STRING,
-        table_name=table_name,
-    )
+def _new_store(table_client: _TableClientProtocol) -> AzureTableThreadStore:
+    return AzureTableThreadStore.from_table_client(cast(Any, table_client))
 
 
 def _set_updated_at(
@@ -90,7 +87,7 @@ def _set_updated_at(
 def test_reset_stale_locks_resets_stale_and_skips_fresh(
     azurite_table_client: _TableClientProtocol,
 ) -> None:
-    store = _new_store(azurite_table_client.table_name)
+    store = _new_store(azurite_table_client)
 
     stale = store.create(metadata={"kind": "stale"})
     fresh = store.create(metadata={"kind": "fresh"})
@@ -116,7 +113,7 @@ def test_reset_stale_locks_uses_projection_rowkey_and_updated_at(
     azurite_table_client: _TableClientProtocol,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    store = _new_store(azurite_table_client.table_name)
+    store = _new_store(azurite_table_client)
     thread = store.create()
     _ = store.try_acquire_run_lock(thread.thread_id)
     _set_updated_at(
@@ -144,7 +141,7 @@ def test_reset_stale_locks_etag_cas_conflict_does_not_stomp(
     azurite_table_client: _TableClientProtocol,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    store = _new_store(azurite_table_client.table_name)
+    store = _new_store(azurite_table_client)
     thread = store.create()
     _ = store.try_acquire_run_lock(thread.thread_id)
     _set_updated_at(
@@ -195,7 +192,7 @@ def test_reset_stale_locks_delete_race_is_skipped(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """If a thread is deleted between query and CAS update, skip gracefully."""
-    store = _new_store(azurite_table_client.table_name)
+    store = _new_store(azurite_table_client)
     thread = store.create()
     _ = store.try_acquire_run_lock(thread.thread_id)
     _set_updated_at(


### PR DESCRIPTION
## Summary
- Add Azurite docker-compose service, hatch \`[table]\` env, \`make test-table\` target, and \`ci-table-integration\` workflow so AzureTableThreadStore integration tests (projection+ETag, stale lock reset, ETag mismatch skip, delete race skip) run in CI.
- Fix \`_new_store\` in \`tests/integration/test_table_store_integration.py\` to use the injected fixture via \`AzureTableThreadStore.from_table_client\` so monkeypatching actually applies.
- Clarify \`get_app_metadata()\` docstring: \`route_prefix\` is configurable (default \`/api\`) and should match \`host.json\` \`routePrefix\`.
- Set \`COSMOS_DISABLE_SSL=true\` on \`make test-cosmos\` for emulator stability.

## Validation
- \`make lint\` ✅
- \`make typecheck\` ✅
- \`make test\` ✅ 869 passed, 9 skipped, coverage 95.15%
- \`make build\` ✅
- \`make test-table\` ✅ 4/4 against Azurite

## Notes
Real-Azure verification skipped (no creds available); Azurite-only per scope.