### PR TITLE
docs(checkpointers): note Cosmos Managed Identity is unsupported by upstream

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -317,6 +317,7 @@ func_app = app.function_app
 - **プレフィックススキャン** — `AzureBlobCheckpointSaver` は blob プレフィックススキャンでチェックポイントを列挙するため、トランザクション数とレイテンシはスレッドあたりのチェックポイント数に比例して増加します。下記のリテンションヘルパーで境界を保ちましょう。
 - **エンティティサイズ** — Azure Table エンティティは 1 MB が上限で、しきい値の 90% で警告がログに記録されます。
 - **ステールロッククリーンアップの注意点** — `AzureTableThreadStore.reset_stale_locks` はプロジェクションクエリ（`select=["RowKey", "updated_at"]`）を使用し、各ロウの ETag が `entity.metadata["etag"]` または `entity["etag"]` のいずれかで公開されることを要求します。どちらの形でも ETag が得られない行は、CAS に使える ETag なしにステールロックをリセットしないためにスキップされ（DEBUG ログ）、次回のスキャンで再試行されます。
+- **Cosmos DB Managed Identity 未サポート** — アップストリームの `langgraph-checkpoint-cosmosdb` パッケージが `TokenCredential` をサポートしていないため、`create_cosmos_checkpointer` は**キーベース認証のみ**を使用します。ヘルパーはコンストラクタ引数から `COSMOSDB_ENDPOINT` / `COSMOSDB_KEY` 環境変数を一時的に設定し、後で復元します。Cosmos DB へのパスワードレス認証が必須の場合は、アップストリームが `TokenCredential` を追加するまで他のチェックポインターバックエンドを選択してください。
 
 #### ネイティブエンドポイントのスレッドロック
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -315,6 +315,7 @@ func_app = app.function_app
 - **Prefix 스캔** — `AzureBlobCheckpointSaver`는 blob prefix 스캔으로 체크포인트를 나열하므로 트랜잭션 수와 지연이 스레드당 체크포인트 수에 비례하여 증가합니다. 아래 보존 헬퍼로 이를 제한하세요.
 - **엔티티 크기** — Azure Table 엔티티는 1 MB로 제한되며, 임계값의 90%에서 경고가 기록됩니다.
 - **스테일 락 정리 주의** — `AzureTableThreadStore.reset_stale_locks`는 프로젝션 쿼리(`select=["RowKey", "updated_at"]`)를 사용하며, `entity.metadata["etag"]` 또는 `entity["etag"]` 중 하나로도 ETag가 노출되어야 합니다. 두 형태 모두에서 ETag가 없는 행은 CAS용 ETag 없이 스테일 락을 재설정하지 않도록 건너뛰어(DEBUG 로그) 다음 스캔에서 다시 시도됩니다.
+- **Cosmos DB Managed Identity 미지원** — 업스트림 `langgraph-checkpoint-cosmosdb` 패키지가 `TokenCredential`을 지원하지 않으므로 `create_cosmos_checkpointer`는 **키 기반 인증만** 사용합니다. 헬퍼는 생성자 인자로부터 `COSMOSDB_ENDPOINT` / `COSMOSDB_KEY` 환경 변수를 일시적으로 설정한 뒤 원복합니다. Cosmos DB에 패스워드리스 인증이 필수라면 업스트림이 `TokenCredential`을 추가할 때까지 다른 체크포인터 백엔드를 사용하세요.
 
 #### 네이티브 엔드포인트 스레드 락
 

