### PR TITLE
chore(examples): sync requirements pins and remove pre-release notes for v0.7.1

### DIFF
--- a/examples/cosmos_checkpoint_azure/requirements.txt
+++ b/examples/cosmos_checkpoint_azure/requirements.txt
@@ -3,12 +3,8 @@
 #
 # This example uses the Cosmos DB checkpointer extra which depends on
 # the langgraph-checkpoint-cosmosdb package.
-#
-# Until v0.7.0 is released, install from a local checkout:
-#
-#     pip install -e ../..[cosmos,azure-identity]
 
 azure-functions
-azure-functions-langgraph[cosmos,azure-identity]>=0.7.0,<0.8.0
+azure-functions-langgraph[cosmos,azure-identity]>=0.7.1,<0.8.0
 langgraph>=1.0,<2.0
 langchain-core>=1.0,<2.0

--- a/examples/maintenance_timer/README.md
+++ b/examples/maintenance_timer/README.md
@@ -29,12 +29,7 @@ or `AZURE_TABLE_ENDPOINT` (Managed Identity path). The timer function tries
 the connection string first, then falls back to `DefaultAzureCredential`.
 
 
-> **Pre-release:** `reset_stale_locks()` ships in a future release. Until
-> then, install from a local checkout:
->
-> ```bash
-> pip install -e ../..[azure-table,azure-identity]
-> ```
+
 ## Local development
 
 ```bash

--- a/examples/maintenance_timer/requirements.txt
+++ b/examples/maintenance_timer/requirements.txt
@@ -1,9 +1,5 @@
 # Do not include azure-functions-worker in this file
 # The Python Worker is managed by the Azure Functions platform
-#
-# Until v0.7.0 is released, install from a local checkout:
-#
-#     pip install -e ../..[azure-table,azure-identity]
 
 azure-functions
-azure-functions-langgraph[azure-table,azure-identity]>=0.7.0,<0.8.0
+azure-functions-langgraph[azure-table,azure-identity]>=0.7.1,<0.8.0

--- a/examples/managed_identity_storage/requirements.txt
+++ b/examples/managed_identity_storage/requirements.txt
@@ -1,15 +1,7 @@
 # Do not include azure-functions-worker in this file
 # The Python Worker is managed by the Azure Functions platform
-#
-# This example uses APIs introduced in v0.6.0 (azure-identity extra,
-# AzureTableThreadStore.from_table_client). Until v0.6.0 is on PyPI,
-# install the package in editable mode from a local checkout:
-#
-#     pip install -e ../..[azure-blob,azure-table,azure-identity]
-#
-# After v0.6.0 is released, the pinned line below is sufficient.
 
 azure-functions
-azure-functions-langgraph[azure-blob,azure-table,azure-identity]>=0.6.0,<0.7.0
+azure-functions-langgraph[azure-blob,azure-table,azure-identity]>=0.7.1,<0.8.0
 langgraph>=1.0,<2.0
 langchain-core>=1.0,<2.0

--- a/examples/openapi_bridge/requirements.txt
+++ b/examples/openapi_bridge/requirements.txt
@@ -2,7 +2,7 @@
 # The Python Worker is managed by the Azure Functions platform
 
 azure-functions
-azure-functions-langgraph>=0.5.1,<0.6.0
+azure-functions-langgraph>=0.7.1,<0.8.0
 azure-functions-openapi-python>=0.16.0
 langgraph>=1.0,<2.0
 langchain-core>=1.0,<2.0

--- a/examples/persistent_agent_blob_table/requirements.txt
+++ b/examples/persistent_agent_blob_table/requirements.txt
@@ -2,6 +2,6 @@
 # The Python Worker is managed by the Azure Functions platform
 
 azure-functions
-azure-functions-langgraph[azure-blob,azure-table]>=0.5.1,<0.6.0
+azure-functions-langgraph[azure-blob,azure-table]>=0.7.1,<0.8.0
 langgraph>=1.0,<2.0
 langchain-core>=1.0,<2.0

--- a/examples/platform_compat_sdk/requirements.txt
+++ b/examples/platform_compat_sdk/requirements.txt
@@ -2,6 +2,6 @@
 # The Python Worker is managed by the Azure Functions platform
 
 azure-functions
-azure-functions-langgraph>=0.5.1,<0.6.0
+azure-functions-langgraph>=0.7.1,<0.8.0
 langgraph>=1.0,<2.0
 langchain-core>=1.0,<2.0

--- a/examples/postgres_checkpoint_production/requirements.txt
+++ b/examples/postgres_checkpoint_production/requirements.txt
@@ -2,6 +2,6 @@
 # The Python Worker is managed by the Azure Functions platform
 
 azure-functions
-azure-functions-langgraph[postgres]>=0.6.0,<0.7.0
+azure-functions-langgraph[postgres]>=0.7.1,<0.8.0
 langgraph>=1.0,<2.0
 langchain-core>=1.0,<2.0

--- a/examples/production_auth/requirements.txt
+++ b/examples/production_auth/requirements.txt
@@ -2,6 +2,6 @@
 # The Python Worker is managed by the Azure Functions platform
 
 azure-functions
-azure-functions-langgraph>=0.5.1,<0.6.0
+azure-functions-langgraph>=0.7.1,<0.8.0
 langgraph>=1.0,<2.0
 langchain-core>=1.0,<2.0

--- a/examples/sqlite_checkpoint_local/requirements.txt
+++ b/examples/sqlite_checkpoint_local/requirements.txt
@@ -2,6 +2,6 @@
 # The Python Worker is managed by the Azure Functions platform
 
 azure-functions
-azure-functions-langgraph[sqlite]>=0.6.0,<0.7.0
+azure-functions-langgraph[sqlite]>=0.7.1,<0.8.0
 langgraph>=1.0,<2.0
 langchain-core>=1.0,<2.0


### PR DESCRIPTION
## Context

Oracle final release-readiness audit for v0.7.1 returned NO-GO because example `requirements.txt` files still pinned `<0.7.0` (would resolve to v0.6.x or even v0.5.x on fresh install) and `examples/maintenance_timer/README.md` still labeled `reset_stale_locks()` as unreleased. The package core (version, CHANGELOG, README parity in EN/ko/ja/zh-CN) is otherwise GO.

## Changes

- `examples/maintenance_timer/README.md`: drop the "Pre-release" callout (`reset_stale_locks()` shipped in v0.7.0).
- `examples/maintenance_timer/requirements.txt`: drop the pre-release comment block; pin updated to `>=0.7.1,<0.8.0`.
- `examples/cosmos_checkpoint_azure/requirements.txt`: drop the pre-release comment block; pin updated to `>=0.7.1,<0.8.0`.
- `examples/managed_identity_storage/requirements.txt`: drop the stale v0.6.0 comment block; pin updated to `>=0.7.1,<0.8.0`.
- `examples/postgres_checkpoint_production/requirements.txt`: pin updated to `>=0.7.1,<0.8.0`.
- `examples/sqlite_checkpoint_local/requirements.txt`: pin updated to `>=0.7.1,<0.8.0`.
- `examples/persistent_agent_blob_table/requirements.txt`: pin updated from stale `<0.6.0` to `>=0.7.1,<0.8.0`.
- `examples/production_auth/requirements.txt`: same.
- `examples/platform_compat_sdk/requirements.txt`: same.
- `examples/openapi_bridge/requirements.txt`: same.

Intentional historical refs preserved: `CHANGELOG.md` (## 0.6.0 / ## 0.7.0 section headings) and `src/azure_functions_langgraph/checkpointers/cosmos.py:3` (`.. versionadded:: 0.7.0`).

## Acceptance Checklist

- [x] `make lint`
- [x] `make typecheck`
- [x] `make test` (870 passed, 10 skipped)
- [x] `make build` (azure_functions_langgraph-0.7.1.tar.gz + .whl)
- [x] Coverage maintained at 95.30%
- [x] No remaining stale `0.7.0` / `<0.7` / `<0.6` / `0.5.1` / `unreleased` / `Pre-release` references in `examples/`
- [x] Historical version references preserved in CHANGELOG and `cosmos.py` docstring

## Out of scope

- Tagging `v0.7.1` and creating the GitHub Release — to be done after this PR merges.
- `release_run_lock` branch coverage at `azure_table.py:517, 530` — tracked as optional follow-up.

## References

- Oracle audit verdict in session `ses_1e561a3d5ffeGt8ltxPGKMtaNf` (NO-GO until example sync)
- Release-prep PR #215 (v0.7.1 version bump + CHANGELOG)
- BLOCKER PRs: #211 (#209), #212 (#210), #213 (#207), #214 (#208)