### PR TITLE
chore(release): prepare v0.7.1 with documentation parity fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 All notable changes to this project will be documented in this file.
 
+## 0.7.1
+
+### 📚 Documentation
+
+- *(readme)* Note native endpoint thread lock is not distributed (#209) (#211)
+- *(stores)* Document `reset_stale_locks` projection/ETag skip behavior (#210) (#212)
+- *(readme)* Clarify `LangGraphApp.route_prefix` is metadata-only (#207) (#213)
+- *(checkpointers)* Note Cosmos Managed Identity is unsupported by upstream (#208) (#214)
+- *(readme)* Translate `health_auth_level` ANONYMOUS-default warning into ko/ja/zh-CN (#205)
+
+### 🧪 Tests
+
+- *(stores)* Assert projection query returns usable ETag against Azurite (#204)
+- *(stores)* Add fake-SDK unit test for metadata-only ETag path in `reset_stale_locks` (#212)
+
+### ⚙️ Miscellaneous Tasks
+
+- *(ci)* Add Azurite-backed Table integration tests and `route_prefix` docstring polish (#199)
+- *(ci)* Move Cosmos integration to scheduled + `workflow_dispatch` only (#206)
+
+
 ## 0.7.0
 
 ### ✨ Features

--- a/src/azure_functions_langgraph/__init__.py
+++ b/src/azure_functions_langgraph/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-__version__ = "0.7.0"
+__version__ = "0.7.1"
 
 if TYPE_CHECKING:
     from azure_functions_langgraph.app import LangGraphApp, get_langgraph_metadata

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 def test_version_string() -> None:
     from azure_functions_langgraph import __version__
 
-    assert __version__ == "0.7.0"
+    assert __version__ == "0.7.1"
 
 
 def test_langgraph_app_importable() -> None:


### PR DESCRIPTION
## Context

v0.7.0 was tagged and published on 2026-05-05 at commit `9b5107c`, before the Oracle release-readiness audit identified four documentation parity BLOCKERS (#207, #208, #209, #210). Those have since been resolved by PRs #211, #212, #213, and #214, alongside earlier post-tag improvements (#199, #204, #205, #206). None of these are in any released version.

This PR cuts a v0.7.1 patch release that captures the documentation parity + CI hardening work merged since v0.7.0.

## Changes

- `src/azure_functions_langgraph/__init__.py`: bump `__version__` to `0.7.1`.
- `tests/test_public_api.py`: update version assertion to `0.7.1` (per AGENTS.md).
- `CHANGELOG.md`: add `## 0.7.1` section listing the eight merged PRs since v0.7.0, grouped under Documentation / Tests / Miscellaneous Tasks.

No source-code or test behavior changes beyond the version bump.

## Acceptance Checklist

- [x] `make lint`
- [x] `make typecheck`
- [x] `make test` (870 passed, 10 skipped — integration tests skipped without emulator)
- [x] `make build` (produced `azure_functions_langgraph-0.7.1.tar.gz` / `.whl`)
- [x] Coverage 95.30% (≥95% gate)
- [x] `__version__` and `tests/test_public_api.py` synchronized
- [x] CHANGELOG entries cover #199, #204, #205, #206, #211 (#209), #212 (#210), #213 (#207), #214 (#208)

## Out of scope

- Tagging `v0.7.1` and creating the GitHub Release — to be done after this PR merges.
- `release_run_lock` branch coverage at `azure_table.py:517, 530` — tracked as optional follow-up.

## References

- v0.7.0 release: https://github.com/yeongseon/azure-functions-langgraph-python/releases/tag/v0.7.0
- BLOCKERs cleared: #207 (PR #213), #208 (PR #214), #209 (PR #211), #210 (PR #212)
- Other post-tag PRs: #199, #204, #205, #206