### PR TITLE
fix(ci): bypass SSL verification for Cosmos emulator in create_cosmos_checkpointer

### DIFF
--- a/src/azure_functions_langgraph/checkpointers/cosmos.py
+++ b/src/azure_functions_langgraph/checkpointers/cosmos.py
@@ -153,6 +153,23 @@ def create_cosmos_checkpointer(
                 database_name=database_name,
                 container_name=container_name,
             )
+            # When running against the Cosmos emulator (self-signed cert),
+            # replace the internal client with one that skips SSL verification.
+            if os.environ.get("COSMOS_DISABLE_SSL", "").lower() in ("true", "1", "yes"):
+                cosmos_sdk = importlib.import_module("azure.cosmos")
+                CosmosClientCls = getattr(cosmos_sdk, "CosmosClient")
+                saver.client = CosmosClientCls(
+                    url=endpoint, credential=resolved_key, connection_verify=False
+                )
+                saver.database = saver.client.create_database_if_not_exists(
+                    id=database_name
+                )
+                saver.container = saver.database.create_container_if_not_exists(
+                    id=container_name,
+                    partition_key=getattr(cosmos_sdk, "PartitionKey")(
+                        path="/partition_key"
+                    ),
+                )
         finally:
             # Restore original env vars
             if old_endpoint is None:


### PR DESCRIPTION
## Summary
- Fixes the recurring Cosmos Integration CI failure (10+ days of daily failures)
- Root cause: upstream `CosmosDBSaver` creates a `CosmosClient` without `connection_verify=False`, causing SSL verification failure against the emulator's self-signed cert
- Fix: when `COSMOS_DISABLE_SSL` env var is truthy (already set in `ci-cosmos-integration.yml`), replace the saver's internal client post-creation with one that skips SSL verification

Closes #230