### PR TITLE
ci(cosmos): move cosmos integration to scheduled + workflow_dispatch only

### DIFF
--- a/.github/workflows/ci-cosmos-integration.yml
+++ b/.github/workflows/ci-cosmos-integration.yml
@@ -1,10 +1,24 @@
 name: Cosmos Integration
 
+# Cosmos integration tests run against the Microsoft-published Linux Cosmos
+# emulator, which is known to be flaky on GitHub-hosted runners (see #202 and
+# upstream microsoft/azure-cosmos-emulator-docker issues). To keep PRs
+# unblocked while still exercising Cosmos coverage regularly, this workflow:
+#
+#   * does NOT run on push or pull_request,
+#   * runs nightly on a schedule (03:00 UTC),
+#   * can be triggered manually via workflow_dispatch.
+#
+# Ownership / monitoring: the repository maintainer (yeongseon) is responsible
+# for triaging nightly failures via the Actions tab. A red nightly run does
+# NOT block merges; persistent failures should be filed as a follow-up issue.
+# Local validation: contributors can run `make test-cosmos` against the
+# docker-compose emulator before merging Cosmos-touching changes.
+
 on:
-  pull_request:
-    types: [opened, synchronize, reopened]
-  push:
-    branches: [main]
+  schedule:
+    - cron: "0 3 * * *"
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -12,7 +26,8 @@ permissions:
 jobs:
   cosmos-integration:
     runs-on: ubuntu-latest
-    continue-on-error: true  # experimental: Cosmos Linux emulator can be flaky on GitHub-hosted runners
+    # Scheduled runs are non-gating; remove continue-on-error so genuine
+    # regressions surface clearly in the Actions tab nightly.
     services:
       cosmos-emulator:
         image: mcr.microsoft.com/cosmosdb/linux/azure-cosmos-emulator

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,6 +43,12 @@ make cov         # Run tests with coverage
 make check-all   # Run the full local gate
 ```
 
+Integration tests (Azurite, Cosmos) require docker-compose services. The
+Cosmos emulator is known-flaky on GitHub-hosted runners, so CI does not run
+it on push or pull_request: it runs nightly on a schedule and on manual
+`workflow_dispatch`. Contributors touching Cosmos code should run
+`make test-cosmos` locally before merging.
+
 ## Example Coverage Policy
 
 Examples are part of the supported API experience and should stay verified.


### PR DESCRIPTION
## Context

Closes #202.

The Cosmos Linux emulator is known-flaky on GitHub-hosted runners.
The `Cosmos Integration` workflow was running on every push and
pull_request with `continue-on-error: true`, which still produced red
checks on PRs (e.g. #204 ran red even though the change was unrelated to
Cosmos) and slowed reviewer feedback without actually blocking merges.

## Change

`.github/workflows/ci-cosmos-integration.yml`:

- Replaces `on: pull_request` + `on: push` triggers with:
  - `on: schedule:` (`cron: "0 3 * * *"` — 03:00 UTC nightly)
  - `on: workflow_dispatch:` (manual)
- Drops `continue-on-error: true` (scheduled runs are non-gating by
  definition; this lets real regressions surface clearly).
- Adds a header comment explaining the rationale, trigger model, and
  ownership.

Per Oracle review, the workflow now explicitly names the repository
maintainer (`yeongseon`) as responsible for triaging nightly failures
via the Actions tab.

`CONTRIBUTING.md`:

- Adds a one-paragraph note under `## Project Commands` pointing
  Cosmos-touching contributors at `make test-cosmos` for local
  validation and explaining the new CI trigger model.

## Acceptance Checklist

- [x] Workflow no longer triggers on push or pull_request.
- [x] Workflow runs on schedule + manual dispatch.
- [x] `continue-on-error` removed.
- [x] Ownership / monitoring documented in the workflow header.
- [x] CONTRIBUTING.md updated.
- [x] YAML is valid (`yaml.safe_load`).

## References

- #202
- Flaky run on unrelated PR #204