### PR TITLE
docs(readme): note native endpoint thread lock is not distributed (#209)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -299,6 +299,12 @@ func_app = app.function_app
 - **プレフィックススキャン** — `AzureBlobCheckpointSaver` は blob プレフィックススキャンでチェックポイントを列挙するため、トランザクション数とレイテンシはスレッドあたりのチェックポイント数に比例して増加します。下記のリテンションヘルパーで境界を保ちましょう。
 - **エンティティサイズ** — Azure Table エンティティは 1 MB が上限で、しきい値の 90% で警告がログに記録されます。
 
+#### ネイティブエンドポイントのスレッドロック
+
+ネイティブ invoke/stream エンドポイント（`POST /api/graphs/{name}/invoke` および `.../stream`）は、グラフに checkpointer が設定され、リクエストに `config.configurable.thread_id` が含まれる場合、**インプロセスのスレッド単位ロック**を使用します。これにより、同一 Python ワーカープロセス内で単一ライター型 checkpointer（例: `AzureBlobCheckpointSaver`）への同時書き込みを防止します。
+
+> **重要:** これは**分散ロックではありません**（not distributed）。複数の Function App インスタンス、ワーカープロセス、ホスト間では協調しません。分散ランロックが必要な場合は、`AzureTableThreadStore` とともに Platform 互換ラン（`platform_compat=True`）を使用してください — ETag ベースの原子的ロックを提供します。
+
 #### リテンションヘルパー
 
 `AzureBlobCheckpointSaver` は、定期クリーンアップ（例: Timer トリガーの Function）向けに 2 つのヘルパーを公開しています:

--- a/README.ko.md
+++ b/README.ko.md
@@ -297,6 +297,12 @@ func_app = app.function_app
 - **Prefix 스캔** — `AzureBlobCheckpointSaver`는 blob prefix 스캔으로 체크포인트를 나열하므로 트랜잭션 수와 지연이 스레드당 체크포인트 수에 비례하여 증가합니다. 아래 보존 헬퍼로 이를 제한하세요.
 - **엔티티 크기** — Azure Table 엔티티는 1 MB로 제한되며, 임계값의 90%에서 경고가 기록됩니다.
 
+#### 네이티브 엔드포인트 스레드 락
+
+네이티브 invoke/stream 엔드포인트(`POST /api/graphs/{name}/invoke` 및 `.../stream`)는 그래프에 체크포인터가 있고 요청에 `config.configurable.thread_id`가 포함된 경우 **인프로세스 스레드별 락**을 사용합니다. 이는 동일 Python 워커 프로세스 내에서 단일 작성자 체크포인터(예: `AzureBlobCheckpointSaver`)에 대한 동시 쓰기를 방지합니다.
+
+> **중요:** 이는 **분산 락이 아닙니다**(not distributed). 여러 Function App 인스턴스, 워커 프로세스 또는 호스트 간에는 조율되지 않습니다. 분산 런 락이 필요하다면 `AzureTableThreadStore`와 함께 Platform 호환 런(`platform_compat=True`)을 사용하세요 — ETag 기반의 원자적 락을 제공합니다.
+
 #### 보존 헬퍼
 
 `AzureBlobCheckpointSaver`는 정기 정리(예: Timer 트리거 Function)를 위한 두 가지 헬퍼를 제공합니다:

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -297,6 +297,12 @@ func_app = app.function_app
 - **前缀扫描** — `AzureBlobCheckpointSaver` 通过 blob 前缀扫描列出检查点，事务数与延迟随每线程检查点数量增长。请使用下文的保留辅助函数加以约束。
 - **实体大小** — Azure Table 实体上限为 1 MB；当达到阈值的 90% 时会记录警告。
 
+#### 原生端点的线程锁
+
+原生 invoke/stream 端点（`POST /api/graphs/{name}/invoke` 与 `.../stream`）在图配置了 checkpointer 且请求包含 `config.configurable.thread_id` 时使用**进程内的逐线程锁**。它可防止同一 Python 工作进程内对单写入者 checkpointer（例如 `AzureBlobCheckpointSaver`）的并发写入。
+
+> **重要:** 这**不是分布式锁**（not distributed），不会跨多个 Function App 实例、工作进程或主机进行协调。如需分布式运行锁，请配合 `AzureTableThreadStore` 使用 Platform 兼容运行（`platform_compat=True`）—— 它提供基于 ETag 的原子锁。
+
 #### 保留辅助函数
 
 `AzureBlobCheckpointSaver` 提供两个用于定期清理（例如 Timer 触发的 Function）的辅助方法:

--- a/src/azure_functions_langgraph/app.py
+++ b/src/azure_functions_langgraph/app.py
@@ -101,6 +101,14 @@ class LangGraphApp:
         deployments, always pass ``auth_level`` explicitly.
         The ``health_auth_level`` parameter controls the auth level of the health
         endpoint independently and defaults to ``ANONYMOUS`` for convenience.
+
+    Note:
+        Per-thread locking on the native invoke/stream endpoints is
+        **in-process only** — it is not distributed across Function App
+        instances, worker processes, or hosts. For distributed run locking,
+        use Platform-compatible runs (``platform_compat=True``) with
+        :class:`~azure_functions_langgraph.stores.azure_table.AzureTableThreadStore`,
+        which provides ETag-based atomic locking.
     """
 
     auth_level: func.AuthLevel = func.AuthLevel.ANONYMOUS


### PR DESCRIPTION
## Context

Closes #209.

Oracle's final v0.7.0 hardening audit flagged that the native invoke/stream per-thread lock's **not distributed** caveat existed only in `README.md` (EN) and an internal `_handlers.py` comment. The Korean/Japanese/Simplified-Chinese READMEs and the public `LangGraphApp` docstring carried no equivalent warning, so non-English readers and IDE-tooltip readers could miss a release-blocking limitation.

## Changes

- **`README.ko.md` / `README.ja.md` / `README.zh-CN.md`** — short focused subsection (`#### 네이티브 엔드포인트 스레드 락` / `#### ネイティブエンドポイントのスレッドロック` / `#### 原生端点的线程锁`) added alongside the existing scale-guidance notes. Phrasing kept stable across languages: **not distributed**, points readers at `AzureTableThreadStore` + `platform_compat=True` for distributed run locking.
- **`src/azure_functions_langgraph/app.py`** — one extra `Note:` on `LangGraphApp` clarifying the per-thread lock is **in-process only** and not distributed across instances / workers / hosts.

EN README already carries the caveat at the `#### Native endpoint thread locking` section (lines 512-516) — no changes needed there.

## Acceptance Checklist

- [x] ko/ja/zh-CN READMEs surface the 'not distributed' caveat.
- [x] Public `LangGraphApp` docstring surfaces the caveat.
- [x] Stable phrasing across languages.
- [x] `make lint` clean.
- [x] `make typecheck` clean (mypy + ruff, 51 files).
- [x] `make test` — 869 passed, 10 skipped (Azurite/Cosmos env), coverage 95.27%.
- [x] `make build` — sdist + wheel 0.7.0 produced.

## Out of scope

- Translating the full `#### Run lock semantics` / `#### Native endpoint thread locking` sections — Oracle review explicitly endorsed short focused subsections for blocker PRs rather than full section parity.
- Other v0.7.0 documentation parity blockers — tracked separately in #207, #208, #210.

## References

- Issue: #209
- Related blockers: #207, #208, #210