### PR TITLE
docs(readme): translate health_auth_level ANONYMOUS-default warning into ko/ja/zh-CN

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -160,6 +160,11 @@ from azure_functions_langgraph import LangGraphApp
 app = LangGraphApp(auth_level=func.AuthLevel.FUNCTION)
 ```
 
+> **注記:** `health_auth_level` は `auth_level` とは独立してデフォルトが `ANONYMOUS` です。
+> このため、`auth_level=FUNCTION` を設定しても health エンドポイントは依然として公開されたままです。
+> health エンドポイントにも function key を要求したい場合は、`health_auth_level=func.AuthLevel.FUNCTION` を
+> 明示的に設定してください。
+
 ### ストリーミングの挙動
 
 > **重要:** すべての `/stream` エンドポイント（ネイティブ `POST /api/graphs/{name}/stream`、

--- a/README.ko.md
+++ b/README.ko.md
@@ -160,6 +160,11 @@ from azure_functions_langgraph import LangGraphApp
 app = LangGraphApp(auth_level=func.AuthLevel.FUNCTION)
 ```
 
+> **참고:** `health_auth_level`은 `auth_level`과 무관하게 기본값이 `ANONYMOUS`입니다.
+> 따라서 `auth_level=FUNCTION`으로 설정해도 health 엔드포인트는 여전히 공개적으로 접근 가능합니다.
+> health 엔드포인트에도 function key를 요구하려면 `health_auth_level=func.AuthLevel.FUNCTION`을
+> 명시적으로 설정하세요.
+
 ### 스트리밍 동작 방식
 
 > **중요:** 모든 `/stream` 엔드포인트(네이티브 `POST /api/graphs/{name}/stream`,

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -160,6 +160,11 @@ from azure_functions_langgraph import LangGraphApp
 app = LangGraphApp(auth_level=func.AuthLevel.FUNCTION)
 ```
 
+> **注意：** `health_auth_level` 默认为 `ANONYMOUS`，与 `auth_level` 独立。
+> 这意味着即使设置了 `auth_level=FUNCTION`，health 端点仍然是公开可访问的。
+> 如果希望 health 端点也要求 function key，请显式设置
+> `health_auth_level=func.AuthLevel.FUNCTION`。
+
 ### 流式传输行为
 
 > **重要：** 所有 `/stream` 端点（包括原生的 `POST /api/graphs/{name}/stream`，


### PR DESCRIPTION
## Context

Closes #201.

The English README has carried this warning since the production-auth
example was introduced:

> **Note:** `health_auth_level` defaults to `ANONYMOUS` independently of
> `auth_level`. This means the health endpoint remains publicly
> accessible even when `auth_level=FUNCTION`. Set
> `health_auth_level=func.AuthLevel.FUNCTION` explicitly if the health
> endpoint should also require a function key.

The Korean, Japanese, and Simplified-Chinese READMEs did not carry this
warning, so operators reading non-English docs could deploy with
`auth_level=FUNCTION` and unintentionally leave the health endpoint
publicly accessible.

## Change

Inserts the warning into the existing production-auth section of each
translation, in the same position as the English source (immediately
after the `LangGraphApp(auth_level=func.AuthLevel.FUNCTION)` example):

- `README.ko.md`
- `README.ja.md`
- `README.zh-CN.md`

Per Oracle review, the translations are semantically literal — same
three points (default is `ANONYMOUS`, behaviour under `auth_level=FUNCTION`,
explicit override) — rather than adding a new section.

## Acceptance Checklist

- [x] All three translations updated.
- [x] Warning inserted in existing production-auth section (no new section).
- [x] `make lint` passes.

## References

- #201
- `README.md` (lines 216-219)