### PR TITLE
chore(ci): pin action-gh-release to commit SHA and document policy

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
         run: git-cliff --latest --strip header -o RELEASE_NOTES.md
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3.0.1
         with:
           body_path: RELEASE_NOTES.md
           prerelease: ${{ contains(github.ref_name, 'alpha') || contains(github.ref_name, 'beta') || contains(github.ref_name, 'rc') }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,6 +49,64 @@ it on push or pull_request: it runs nightly on a schedule and on manual
 `workflow_dispatch`. Contributors touching Cosmos code should run
 `make test-cosmos` locally before merging.
 
+## GitHub Actions Pinning
+
+All external `uses:` references in `.github/workflows/` MUST pin to a
+full 40-character commit SHA with a trailing comment documenting the
+released version or channel. Example:
+
+```yaml
+- uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+```
+
+This applies to first-party (`actions/*`, `github/*`, `azure/*`) and
+third-party Actions alike.
+
+**Rationale.** Mutable tags (including immutable-looking version tags
+like `@v6.0.1`) can be retroactively moved by an attacker who gains
+write access to the upstream repository. The
+[`tj-actions/changed-files` compromise (CVE-2025-30066, March 2025)](https://www.cisa.gov/news-events/alerts/2025/03/18/supply-chain-compromise-third-party-tj-actionschanged-files-cve-2025-30066)
+demonstrated this exact failure mode: ~23,000 repositories had their CI
+secrets exfiltrated, and only workflows that pinned to a commit SHA were
+safe. GitHub's own guidance now identifies SHA pinning as
+[the only way to use an Action as an immutable release](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions),
+and OpenSSF Scorecard's
+[`Pinned-Dependencies` check](https://github.com/ossf/scorecard/blob/main/docs/checks.md#pinned-dependencies)
+flags anything weaker as Medium-risk.
+
+Dependabot updates SHA-pinned references on the configured schedule and
+keeps the trailing version comment in sync, so the human-readable
+context never drifts from the pinned commit.
+
+**Approved exceptions.** The following mutable refs are the only ones
+permitted in this repository and are flagged with an inline comment at
+the call site:
+
+- `pypa/gh-action-pypi-publish@release/v1` — PyPA-maintained stable
+  release channel; this pinning style is explicitly recommended upstream.
+- Local composite actions (`uses: ./...`) — versioned with the repo.
+
+When adding a new external Action, resolve the SHA with
+`git ls-remote <repo-url> 'refs/tags/<tag>^{}'`. The trailing `^{}`
+**dereferences** the ref to its target commit; without it, an
+*annotated* tag returns the tag-object SHA instead of the commit SHA,
+and the tag-object SHA is **not** a valid `uses:` target.
+
+```bash
+# Annotated tag — the two forms return *different* SHAs:
+git ls-remote https://github.com/Azure/login 'refs/tags/v3.0.0' 'refs/tags/v3.0.0^{}'
+# 93381592...   refs/tags/v3.0.0       <- tag object, do NOT pin to this
+# 532459ea...   refs/tags/v3.0.0^{}    <- commit, pin to this one
+
+# Lightweight tag — only the non-deref form returns a row, and it is
+# already the commit SHA. Always include the `^{}` form anyway so the
+# same command works for both tag types:
+git ls-remote https://github.com/actions/setup-python 'refs/tags/v6' 'refs/tags/v6^{}'
+```
+
+Single-quote the `refs/...^{}` argument so the `{}` and `^` are not
+interpreted by your shell (notably zsh with `EXTENDED_GLOB`).
+
 ## Example Coverage Policy
 
 Examples are part of the supported API experience and should stay verified.


### PR DESCRIPTION
## Summary
Pins the previously-unpinned action ref in `.github/workflows/release.yml` to a full commit SHA, and adds the canonical `## GitHub Actions Pinning` section to `CONTRIBUTING.md`, standardizing this repo with the sibling repos in the Azure Functions Python DX Toolkit.

## Changes
- Add `## GitHub Actions Pinning` section to `CONTRIBUTING.md` (58 lines)
- Pin 1 action ref in `.github/workflows/release.yml` to a commit SHA with trailing version comment:
  - `softprops/action-gh-release@v3` → `718ea10b132b3b2eba29c1007bb80653f286566b # v3.0.1`

## Rationale
See the new CONTRIBUTING.md section for full context:

- **`tj-actions/changed-files` (CVE-2025-30066, March 2025)** — ~23,000 repositories had CI secrets exfiltrated because they pinned to a mutable tag; only SHA-pinned workflows were safe.
- **GitHub's own guidance** — SHA pinning is the only supported way to use an Action as an immutable release.
- **OpenSSF Scorecard** — `Pinned-Dependencies` check flags anything weaker as Medium-risk.

## Test Plan
- [x] CONTRIBUTING.md renders correctly on GitHub
- [x] SHA verified via `git ls-remote https://github.com/softprops/action-gh-release 'refs/tags/v3.0.1^{}'` → `718ea10b132b3b2eba29c1007bb80653f286566b`
- [x] Dependabot config unchanged (updates trailing version comments in place)

Closes #245
