### PR TITLE
fix(app): default auth_level to FUNCTION; align Alpha maturity claims

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -12,7 +12,7 @@
 
 この文書の言語: [한국어](README.ko.md) | **日本語** | [简体中文](README.zh-CN.md) | [English](README.md)
 
-> **ベータ版について** — このパッケージは活発に開発中です。コアAPIは安定化に向かっていますが、v1.0 までは変更される可能性があります。GitHubでイシューを報告してください。
+> **アルファ版について** — このパッケージは活発に開発中です。`pyproject.toml` の `Development Status :: 3 - Alpha` 分類が真実の原本です。v1.0 まではマイナーバージョン間で破壊的変更が発生しうることを想定してください。GitHub でイシューを報告してください。
 
 最小限のボイラープレートで [LangGraph](https://github.com/langchain-ai/langgraph) グラフを **Azure Functions** HTTPエンドポイントとしてデプロイできます。
 
@@ -149,15 +149,19 @@ func_app = app.function_app  # ← Azure Functionsアプリとして使用
 
 ### プロダクション認証
 
-`LangGraphApp`はローカル開発の利便性のためにデフォルトで`AuthLevel.ANONYMOUS`を使用します。
-プロダクションデプロイでは`FUNCTION`または`ADMIN`認証を使用し、Azure Functionsキーを送信してください。
+`LangGraphApp` はデプロイされたエンドポイントで関数キーが必要となるよう、デフォルトで `AuthLevel.FUNCTION` を使用します。
+ローカル開発などでキーなしにエンドポイントにアクセスしたい場合は `auth_level=func.AuthLevel.ANONYMOUS` を明示的に渡してください。不用意なパブリック公開を防ぐため、無条件で `UserWarning` が発生します。
 
 ```python
 import azure.functions as func
 
 from azure_functions_langgraph import LangGraphApp
 
-app = LangGraphApp(auth_level=func.AuthLevel.FUNCTION)
+# プロダクションデフォルト: 関数キー認証を要求
+app = LangGraphApp()  # LangGraphApp(auth_level=func.AuthLevel.FUNCTION) と同等
+
+# ローカル開発専用: 匿名アクセスを明示的に許可 — UserWarning 発生
+app_local = LangGraphApp(auth_level=func.AuthLevel.ANONYMOUS)
 ```
 
 > **注記:** `health_auth_level` は `auth_level` とは独立してデフォルトが `ANONYMOUS` です。

--- a/README.ko.md
+++ b/README.ko.md
@@ -12,7 +12,7 @@
 
 이 문서의 언어: **한국어** | [日本語](README.ja.md) | [简体中文](README.zh-CN.md) | [English](README.md)
 
-> **베타 버전 안내** — 이 패키지는 활발히 개발 중입니다. 핵심 API는 안정화되어 가고 있으나 v1.0 이전에는 변경될 수 있습니다. GitHub에서 이슈를 보고해 주세요.
+> **알파 버전 안내** — 이 패키지는 활발히 개발 중입니다. `pyproject.toml`의 `Development Status :: 3 - Alpha` 분류가 진실의 원철입니다. v1.0 이전에는 minor 버전 간 변경될 수 있습니다. GitHub에서 이슈를 보고해 주세요.
 
 [LangGraph](https://github.com/langchain-ai/langgraph) 그래프를 최소한의 보일러플레이트로 **Azure Functions** HTTP 엔드포인트로 배포하세요.
 
@@ -149,15 +149,19 @@ func_app = app.function_app  # ← Azure Functions 앱으로 사용
 
 ### 프로덕션 인증
 
-`LangGraphApp`은 로컬 개발 편의를 위해 기본적으로 `AuthLevel.ANONYMOUS`를 사용합니다.
-프로덕션 배포 시에는 `FUNCTION` 또는 `ADMIN` 인증을 사용하고 Azure Functions 키를 전송하세요.
+`LangGraphApp`은 배포된 엔드포인트에 함수 키가 요구되도록 기본으로 `AuthLevel.FUNCTION`을 사용합니다.
+로컬 개발 등 키 없이 엔드포인트에 접근하려면 `auth_level=func.AuthLevel.ANONYMOUS`를 명시적으로 전달하세요. 그러면 실수로 공개 배포되는 것을 방지하기 위해 무조건 `UserWarning`이 명시적으로 발생합니다.
 
 ```python
 import azure.functions as func
 
 from azure_functions_langgraph import LangGraphApp
 
-app = LangGraphApp(auth_level=func.AuthLevel.FUNCTION)
+# 프로덕션 기본값: 함수 키 인증 요구
+app = LangGraphApp()  # LangGraphApp(auth_level=func.AuthLevel.FUNCTION)과 동일
+
+# 로컬 개발 전용: 명시적으로 익명 접근 허용 — UserWarning 발생
+app_local = LangGraphApp(auth_level=func.AuthLevel.ANONYMOUS)
 ```
 
 > **참고:** `health_auth_level`은 `auth_level`과 무관하게 기본값이 `ANONYMOUS`입니다.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 Read this in: [한국어](README.ko.md) | [日本語](README.ja.md) | [简体中文](README.zh-CN.md)
 
-> **Beta Notice** — This package is under active development. Core APIs are stabilizing but may still change before v1.0. Please report issues on GitHub.
+> **Alpha Notice** — This package is under active development. The `Development Status :: 3 - Alpha` classifier in `pyproject.toml` is the source of truth: expect breaking changes between minor versions until v1.0. Please report issues on GitHub.
 
 Deploy [LangGraph](https://github.com/langchain-ai/langgraph) graphs as **Azure Functions** HTTP endpoints with minimal boilerplate.
 
@@ -159,8 +159,8 @@ builder.add_edge(START, "chat")
 builder.add_edge("chat", END)
 graph = builder.compile()
 
-# 4. Deploy (ANONYMOUS for local dev; use FUNCTION in production — see below)
-app = LangGraphApp(auth_level=func.AuthLevel.ANONYMOUS)
+# 4. Deploy (default is `AuthLevel.FUNCTION` — requires a function key when deployed).
+app = LangGraphApp()
 app.register(graph=graph, name="echo_agent")
 func_app = app.function_app  # ← use this as your Azure Functions app
 ```
@@ -200,17 +200,24 @@ curl -s "https://<your-app>.azurewebsites.net/api/health?code=<FUNCTION_KEY>"
 
 ### Production authentication
 
-> **Important:** `LangGraphApp` defaults to `AuthLevel.ANONYMOUS` for local development
-> convenience. This default will change to `AuthLevel.FUNCTION` in v1.0.
-> For production deployments, **always** set `auth_level` explicitly:
+> **Important:** `LangGraphApp` defaults to `AuthLevel.FUNCTION`, so deployed
+> endpoints require a function key (`?code=<FUNCTION_KEY>` or the
+> `x-functions-key` header) out of the box. For an unauthenticated public
+> surface — e.g. local development against `func start` when you also want to
+> hit the endpoint without a key — pass `auth_level=func.AuthLevel.ANONYMOUS`
+> **explicitly**. Doing so emits an unconditional `UserWarning` so an
+> accidental anonymous deployment is loud in test and CI output:
 
 ```python
 import azure.functions as func
 
 from azure_functions_langgraph import LangGraphApp
 
-# Production: require function key authentication
-app = LangGraphApp(auth_level=func.AuthLevel.FUNCTION)
+# Production (default): require function key authentication
+app = LangGraphApp()  # equivalent to LangGraphApp(auth_level=func.AuthLevel.FUNCTION)
+
+# Local dev only: explicit opt-in to anonymous — emits a UserWarning
+app_local = LangGraphApp(auth_level=func.AuthLevel.ANONYMOUS)
 ```
 
 > **Note:** `health_auth_level` defaults to `ANONYMOUS` independently of `auth_level`.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -12,7 +12,7 @@
 
 本文档语言: [한국어](README.ko.md) | [日本語](README.ja.md) | **简体中文** | [English](README.md)
 
-> **Beta 版本说明** — 此软件包正在积极开发中。核心 API 趋于稳定，但在 v1.0 之前可能仍会发生变更。请在 GitHub 上报告问题。
+> **Alpha 版本说明** — 此软件包正在积极开发中。`pyproject.toml` 中的 `Development Status :: 3 - Alpha` 分类属于唯一权威来源：在 v1.0 之前，次要版本之间可能会发生破坏性变更。请在 GitHub 上报告问题。
 
 以最少的样板代码将 [LangGraph](https://github.com/langchain-ai/langgraph) 图部署为 **Azure Functions** HTTP 端点。
 
@@ -149,15 +149,19 @@ func_app = app.function_app  # ← 用作 Azure Functions 应用
 
 ### 生产环境认证
 
-`LangGraphApp` 默认使用 `AuthLevel.ANONYMOUS` 以方便本地开发。
-生产部署时，建议使用 `FUNCTION` 或 `ADMIN` 认证并发送 Azure Functions 密钥。
+`LangGraphApp` 默认使用 `AuthLevel.FUNCTION`，以确保已部署的端点默认需要函数密钥。
+在本地开发等希望无密钥访问端点的情况下，请显式传入 `auth_level=func.AuthLevel.ANONYMOUS`。此时会无条件地发出 `UserWarning`，以防止意外将应用公开部署。
 
 ```python
 import azure.functions as func
 
 from azure_functions_langgraph import LangGraphApp
 
-app = LangGraphApp(auth_level=func.AuthLevel.FUNCTION)
+# 生产默认：要求函数密钥认证
+app = LangGraphApp()  # 等同于 LangGraphApp(auth_level=func.AuthLevel.FUNCTION)
+
+# 仅本地开发：显式允许匿名访问 — 会发出 UserWarning
+app_local = LangGraphApp(auth_level=func.AuthLevel.ANONYMOUS)
 ```
 
 > **注意：** `health_auth_level` 默认为 `ANONYMOUS`，与 `auth_level` 独立。

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,32 @@ This project follows [Conventional Commits](https://www.conventionalcommits.org/
 
 For the full changelog, see [CHANGELOG.md](https://github.com/yeongseon/azure-functions-langgraph-python/blob/main/CHANGELOG.md) in the repository root.
 
+## Unreleased
+
+### Breaking Changes
+
+- **`LangGraphApp(auth_level=...)` now defaults to `AuthLevel.FUNCTION`** (was `AuthLevel.ANONYMOUS`). Deployed endpoints require a function key by default. Existing code that relied on the anonymous default must pass `auth_level=func.AuthLevel.ANONYMOUS` explicitly. (#240)
+- Opting into `AuthLevel.ANONYMOUS` at the app level now emits an **unconditional** `UserWarning` (previously only when `AZURE_FUNCTIONS_ENVIRONMENT` was set). The warning fires in tests, CI, and local runs so accidental anonymous deployments are always loud. The environment-gated codepath and the `os`/`logging` imports it required have been removed. (#240)
+
+### Changed
+
+- README banner across all locales (`README.md`, `README.ko.md`, `README.ja.md`, `README.zh-CN.md`) now says **Alpha Notice** to match the existing `Development Status :: 3 - Alpha` classifier in `pyproject.toml`. Documentation now explicitly points at the classifier as the source of truth for maturity. (#242)
+- `docs/{security,production-guide,configuration,faq,installation}.md` updated to reflect the FUNCTION default and the ANONYMOUS opt-in warning.
+- `examples/openapi_bridge`, `examples/platform_compat_sdk`, `examples/sqlite_checkpoint_local`, `examples/persistent_agent_blob_table` now include inline comments explaining the ANONYMOUS opt-in and its unconditional warning.
+
+### Migration
+
+```python
+# Before (implicit ANONYMOUS default — no auth required)
+app = LangGraphApp()
+
+# After (implicit FUNCTION default — function key required)
+app = LangGraphApp()
+
+# To preserve the old behavior explicitly (emits UserWarning):
+app = LangGraphApp(auth_level=func.AuthLevel.ANONYMOUS)
+```
+
 ## 0.5.0 (2026-04-07)
 
 ### Breaking Changes

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -13,13 +13,13 @@ import azure.functions as func
 
 from azure_functions_langgraph import LangGraphApp
 
-# Default: anonymous (no authentication required)
+# Default: FUNCTION (requires an Azure Functions key on every request)
 app = LangGraphApp()
 
-# Require function key
-app = LangGraphApp(auth_level=func.AuthLevel.FUNCTION)
+# Public / local-dev only — emits UserWarning
+app = LangGraphApp(auth_level=func.AuthLevel.ANONYMOUS)
 
-# Require admin key
+# Require admin (host master) key
 app = LangGraphApp(auth_level=func.AuthLevel.ADMIN)
 ```
 
@@ -27,8 +27,8 @@ Available levels:
 
 | Level | Description |
 |-------|-------------|
-| `ANONYMOUS` | No authentication (default) |
-| `FUNCTION` | Requires a function-specific API key |
+| `ANONYMOUS` | No authentication (emits `UserWarning` when opted-in) |
+| `FUNCTION` | Requires a function-specific API key (**default**) |
 | `ADMIN` | Requires the master host key |
 
 ## Graph registration

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -64,14 +64,14 @@ This creates:
 
 `LangGraphApp` supports Azure Functions authentication levels:
 
-- `AuthLevel.ANONYMOUS` (default) — no authentication
-- `AuthLevel.FUNCTION` — requires function key
+- `AuthLevel.ANONYMOUS` — no authentication (emits `UserWarning` when opted-in at app level)
+- `AuthLevel.FUNCTION` (default) — requires function key
 - `AuthLevel.ADMIN` — requires master key
 
 ```python
 import azure.functions as func
 
-app = LangGraphApp(auth_level=func.AuthLevel.FUNCTION)
+app = LangGraphApp()  # FUNCTION is the default
 ```
 
 ## How is this different from LangGraph Platform?

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -64,5 +64,5 @@ from azure_functions_langgraph import LangGraphApp
 
 app = LangGraphApp()
 print(app)
-# LangGraphApp(auth_level=<AuthLevel.ANONYMOUS: 'anonymous'>)
+# LangGraphApp(auth_level=<AuthLevel.FUNCTION: 'function'>, health_auth_level=<AuthLevel.ANONYMOUS: 'anonymous'>, ...)
 ```

--- a/docs/production-guide.md
+++ b/docs/production-guide.md
@@ -5,29 +5,36 @@ This guide focuses on production hardening for `azure-functions-langgraph` deplo
 ## Authentication & Authorization
 ### Default auth behavior
 
-`LangGraphApp` defaults to anonymous HTTP access:
+`LangGraphApp` defaults to function-key HTTP access:
 
 ```python
 # src/azure_functions_langgraph/app.py
-auth_level: func.AuthLevel = func.AuthLevel.ANONYMOUS
+auth_level: func.AuthLevel = func.AuthLevel.FUNCTION
 ```
 
-In production environments, this default is intentionally noisy.
-When `AZURE_FUNCTIONS_ENVIRONMENT` is set and `auth_level` remains anonymous,
-the app logs a warning at startup (`app.py`, `__post_init__`, around lines 98-104).
+This default is intentionally secure: deploying a `LangGraphApp()` without any auth configuration will require a function key on every request.
+
+If you opt into `ANONYMOUS` at the app level, the library emits an unconditional `UserWarning` at construction time (regardless of environment). This ensures the choice is always visible in test output, CI logs, and startup output.
+
+```python
+# Opting into anonymous access (e.g. local dev) emits UserWarning:
+# UserWarning: LangGraphApp is using ANONYMOUS auth. ...
+app = LangGraphApp(auth_level=func.AuthLevel.ANONYMOUS)
+```
 
 ⚠️ `ANONYMOUS` is convenient for local development but too permissive for internet-facing production APIs.
 
 ### Set a production-safe app-level auth level
 
-Use `FUNCTION` (recommended baseline) or `ADMIN` (only for tightly controlled internal surfaces).
+`FUNCTION` is the default (recommended baseline). Use `ADMIN` only for tightly controlled internal surfaces.
 
 ```python
 import azure.functions as func
 
 from azure_functions_langgraph import LangGraphApp
 
-app = LangGraphApp(auth_level=func.AuthLevel.FUNCTION)
+app = LangGraphApp()                                        # default: FUNCTION
+app = LangGraphApp(auth_level=func.AuthLevel.ADMIN)          # only if truly internal
 ```
 
 ### Per-graph auth override

--- a/docs/security.md
+++ b/docs/security.md
@@ -2,15 +2,23 @@
 
 ## Authentication
 
-By default, `LangGraphApp` creates endpoints with `AuthLevel.ANONYMOUS`. For production deployments, consider setting a higher auth level:
+By default, `LangGraphApp` creates endpoints with `AuthLevel.FUNCTION`, requiring an Azure Functions key on every request. This is the recommended baseline for production deployments:
 
 ```python
 import azure.functions as func
 
 from azure_functions_langgraph import LangGraphApp
 
-app = LangGraphApp(auth_level=func.AuthLevel.FUNCTION)
+app = LangGraphApp()  # default: AuthLevel.FUNCTION
 ```
+
+For local development or explicitly public surfaces, opt in to `ANONYMOUS`. Doing so emits an unconditional `UserWarning` on app construction:
+
+```python
+app = LangGraphApp(auth_level=func.AuthLevel.ANONYMOUS)  # emits UserWarning
+```
+
+> The health endpoint is controlled separately via `health_auth_level`, which defaults to `ANONYMOUS` (the conventional choice for liveness/readiness probes).
 
 See [Azure Functions authentication](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-http-webhook-trigger#authorization-keys) for details on function keys and admin keys.
 

--- a/examples/openapi_bridge/function_app.py
+++ b/examples/openapi_bridge/function_app.py
@@ -5,6 +5,9 @@ import azure.functions as func
 from azure_functions_langgraph import LangGraphApp
 from azure_functions_langgraph.openapi import register_with_openapi
 
+# Local-dev example: opt into ANONYMOUS to avoid needing a function key.
+# This emits an unconditional UserWarning at construction time; that is expected.
+# Production: drop the `auth_level=` kwarg to use the FUNCTION default.
 langgraph_app = LangGraphApp(auth_level=func.AuthLevel.ANONYMOUS)
 langgraph_app.register(
     graph=compiled_graph,

--- a/examples/persistent_agent_blob_table/function_app.py
+++ b/examples/persistent_agent_blob_table/function_app.py
@@ -29,7 +29,9 @@ compiled_graph = build_graph().compile(checkpointer=checkpointer)
 
 langgraph_app = LangGraphApp(
     platform_compat=True,
-    # Local dev: ANONYMOUS; use FUNCTION + health_auth_level=FUNCTION in production
+    # Local dev opt-in to ANONYMOUS — emits an unconditional UserWarning.
+    # Production: drop this kwarg to use the FUNCTION default; set
+    # `health_auth_level=func.AuthLevel.FUNCTION` too if you want to protect /health.
     auth_level=func.AuthLevel.ANONYMOUS,
 )
 langgraph_app.thread_store = thread_store

--- a/examples/platform_compat_sdk/README.md
+++ b/examples/platform_compat_sdk/README.md
@@ -46,6 +46,6 @@ curl -s -X POST http://localhost:7071/api/runs/wait \
 
 ## Production notes
 
-- `LangGraphApp` defaults to `AuthLevel.ANONYMOUS` for local convenience. For production, set `auth_level=func.AuthLevel.FUNCTION` and pass `?code=<FUNCTION_KEY>` on every request.
+- `LangGraphApp` now defaults to `AuthLevel.FUNCTION`. This example opts into `AuthLevel.ANONYMOUS` for local convenience, which emits an unconditional `UserWarning`. For production, drop the `auth_level=` kwarg (uses the FUNCTION default) and pass `?code=<FUNCTION_KEY>` on every request.
 - The platform-compatible endpoints share the same buffered-SSE behavior as the native `/stream` endpoint — see [docs/production-guide.md](../../docs/production-guide.md#streaming-behavior).
 - See [COMPATIBILITY.md](../../COMPATIBILITY.md) for the per-feature SDK matrix and which `RunCreate` fields return `501 Not Implemented`.

--- a/examples/platform_compat_sdk/function_app.py
+++ b/examples/platform_compat_sdk/function_app.py
@@ -6,6 +6,8 @@ from azure_functions_langgraph import LangGraphApp
 
 langgraph_app = LangGraphApp(
     platform_compat=True,
+    # Local-dev opt-in to ANONYMOUS: emits an unconditional UserWarning.
+    # For production, drop this kwarg to use the FUNCTION default.
     auth_level=func.AuthLevel.ANONYMOUS,
 )
 langgraph_app.register(

--- a/examples/sqlite_checkpoint_local/function_app.py
+++ b/examples/sqlite_checkpoint_local/function_app.py
@@ -17,6 +17,8 @@ compiled_graph = build_graph().compile(checkpointer=checkpointer)
 
 langgraph_app = LangGraphApp(
     platform_compat=True,
+    # Local-dev opt-in to ANONYMOUS: emits an unconditional UserWarning.
+    # For production, drop this kwarg to use the FUNCTION default.
     auth_level=func.AuthLevel.ANONYMOUS,
 )
 langgraph_app.register(

--- a/src/azure_functions_langgraph/app.py
+++ b/src/azure_functions_langgraph/app.py
@@ -3,10 +3,9 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-import logging
-import os
 from types import MappingProxyType
 from typing import Any, Callable, Optional
+import warnings
 
 import azure.functions as func
 
@@ -33,9 +32,6 @@ _ROUTE_HEALTH = "health"
 _ROUTE_INVOKE = "graphs/{name}/invoke"
 _ROUTE_STREAM = "graphs/{name}/stream"
 _ROUTE_STATE = "graphs/{name}/threads/{{thread_id}}/state"
-
-logger = logging.getLogger(__name__)
-
 _TOOLKIT_META_ATTR = "_azure_functions_metadata"
 
 
@@ -96,11 +92,13 @@ class LangGraphApp:
         Python HTTP streaming stabilises.
 
     Note:
-        The default ``auth_level`` is ``ANONYMOUS`` for local development
-        convenience. This will change to ``FUNCTION`` in v1.0. For production
-        deployments, always pass ``auth_level`` explicitly.
+        The default ``auth_level`` is :attr:`~azure.functions.AuthLevel.FUNCTION`,
+        so deployed endpoints require a function key by default. Pass
+        ``auth_level=func.AuthLevel.ANONYMOUS`` explicitly for public access
+        (e.g. local development); doing so emits an unconditional ``UserWarning``.
         The ``health_auth_level`` parameter controls the auth level of the health
-        endpoint independently and defaults to ``ANONYMOUS`` for convenience.
+        endpoint independently and defaults to :attr:`~azure.functions.AuthLevel.ANONYMOUS`,
+        which is the conventional choice for liveness/readiness probes.
 
     Note:
         Per-thread locking on the native invoke/stream endpoints is
@@ -111,7 +109,7 @@ class LangGraphApp:
         which provides ETag-based atomic locking.
     """
 
-    auth_level: func.AuthLevel = func.AuthLevel.ANONYMOUS
+    auth_level: func.AuthLevel = func.AuthLevel.FUNCTION
     health_auth_level: func.AuthLevel = func.AuthLevel.ANONYMOUS
     max_stream_response_bytes: int = 1024 * 1024
     max_request_body_bytes: int = 1024 * 1024
@@ -124,16 +122,15 @@ class LangGraphApp:
     _thread_store: Any = field(default=None, init=False, repr=False)
 
     def __post_init__(self) -> None:
-        if self.auth_level == func.AuthLevel.ANONYMOUS and os.environ.get(
-            "AZURE_FUNCTIONS_ENVIRONMENT"
-        ):
-            logger.warning(
-                "LangGraphApp is using ANONYMOUS auth in an Azure environment. "
-                "Endpoints are publicly accessible without authentication.\n"
+        if self.auth_level == func.AuthLevel.ANONYMOUS:
+            warnings.warn(
+                "LangGraphApp is using ANONYMOUS auth. Endpoints are publicly "
+                "accessible without authentication.\n"
                 "  Recommended: LangGraphApp(auth_level=func.AuthLevel.FUNCTION)\n"
                 "  Per-graph:   app.register(..., auth_level=func.AuthLevel.FUNCTION)\n"
-                "  See the 'Production authentication' section in README.md\n"
-                "Note: The default will change from ANONYMOUS to FUNCTION in v1.0."
+                "  See the 'Production authentication' section in README.md",
+                UserWarning,
+                stacklevel=2,
             )
         # Normalize route_prefix: ensure leading slash, strip trailing slashes
         if not self.route_prefix.startswith("/"):

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -6,6 +6,7 @@ import dataclasses
 import json
 from typing import Any
 from unittest.mock import MagicMock
+import warnings
 
 import azure.functions as func
 import pytest
@@ -27,40 +28,35 @@ from tests.conftest import (
 
 
 class TestRegistration:
-    def test_warns_for_anonymous_auth_level(
-        self,
-        caplog: pytest.LogCaptureFixture,
-        monkeypatch: pytest.MonkeyPatch,
+    def test_default_auth_level_is_function(self) -> None:
+        """Default auth_level is FUNCTION so deployed endpoints require a function key."""
+        app = LangGraphApp()
+        assert app.auth_level == func.AuthLevel.FUNCTION
+
+    def test_warns_for_anonymous_auth_level(self) -> None:
+        """Passing auth_level=ANONYMOUS emits an unconditional UserWarning."""
+        with pytest.warns(UserWarning, match="ANONYMOUS auth") as record:
+            app = LangGraphApp(auth_level=func.AuthLevel.ANONYMOUS)
+        assert app.auth_level == func.AuthLevel.ANONYMOUS
+        # Message points users at the recommended remediation.
+        message = str(record[0].message)
+        assert "LangGraphApp(auth_level=func.AuthLevel.FUNCTION)" in message
+        assert "Production authentication" in message
+
+    def test_warns_anonymous_regardless_of_env(
+        self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        with caplog.at_level("WARNING"):
-            monkeypatch.setenv("AZURE_FUNCTIONS_ENVIRONMENT", "Production")
+        """Warning must fire even outside an Azure Functions environment."""
+        monkeypatch.delenv("AZURE_FUNCTIONS_ENVIRONMENT", raising=False)
+        with pytest.warns(UserWarning, match="ANONYMOUS auth"):
+            LangGraphApp(auth_level=func.AuthLevel.ANONYMOUS)
+
+    def test_no_warning_for_function_auth_level(self) -> None:
+        """Passing (or defaulting to) FUNCTION does not emit a UserWarning."""
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")  # any warning becomes a test failure
             LangGraphApp()
-
-        assert "ANONYMOUS auth" in caplog.text
-        assert "LangGraphApp(auth_level=func.AuthLevel.FUNCTION)" in caplog.text
-        assert "v1.0" in caplog.text
-
-    def test_no_warning_for_function_auth_level(
-        self,
-        caplog: pytest.LogCaptureFixture,
-        monkeypatch: pytest.MonkeyPatch,
-    ) -> None:
-        with caplog.at_level("WARNING"):
-            monkeypatch.setenv("AZURE_FUNCTIONS_ENVIRONMENT", "Production")
             LangGraphApp(auth_level=func.AuthLevel.FUNCTION)
-
-        assert "anonymous HTTP auth" not in caplog.text
-
-    def test_no_warning_without_azure_env(
-        self,
-        caplog: pytest.LogCaptureFixture,
-        monkeypatch: pytest.MonkeyPatch,
-    ) -> None:
-        with caplog.at_level("WARNING"):
-            monkeypatch.delenv("AZURE_FUNCTIONS_ENVIRONMENT", raising=False)
-            LangGraphApp()
-
-        assert "anonymous HTTP auth" not in caplog.text
 
     def test_register_single_graph(self, fake_graph: FakeCompiledGraph) -> None:
         app = LangGraphApp()
@@ -865,7 +861,8 @@ class TestRegisterWithFunctionAuth:
 
     def test_register_with_function_auth_level(self) -> None:
         """Register should accept and preserve auth_level=FUNCTION."""
-        app = LangGraphApp(auth_level=func.AuthLevel.ANONYMOUS)
+        with pytest.warns(UserWarning, match="ANONYMOUS auth"):
+            app = LangGraphApp(auth_level=func.AuthLevel.ANONYMOUS)
         app.register(graph=FakeCompiledGraph(), name="secure", auth_level=func.AuthLevel.FUNCTION)
 
         reg = app._registrations["secure"]


### PR DESCRIPTION
Closes #240
Closes #242

## Priority: P1 (auth default flip), P2 (maturity alignment)

## Context

Ships together as a coherent "secure-by-default + honest-about-maturity" pair:

- **#240 (P1 auth flip)** — Pre-v1.0 `LangGraphApp` defaulted to `AuthLevel.ANONYMOUS`, so a developer who runs `func start` locally and then deploys the same code accidentally publishes an unauthenticated agent surface. The environment-gated warning (`AZURE_FUNCTIONS_ENVIRONMENT`) only fired inside Azure, so the risk was invisible during dev/CI. This PR flips the default to `AuthLevel.FUNCTION` and makes the ANONYMOUS opt-in warning **unconditional** so the choice is loud in every environment.

- **#242 (P2 maturity alignment)** — `pyproject.toml` already carries `Development Status :: 3 - Alpha`. The README banner said "Beta Notice", which contradicted the classifier and understated the maturity risk to consumers. This PR renames the banner to "Alpha Notice" across all four locales and explicitly points at the classifier as the source of truth.

## Breaking Changes

- `LangGraphApp(auth_level=...)` now defaults to `AuthLevel.FUNCTION`. Existing code that relied on the ANONYMOUS default must pass `auth_level=func.AuthLevel.ANONYMOUS` explicitly to preserve the old behavior.
- Opting into `AuthLevel.ANONYMOUS` at the app level now emits an **unconditional** `UserWarning` (previously only when `AZURE_FUNCTIONS_ENVIRONMENT` was set). Tests calling `LangGraphApp(auth_level=func.AuthLevel.ANONYMOUS)` will now see this warning unless they wrap it in `pytest.warns(UserWarning, ...)` or filter it.

## Migration

```python
# Before (implicit ANONYMOUS default — no auth required)
app = LangGraphApp()

# After (implicit FUNCTION default — function key required)
app = LangGraphApp()

# To preserve the old behavior explicitly (emits UserWarning):
app = LangGraphApp(auth_level=func.AuthLevel.ANONYMOUS)
```

## What Changed

**Code**
- `src/azure_functions_langgraph/app.py`:
  - `auth_level` default: `ANONYMOUS` → `FUNCTION`
  - `health_auth_level` default: unchanged (`ANONYMOUS`, the conventional choice for liveness/readiness probes; documented)
  - `__post_init__` now emits an unconditional `UserWarning` via `warnings.warn(..., UserWarning, stacklevel=2)`
  - Removed now-unused `os` and `logging` imports (the only consumers were the env-gated warning path)

**Tests**
- `tests/test_app.py`: replaced anonymous-default assertions with four warning-focused tests:
  - `test_default_auth_level_is_function` — asserts the new default
  - `test_warns_for_anonymous_auth_level` — asserts warning text and remediation
  - `test_warns_anonymous_regardless_of_env` — proves warning is unconditional (`monkeypatch.delenv`)
  - `test_no_warning_for_function_auth_level` — uses `warnings.catch_warnings() + simplefilter("error")` to fail on any warning
- `TestRegisterWithFunctionAuth.test_register_with_function_auth_level` wrapped in `pytest.warns(UserWarning)` where it constructs an ANONYMOUS-level app

**Docs**
- README (`README.md` + `README.ko.md` + `README.ja.md` + `README.zh-CN.md`):
  - "Beta Notice" → "Alpha Notice" (points at `Development Status :: 3 - Alpha` classifier as source of truth)
  - Quick Start uses the FUNCTION default (`LangGraphApp()`)
  - "Production authentication" section flipped to describe the ANONYMOUS opt-in and its unconditional warning
- `docs/security.md`, `docs/production-guide.md`, `docs/configuration.md`, `docs/faq.md`, `docs/installation.md` — updated default references, removed the env-gated warning explanation
- `docs/changelog.md` — new `## Unreleased` section with `### Breaking Changes`, `### Changed`, and `### Migration` blocks

**Examples**
- `examples/openapi_bridge/function_app.py`
- `examples/platform_compat_sdk/function_app.py` (+ `README.md`)
- `examples/sqlite_checkpoint_local/function_app.py`
- `examples/persistent_agent_blob_table/function_app.py`

Each ANONYMOUS-opt-in example now carries an inline comment explaining why they see a UserWarning and how to drop the kwarg for production. Production examples (`production_auth`, `postgres_checkpoint_production`, `managed_identity_storage`, `cosmos_checkpoint_azure`) were already using `FUNCTION` and needed no changes.

## Validation

- `hatch run pytest --cov` — **767 passed, 6 skipped**; coverage **95.12%** (above the 95% AGENTS.md threshold)
- `hatch run lint` — All checks passed (2 fixable import-ordering issues auto-fixed via `ruff check --fix`)
- `hatch run typecheck` — no issues found in 51 source files
- `hatch build` — sdist + wheel built successfully

## Out of scope

- `health_auth_level` default (stays `ANONYMOUS`; conventional for liveness/readiness probes; documented in Quick Start Note block)
- Per-graph override semantics via `app.register(..., auth_level=...)` — unchanged
- Pluggable distributed thread lock (tracked separately by #241)