### PR TITLE
docs(stores): document reset_stale_locks projection/ETag skip behavior (#210)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -298,6 +298,7 @@ func_app = app.function_app
 - **単一パーティション** — `AzureTableThreadStore` は全スレッドを単一の PartitionKey に格納し、Azure Table のパーティション単位スループット（Standard アカウントで約 2000 エンティティ/秒）が上限となります。`status` 以外の検索とカウントは**クライアントサイド**でフィルタリングされます。[COMPATIBILITY.md](COMPATIBILITY.md) を参照してください。
 - **プレフィックススキャン** — `AzureBlobCheckpointSaver` は blob プレフィックススキャンでチェックポイントを列挙するため、トランザクション数とレイテンシはスレッドあたりのチェックポイント数に比例して増加します。下記のリテンションヘルパーで境界を保ちましょう。
 - **エンティティサイズ** — Azure Table エンティティは 1 MB が上限で、しきい値の 90% で警告がログに記録されます。
+- **ステールロッククリーンアップの注意点** — `AzureTableThreadStore.reset_stale_locks` はプロジェクションクエリ（`select=["RowKey", "updated_at"]`）を使用し、各ロウの ETag が `entity.metadata["etag"]` または `entity["etag"]` のいずれかで公開されることを要求します。どちらの形でも ETag が得られない行は、CAS に使える ETag なしにステールロックをリセットしないためにスキップされ（DEBUG ログ）、次回のスキャンで再試行されます。
 
 #### ネイティブエンドポイントのスレッドロック
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -296,6 +296,7 @@ func_app = app.function_app
 - **단일 파티션** — `AzureTableThreadStore`는 모든 스레드를 단일 PartitionKey에 저장하며, Azure Table 파티션당 처리량(Standard 계정 기준 약 2000 엔티티/초)에 의해 제한됩니다. `status` 외의 검색 및 카운트 필터링은 **클라이언트 사이드**에서 수행됩니다. [COMPATIBILITY.md](COMPATIBILITY.md) 참고.
 - **Prefix 스캔** — `AzureBlobCheckpointSaver`는 blob prefix 스캔으로 체크포인트를 나열하므로 트랜잭션 수와 지연이 스레드당 체크포인트 수에 비례하여 증가합니다. 아래 보존 헬퍼로 이를 제한하세요.
 - **엔티티 크기** — Azure Table 엔티티는 1 MB로 제한되며, 임계값의 90%에서 경고가 기록됩니다.
+- **스테일 락 정리 주의** — `AzureTableThreadStore.reset_stale_locks`는 프로젝션 쿼리(`select=["RowKey", "updated_at"]`)를 사용하며, `entity.metadata["etag"]` 또는 `entity["etag"]` 중 하나로도 ETag가 노출되어야 합니다. 두 형태 모두에서 ETag가 없는 행은 CAS용 ETag 없이 스테일 락을 재설정하지 않도록 건너뛰어(DEBUG 로그) 다음 스캔에서 다시 시도됩니다.
 
 #### 네이티브 엔드포인트 스레드 락
 

--- a/README.md
+++ b/README.md
@@ -509,6 +509,8 @@ count = thread_store.reset_stale_locks(older_than_seconds=600)
 
 Each reset uses ETag CAS so a thread that has been legitimately re-acquired since the scan is never stomped. Choose `older_than_seconds` comfortably above your longest expected graph execution time — ETag CAS protects against re-acquire races, but a still-running long job will not update its `updated_at` and could be reclaimed if the threshold is too short. See [`examples/maintenance_timer/`](examples/maintenance_timer/) for a complete Timer Trigger wiring.
 
+> **Stale-lock cleanup caveat:** `reset_stale_locks` issues a projection query (`select=["RowKey", "updated_at"]`) and relies on the Azure Tables SDK to expose each row's ETag via either `entity.metadata["etag"]` or `entity["etag"]`. Rows where **neither shape** populates an ETag are skipped (logged at DEBUG) so a stale lock is never reset without a writable ETag for CAS; such rows are retried on the next scan once the SDK returns a usable ETag.
+
 #### Native endpoint thread locking
 
 Native invoke/stream endpoints (`POST /api/graphs/{name}/invoke` and `.../stream`) use an **in-process per-thread lock** when the graph has a checkpointer and the request includes `config.configurable.thread_id`. This prevents concurrent writes to single-writer checkpointers (e.g. `AzureBlobCheckpointSaver`) within the same Python worker process.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -296,6 +296,7 @@ func_app = app.function_app
 - **单分区** — `AzureTableThreadStore` 将所有线程置于同一 PartitionKey 下，受 Azure Table 单分区吞吐量（Standard 账户约 2000 实体/秒）限制。除 `status` 以外的搜索与计数过滤均在**客户端**完成，详见 [COMPATIBILITY.md](COMPATIBILITY.md)。
 - **前缀扫描** — `AzureBlobCheckpointSaver` 通过 blob 前缀扫描列出检查点，事务数与延迟随每线程检查点数量增长。请使用下文的保留辅助函数加以约束。
 - **实体大小** — Azure Table 实体上限为 1 MB；当达到阈值的 90% 时会记录警告。
+- **锁清理警告** — `AzureTableThreadStore.reset_stale_locks` 使用投影查询（`select=["RowKey", "updated_at"]`），依赖于每行通过 `entity.metadata["etag"]` 或 `entity["etag"]` 中任一暴露 ETag。两种形状都未提供 ETag 的行会被跳过（记录为 DEBUG 日志），以免在没有可写 ETag 的情况下重置锁；下一轮扫描会重试。
 
 #### 原生端点的线程锁
 

--- a/src/azure_functions_langgraph/stores/azure_table.py
+++ b/src/azure_functions_langgraph/stores/azure_table.py
@@ -559,6 +559,13 @@ class AzureTableThreadStore(ThreadStore):
         Raises:
             ValueError: If *older_than_seconds* is negative or *status*
                 is not ``"idle"`` or ``"error"``.
+        Note:
+            Each scanned row must expose an ETag via either
+            ``entity.metadata["etag"]`` or ``entity["etag"]``.
+            Rows where neither shape populates an ETag are skipped
+            (logged at DEBUG) so a stale lock is never reset without
+            a writable ETag for CAS; such rows are retried on the next
+            scan once the SDK returns a usable ETag.
         """
         if older_than_seconds < 0:
             raise ValueError(

--- a/tests/test_stores_azure_table.py
+++ b/tests/test_stores_azure_table.py
@@ -1020,3 +1020,56 @@ def test_reset_stale_locks_deleted_thread_skipped(monkeypatch: Any) -> None:
     count = store.reset_stale_locks(older_than_seconds=300)
 
     assert count == 0
+
+
+
+def test_reset_stale_locks_metadata_only_etag(monkeypatch: Any) -> None:
+    """Stale lock is reset when ETag is exposed only via entity.metadata.
+
+    The Azure Tables SDK may surface the row ETag either as a dict key
+    (``entity["etag"]``) or as a Mapping attribute
+    (``entity.metadata["etag"]``).  ``reset_stale_locks`` must accept the
+    metadata-only shape so CAS-based reset still works on SDK versions
+    that do not project ``etag`` into the dict body of a projected row.
+    """
+    store, table_client = _new_store()
+
+    # Force projected query rows to surface ETag ONLY via .metadata,
+    # never as a top-level dict key.
+    original_query = table_client.query_entities
+
+    def query_metadata_only_etag(
+        query_filter: str | None = None, **kwargs: Any
+    ) -> list[dict[str, Any]]:
+        rows = original_query(query_filter, **kwargs)
+        wrapped: list[dict[str, Any]] = []
+        for row in rows:
+            etag = row.pop("etag", None)
+            entity = MockEntity(row)
+            if etag is not None:
+                entity.metadata = {"etag": etag}
+            wrapped.append(cast(dict[str, Any], entity))
+        return wrapped
+
+    monkeypatch.setattr(table_client, "query_entities", query_metadata_only_etag)
+
+    base = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    timestamps = iter([
+        base,                            # create
+        base + timedelta(seconds=10),    # acquire (updated_at=10)
+        base + timedelta(seconds=700),   # reset cutoff (700 - 300 = 400)
+        base + timedelta(seconds=700),   # patch updated_at
+    ])
+    monkeypatch.setattr(store, "_now", lambda: next(timestamps))
+
+    thread = store.create()
+    store.try_acquire_run_lock(thread.thread_id)
+
+    count = store.reset_stale_locks(older_than_seconds=300)
+
+    assert count == 1, (
+        "reset_stale_locks must accept metadata-only ETag shape"
+    )
+    assert store.get(thread.thread_id).status == "error"
+    # Confirm CAS path was actually taken (etag forwarded to update_entity).
+    assert table_client.last_update_kwargs.get("etag") is not None


### PR DESCRIPTION
## Context

Closes #210.

`AzureTableThreadStore.reset_stale_locks` already accepts the ETag from either `entity.metadata[\"etag\"]` or the dict body and silently skips rows missing both shapes (logged at DEBUG). Oracle's final v0.7.0 hardening audit flagged that this skip behavior was undocumented in `README.md` (EN + translations) and `reset_stale_locks`'s docstring, and that only the dict-shape path was unit-tested.

## Changes

- **`README.md`** — added a `> **Stale-lock cleanup caveat:**` note right after the existing `reset_stale_locks()` block, phrased as **stale-lock cleanup behavior** (not as a general Azure Table limitation).
- **`README.ko.md` / `README.ja.md` / `README.zh-CN.md`** — added an equivalent short bullet to the existing scale-guidance notes section, keeping phrasing stable: \"skips rows missing required projection or ETag shape\".
- **`src/azure_functions_langgraph/stores/azure_table.py`** — appended a `Note:` to `reset_stale_locks`'s docstring documenting the same caveat for IDE-tooltip readers.
- **`tests/test_stores_azure_table.py`** — new `test_reset_stale_locks_metadata_only_etag` forces the projected query to surface ETag only via `entity.metadata[\"etag\"]` (popping the dict-body `etag` key) and asserts CAS-based reset still works, exercising the first branch of the etag-extraction logic in `azure_table.py:597-602`.

## Acceptance Checklist

- [x] EN README documents the projection/ETag dual-shape skip behavior near the stale-lock cleanup block.
- [x] ko/ja/zh-CN READMEs surface the same caveat with stable phrasing.
- [x] `reset_stale_locks` docstring documents the caveat for tooltip readers.
- [x] Fake-SDK unit test forces `entity.metadata[\"etag\"]` shape and asserts CAS-based reset.
- [x] `make lint` clean.
- [x] `make typecheck` clean (mypy + ruff, 51 files).
- [x] `make test` — 870 passed (+1 new), 10 skipped (Azurite/Cosmos env), coverage ≥ 95%.
- [x] `make build` — sdist + wheel 0.7.0 produced.

## Out of scope

- Class-level limitations section on `AzureTableThreadStore` — Oracle review endorsed `reset_stale_locks` docstring as the primary home for this caveat.
- `release_run_lock` branch coverage (`azure_table.py:517, 530`) — tracked as a standalone follow-up per Oracle review.
- Other v0.7.0 documentation parity blockers — tracked separately in #207, #208 (#209 merged via #211).

## References

- Issue: #210
- Related blockers: #207, #208 (#209 merged via #211)