### PR TITLE
test(stores): assert projection query returns usable ETag against Azurite

### DIFF
--- a/tests/integration/test_table_store_integration.py
+++ b/tests/integration/test_table_store_integration.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Iterable, Iterator
+from collections.abc import Iterable, Iterator, Mapping
 from datetime import datetime, timedelta, timezone
 import importlib
 from typing import Any, Protocol, cast
@@ -240,3 +240,43 @@ def test_reset_stale_locks_delete_race_is_skipped(
     assert reset_count == 0
     # Thread no longer exists
     assert store.get(thread.thread_id) is None
+
+
+def test_reset_stale_locks_projection_returns_usable_etag(
+    azurite_table_client: _TableClientProtocol,
+) -> None:
+    """Projected query used by reset_stale_locks must expose a usable ETag.
+
+    The Azure Tables SDK may surface the ETag either via
+    ``entity.metadata["etag"]`` or as a top-level ``entity["etag"]`` key
+    depending on the SDK version. ``reset_stale_locks`` accepts either
+    shape, so this test asserts that at least one of them is populated
+    when querying with a projection (``select=...``) against Azurite.
+    """
+    store = _new_store(azurite_table_client)
+    thread = store.create()
+    acquired = store.try_acquire_run_lock(thread.thread_id)
+    assert acquired is not None, "expected to acquire run lock on fresh thread"
+
+    entities = list(
+        cast(
+            Iterable[object],
+            azurite_table_client.query_entities(
+                query_filter="PartitionKey eq 'thread' and status eq 'busy'",
+                select=["RowKey", "updated_at"],
+            ),
+        )
+    )
+    assert entities, "projected query should return the busy thread"
+
+    entity = entities[0]
+    metadata = getattr(entity, "metadata", None)
+    etag: object = None
+    if isinstance(metadata, Mapping):
+        etag = metadata.get("etag")
+    if etag is None and isinstance(entity, Mapping):
+        etag = entity.get("etag")
+    assert etag, (
+        "projected query result must expose a usable ETag via "
+        "entity.metadata['etag'] or entity['etag']"
+    )


### PR DESCRIPTION
## Context

Closes #200.

`AzureTableThreadStore.reset_stale_locks` uses a projected query
(`select=["RowKey", "updated_at"]`) and accepts the ETag via either
`entity.metadata["etag"]` or a top-level `entity["etag"]`, because the
Azure Tables SDK has surfaced the ETag in both shapes across versions.

There is no integration coverage today that proves Azurite actually
exposes a usable ETag through that projected query. If the SDK or
Azurite ever stopped populating both shapes, `reset_stale_locks` would
silently skip rows (it has a no-ETag → skip branch) and stale locks
would accumulate without a test failure.

## Change

Adds `test_reset_stale_locks_projection_returns_usable_etag` in
`tests/integration/test_table_store_integration.py` which:

- Creates a thread and acquires its run lock (busy state).
- Issues the same projected query `reset_stale_locks` issues.
- Asserts at least one of `entity.metadata["etag"]` or `entity["etag"]`
  is populated.

Per Oracle review, the assertion accepts either shape rather than
hard-asserting `metadata["etag"]`, matching what production code does.

## Acceptance Checklist

- [x] New test added under `tests/integration/`.
- [x] `make lint typecheck test` — 869 passed, 10 skipped, coverage 95.27%.
- [x] `make test-table` against Azurite — 5 passed (incl. new test).
- [x] `make build` — sdist + wheel produced.

## References

- #200
- `src/azure_functions_langgraph/stores/azure_table.py` (lines 579–645, `reset_stale_locks`)