--- a/README.md
+++ b/README.md
@@ -471,6 +471,8 @@ For workloads that already run a managed database (or need state shared across m
 
 Each helper owns the connection lifetime and emits clear ImportErrors pointing at the right extra. The Postgres and SQLite helpers accept a connection string and (by default) call upstream `setup()` on cold start so the checkpoint tables exist; the Cosmos DB helper accepts an endpoint and key, temporarily wires the upstream `COSMOSDB_ENDPOINT` / `COSMOSDB_KEY` environment variables, and directly instantiates the upstream `CosmosDBSaver`:
 
+> **Authentication — `create_cosmos_checkpointer` uses key-based auth only.** Managed Identity / `DefaultAzureCredential` is **unsupported** by the upstream `langgraph-checkpoint-cosmosdb` package, so this helper temporarily wires `COSMOSDB_ENDPOINT` / `COSMOSDB_KEY` from the constructor arguments and restores the original environment afterwards. If your platform mandates passwordless auth to Cosmos DB, prefer one of the other checkpointer backends until upstream adds `TokenCredential` support.
+
 ```python
 import os
 from azure_functions_langgraph.checkpointers.postgres import create_postgres_checkpointer

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -315,6 +315,7 @@ func_app = app.function_app
 - **前缀扫描** — `AzureBlobCheckpointSaver` 通过 blob 前缀扫描列出检查点，事务数与延迟随每线程检查点数量增长。请使用下文的保留辅助函数加以约束。
 - **实体大小** — Azure Table 实体上限为 1 MB；当达到阈值的 90% 时会记录警告。
 - **锁清理警告** — `AzureTableThreadStore.reset_stale_locks` 使用投影查询（`select=["RowKey", "updated_at"]`），依赖于每行通过 `entity.metadata["etag"]` 或 `entity["etag"]` 中任一暴露 ETag。两种形状都未提供 ETag 的行会被跳过（记录为 DEBUG 日志），以免在没有可写 ETag 的情况下重置锁；下一轮扫描会重试。
+- **Cosmos DB 不支持 Managed Identity** — 上游 `langgraph-checkpoint-cosmosdb` 包未支持 `TokenCredential`，因此 `create_cosmos_checkpointer` **仅使用基于密钥的身份验证**。辅助函数从构造参数临时写入 `COSMOSDB_ENDPOINT` / `COSMOSDB_KEY` 环境变量，随后恢复。若平台要求对 Cosmos DB 采用免密码认证，请在上游添加 `TokenCredential` 支持之前选择其他检查点后端。
 
 #### 原生端点的线程锁
 


### PR DESCRIPTION
## Context

Closes #208.

Oracle audit (and the upstream `langgraph-checkpoint-cosmosdb` source) confirmed that the Cosmos checkpointer cannot use Managed Identity / `DefaultAzureCredential` — only key-based auth is supported. The English README's checkpointer paragraph already explains the env-var wiring, but there was no explicit callout that passwordless auth is **unsupported**, and the ko/ja/zh-CN translations had no equivalent guidance at all.

## Changes

- `README.md`: add an **Authentication** callout immediately after the `create_cosmos_checkpointer` description paragraph stating Managed Identity / `DefaultAzureCredential` is unsupported by upstream, explaining the temporary `COSMOSDB_ENDPOINT` / `COSMOSDB_KEY` env wiring, and recommending alternative backends when passwordless auth is mandatory.
- `README.ko.md`, `README.ja.md`, `README.zh-CN.md`: add a focused bullet to the existing scale-guidance notes section noting that `create_cosmos_checkpointer` uses key-based auth only and that Managed Identity is unsupported by the upstream package.

Phrasing is kept stable across languages ("Managed Identity unsupported" / "key-based auth only"), consistent with the parity language used in PRs #211, #212, and #213.

## Acceptance Checklist

- [x] `make lint`
- [x] `make typecheck`
- [x] `make test` (870 passed, 10 skipped — integration tests skipped without emulator)
- [x] `make build`
- [x] Coverage 95.30% (≥95% gate)
- [x] EN README updated with Managed Identity unsupported callout
- [x] ko/ja/zh-CN README updated with focused parity note
- [x] No source code changes (docstring at cosmos.py:19-23 already documents this)

## Out of scope

- CHANGELOG backfill — handled by the follow-up standalone PR before v0.7.0 tag.
- release_run_lock branch coverage at azure_table.py:517, 530 — tracked as optional follow-up issue.

## References

- #208 (this issue)
- PR #211 (closes #209 — native lock 'not distributed' parity)
- PR #212 (closes #210 — stale-lock projection/ETag caveat)
- PR #213 (closes #207 — route_prefix metadata-only parity)