### PR TITLE
docs(readme): clarify LangGraphApp.route_prefix is metadata-only (#207)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -197,6 +197,24 @@ curl -X POST "https://<app>.azurewebsites.net/api/graphs/echo_agent/invoke?code=
   -d '{"input": {"messages": [{"role": "human", "content": "Hello!"}]}}'
 ```
 
+### カスタムルートプレフィックス
+
+すべてのルートは Azure Functions のデフォルトプレフィックス `/api` を使用します。プレフィックスを変更するには `host.json` の `routePrefix` を設定します:
+
+```json
+{
+  "extensions": {
+    "http": {
+      "routePrefix": "v1"
+    }
+  }
+}
+```
+
+これによりすべてのルート（例: `POST /v1/graphs/{name}/invoke`）が変わります。プレフィックスを完全に取り除くには `routePrefix` を `""` に設定してください。
+
+> **重要 — `LangGraphApp(route_prefix=...)` はメタデータ専用です（metadata-only）。** Azure Functions は HTTP ルートを `host.json`（**真実の原本**）から解決し、コンストラクタ引数からは解決しません。`route_prefix` 引数は `azure-functions-openapi-python` ブリッジなどが利用するメタデータスナップショットに記録され、生成されるスペックがデプロイされたルートを反映しますが、`host.json` を更新せずにこの値だけを変えてもリクエストが処理される位置は**変わりません**。ルートを実際に移動させるには常に `host.json` を編集し、メタデータを同期させるために `LangGraphApp(route_prefix=...)` にも同じ値を渡してください。
+
 ### 生成されるエンドポイント
 
 1. `POST /api/graphs/echo_agent/invoke` — エージェントの呼び出し

--- a/README.ko.md
+++ b/README.ko.md
@@ -195,6 +195,24 @@ curl -X POST "https://<app>.azurewebsites.net/api/graphs/echo_agent/invoke?code=
   -d '{"input": {"messages": [{"role": "human", "content": "Hello!"}]}}'
 ```
 
+### 커스텀 라우트 프리픽스
+
+모든 라우트는 Azure Functions 기본값인 `/api` 프리픽스를 사용합니다. 프리픽스를 변경하려면 `host.json`의 `routePrefix`를 수정하세요:
+
+```json
+{
+  "extensions": {
+    "http": {
+      "routePrefix": "v1"
+    }
+  }
+}
+```
+
+이는 모든 라우트(예: `POST /v1/graphs/{name}/invoke`)를 변경합니다. 프리픽스를 제거하려면 `routePrefix`를 `""`로 설정하세요.
+
+> **중요 — `LangGraphApp(route_prefix=...)`는 메타데이터 전용입니다(metadata-only).** Azure Functions는 HTTP 라우트를 `host.json`(**진실의 원천**)에서 결정하며, 생성자 인수는 해당하지 않습니다. `route_prefix` 인수는 `azure-functions-openapi-python` 브리지가 사용하는 메타데이터 스냅샷에만 기록되어 생성된 스펙이 배포된 라우트를 반영하도록 도웁니다. `host.json`을 함께 수정하지 않으면 요청이 제공되는 위치는 **바뀌지 않습니다**. 라우트를 실제로 이동하려면 항상 `host.json`을 수정하고, 메타데이터 일관성을 위해 `LangGraphApp(route_prefix=...)`에 동일한 값을 전달하세요.
+
 ### 생성되는 엔드포인트
 
 1. `POST /api/graphs/echo_agent/invoke` — 에이전트 호출

--- a/README.md
+++ b/README.md
@@ -266,6 +266,8 @@ configure `routePrefix` in your `host.json`:
 This changes all routes (e.g. `POST /v1/graphs/{name}/invoke`). Set `routePrefix`
 to `""` to remove the prefix entirely.
 
+> **Important — `LangGraphApp(route_prefix=...)` is metadata-only.** Azure Functions resolves HTTP routes from `host.json` (the **source of truth**), not from the constructor argument. The `route_prefix` argument is recorded into the metadata snapshot consumed by tooling such as the `azure-functions-openapi-python` bridge so generated specs reflect the deployed routes, but changing it without also updating `host.json` does **not** change where requests are served. Always edit `host.json` to actually move routes, and pass the same value to `LangGraphApp(route_prefix=...)` so metadata stays in sync.
+
 ### What you get
 
 1. `POST /api/graphs/echo_agent/invoke` — invoke the agent

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -195,6 +195,24 @@ curl -X POST "https://<app>.azurewebsites.net/api/graphs/echo_agent/invoke?code=
   -d '{"input": {"messages": [{"role": "human", "content": "Hello!"}]}}'
 ```
 
+### 自定义路由前缀
+
+所有路由默认使用 Azure Functions 的 `/api` 前缀。要修改前缀，请在 `host.json` 中配置 `routePrefix`:
+
+```json
+{
+  "extensions": {
+    "http": {
+      "routePrefix": "v1"
+    }
+  }
+}
+```
+
+这会修改所有路由（例如 `POST /v1/graphs/{name}/invoke`）。将 `routePrefix` 设为 `""` 可完全去除前缀。
+
+> **重要 — `LangGraphApp(route_prefix=...)` 仅为元数据**（metadata-only）。Azure Functions 从 `host.json`（**唯一权威来源**）解析 HTTP 路由，而不是从构造器参数。`route_prefix` 参数仅记录到供 `azure-functions-openapi-python` 等工具使用的元数据快照中，以使生成的规范反映部署后的路由；不同步修改 `host.json` 则请求实际接收位置**不会改变**。要真正移动路由，请始终修改 `host.json`，并向 `LangGraphApp(route_prefix=...)` 传递相同值以保持元数据同步。
+
 ### 生成的端点
 
 1. `POST /api/graphs/echo_agent/invoke` — 调用智能体


### PR DESCRIPTION
## Context

Closes #207.

Oracle's final v0.7.0 hardening audit flagged that the `route_prefix` argument's **metadata-only** nature appeared only in source comments/docstrings (`app.py:121`, `app.py:395-398`) and in the EN README's Custom route prefix section. The Korean/Japanese/Simplified-Chinese READMEs did not document the Custom route prefix flow at all, and EN did not warn explicitly that the constructor argument does not actually move routes.

## Changes

- **`README.md`** — added a `> **Important — ... is metadata-only.**` callout right after the `routePrefix=\"\"` line in the `Custom route prefix` section, naming `host.json` as the source of truth and `azure-functions-openapi-python` as the downstream consumer of the metadata snapshot.
- **`README.ko.md` / `README.ja.md` / `README.zh-CN.md`** — added a new focused `### Custom route prefix` subsection (translating the `host.json` snippet and the same metadata-only caveat) right after the curl-invocation block. Phrasing kept stable across languages: **metadata-only**, **source of truth**.

LangGraphApp's existing docstrings (`app.py:121`, `app.py:395-398`) already say \"metadata-only\" and reference `host.json`, so no source-level changes are needed.

## Acceptance Checklist

- [x] EN README explicitly warns that `LangGraphApp(route_prefix=...)` does not move routes.
- [x] ko/ja/zh-CN READMEs surface a focused 'Custom route prefix' subsection with the metadata-only caveat.
- [x] `host.json` is named as the source of truth in all four languages.
- [x] `make lint` clean.
- [x] `make typecheck` clean (mypy + ruff, 51 files).
- [x] `make test` — 870 passed, 10 skipped (Azurite/Cosmos env), coverage ≥ 95%.
- [x] `make build` — sdist + wheel 0.7.0 produced.

## Out of scope

- Modifying `app.py` docstrings — Oracle review confirmed the existing 'metadata-only' wording is already user-facing and clear.
- Other v0.7.0 documentation parity blockers — tracked separately in #208 (#209 merged via #211, #210 merged via #212).

## References

- Issue: #207
- Remaining blocker: #208