### PR TITLE
docs(locks): warn that AzureBlobLeaseThreadLock does not renew Azure Blob leases

### DIFF
--- a/docs/production-guide.md
+++ b/docs/production-guide.md
@@ -286,6 +286,8 @@ The native invoke/stream endpoints (`POST /api/graphs/{name}/invoke` and `.../st
 
 For multi-instance deployments, `LangGraphApp` accepts any object satisfying the [`ThreadLock`](https://github.com/yeongseon/azure-functions-langgraph-python/blob/main/src/azure_functions_langgraph/locks/base.py) protocol via the `thread_lock` constructor argument. The package ships one distributed implementation — `AzureBlobLeaseThreadLock` — which uses **Azure Blob lease compare-and-swap** as the underlying primitive; leases naturally expire (15–60 s) so a crashed host cannot orphan a lock indefinitely.
 
+> ⚠️ **Non-renewal caveat.** `AzureBlobLeaseThreadLock` does **not** renew leases in the background. If graph execution exceeds `lease_duration` seconds, the lease silently expires mid-execution and another instance can acquire the same lock, allowing concurrent writes to single-writer checkpointers. Pass `lease_duration=-1` (infinite) whenever graph execution can exceed 60 seconds (the maximum finite lease Azure allows). Construction emits a `UserWarning` for finite `lease_duration` so the trade-off is visible in test and CI output. Auto-renewal is tracked as a future enhancement.
+
 ```python
 import azure.functions as func
 from azure.identity import DefaultAzureCredential
@@ -318,7 +320,7 @@ The Blob backend needs `Storage Blob Data Contributor` on the lock container (or
 | Backend | Distributed? | Infra required | Failure mode | Use case |
 | --- | --- | --- | --- | --- |
 | `InProcessThreadLock` (default) | No | None | Lock lost on worker restart; racing instances get separate locks | Local dev, single-instance production |
-| `AzureBlobLeaseThreadLock` | Yes — Azure Blob lease CAS | One Blob container | Lease expiry (15–60 s) reclaims locks after host crash | Multi-instance (Consumption / Elastic Premium) |
+| `AzureBlobLeaseThreadLock` | Yes — Azure Blob lease CAS | One Blob container | Lease expiry (15–60 s) reclaims locks after host crash; **no background renewal**, so finite leases cap safe graph runtime | Multi-instance (Consumption / Elastic Premium); prefer `lease_duration=-1` for long executions |
 | Custom `ThreadLock` implementation | Yours to design | Yours to provision | Yours to reason about | Redis, Cosmos DB, Postgres advisory locks, etc. |
 
 **Safety guard — `AZFUNC_LANGGRAPH_LOCK_BACKEND`.** In multi-instance environments, set this environment variable to `distributed` (or any non-empty value other than `inprocess`). When the value indicates a distributed backend is required and `thread_lock` resolves to the default `InProcessThreadLock`, `LangGraphApp.__post_init__` raises `RuntimeError` at construction — turning a silent-race deployment mistake into a fail-fast startup error. Set the value to `inprocess` (or leave it unset) in single-instance environments; the guard passes for any wired custom backend regardless of the environment value.

--- a/src/azure_functions_langgraph/locks/azure_blob.py
+++ b/src/azure_functions_langgraph/locks/azure_blob.py
@@ -10,9 +10,11 @@ Lease semantics recap (see the Azure Blob REST reference for details):
 * A blob can have at most one active lease at any time.
 * Leases can be finite (15-60 seconds) or infinite (``-1``).
 * Attempting to acquire a held lease returns ``409 LeaseAlreadyPresent``.
-* Leases auto-expire if not renewed. On expiry the lock is silently
-  released — pick ``lease_duration`` comfortably above your longest
-  expected graph execution time, or use ``-1`` and rely on
+* **This class never renews leases** — there is no background renewal
+  task. A finite lease that outlives its ``lease_duration`` silently
+  releases mid-execution and lets another instance acquire the same
+  lock, so pick ``lease_duration`` comfortably above your longest
+  expected graph execution time, or use ``-1`` (infinite) and rely on
   :meth:`release` running in the request ``finally`` block.
 """
 
@@ -24,6 +26,7 @@ import threading
 import time
 from typing import Any, Protocol, cast
 from urllib.parse import quote
+import warnings
 
 logger = logging.getLogger(__name__)
 
@@ -63,6 +66,17 @@ class AzureBlobLeaseThreadLock:
     same container as the ``AzureBlobCheckpointSaver`` is a natural fit but
     a dedicated container is fine too.
 
+    .. warning::
+        This class does **not** renew Azure Blob leases in the background.
+        If a graph execution exceeds ``lease_duration`` seconds (default 60,
+        the maximum finite value Azure allows), the lease silently expires
+        and another instance can acquire the same ``(graph_name, thread_id)``
+        lock, allowing concurrent writes to single-writer checkpointers.
+        Pass ``lease_duration=-1`` (infinite) whenever graph execution can
+        exceed 60 seconds. Construction emits a :class:`UserWarning` for
+        finite ``lease_duration`` to make the trade-off visible in test and
+        CI output. Auto-renewal is tracked as a future enhancement.
+
     Example:
         >>> from azure.storage.blob import ContainerClient
         >>> from azure_functions_langgraph import LangGraphApp
@@ -80,10 +94,17 @@ class AzureBlobLeaseThreadLock:
             already exist — this class never creates it (that decision
             belongs to app-level infrastructure code).
         lease_duration: Lease length in seconds. Must be 15-60 (finite) or
-            ``-1`` (infinite). Defaults to 60. Finite leases auto-expire if
-            :meth:`release` never runs (host crash, scale-in), which is the
-            recommended recovery mechanism; infinite leases require an
-            operator to break them manually.
+            ``-1`` (infinite). Defaults to 60. **Because this class does
+            not renew leases in the background**, a finite ``lease_duration``
+            bounds the maximum safe graph execution time — pick a value
+            comfortably above your longest expected execution or use ``-1``
+            (infinite). Finite leases also auto-expire on the service if
+            :meth:`release` never runs (host crash, scale-in), giving you a
+            crash-recovery mechanism at the cost of the mid-execution race
+            above. Infinite leases require an operator to break them
+            manually when a host crashes. Construction emits a
+            :class:`UserWarning` for finite ``lease_duration`` to make the
+            trade-off visible in test and CI output.
         blob_prefix: Prefix applied to every marker blob so lock blobs are
             visually grouped inside the container. Defaults to
             ``"thread-locks/"``.
@@ -158,6 +179,20 @@ class AzureBlobLeaseThreadLock:
         )
         self._active_leases: dict[tuple[str, str], _BlobLeaseClientProtocol] = {}
         self._active_leases_guard = threading.Lock()
+
+        if lease_duration != _LEASE_DURATION_INFINITE:
+            warnings.warn(
+                f"AzureBlobLeaseThreadLock(lease_duration={lease_duration}) is "
+                "finite and this class does not renew leases in the background. "
+                "If a graph execution exceeds lease_duration seconds, the lease "
+                "will silently expire mid-execution and another instance may "
+                "acquire the same (graph_name, thread_id) lock, allowing "
+                "concurrent writes to single-writer checkpointers. Pass "
+                "lease_duration=-1 (infinite) whenever graph execution can "
+                "exceed 60 seconds.",
+                UserWarning,
+                stacklevel=2,
+            )
 
     def _blob_name(self, graph_name: str, thread_id: str) -> str:
         """Return the URL-safe blob path for ``(graph_name, thread_id)``."""

--- a/tests/test_locks_azure_blob.py
+++ b/tests/test_locks_azure_blob.py
@@ -6,8 +6,13 @@ import sys
 import time
 import types
 from typing import Any, Callable
+import warnings
 
 import pytest
+
+pytestmark = pytest.mark.filterwarnings(
+    "ignore:.*does not renew leases in the background.*:UserWarning"
+)
 
 # ------------------------------------------------------------------
 # Fake azure.storage.blob + azure.core.exceptions used by the tests.
@@ -413,4 +418,60 @@ class TestErrorPropagation:
         lock = _make_lock()
         assert not lock._is_lease_conflict(
             FakeHttpResponseError(error_code="InternalError", status_code=500)
+        )
+
+
+
+# ------------------------------------------------------------------
+# Non-renewal warning
+# ------------------------------------------------------------------
+
+
+class TestFiniteLeaseWarning:
+    """AzureBlobLeaseThreadLock emits UserWarning for finite lease_duration."""
+
+    def test_default_lease_duration_emits_warning(self) -> None:
+        """Default finite lease_duration=60 emits UserWarning about non-renewal."""
+        with warnings.catch_warnings(record=True) as records:
+            warnings.simplefilter("always")
+            _make_lock()
+        matching = [
+            r
+            for r in records
+            if issubclass(r.category, UserWarning)
+            and "does not renew leases in the background" in str(r.message)
+        ]
+        assert matching, (
+            f"Expected finite-lease UserWarning; got {[str(r.message) for r in records]}"
+        )
+
+    def test_explicit_finite_lease_emits_warning(self) -> None:
+        """Explicit finite lease_duration=30 emits UserWarning naming the value."""
+        with warnings.catch_warnings(record=True) as records:
+            warnings.simplefilter("always")
+            _make_lock(lease_duration=30)
+        matching = [
+            r
+            for r in records
+            if issubclass(r.category, UserWarning)
+            and "lease_duration=30" in str(r.message)
+        ]
+        assert matching, (
+            f"Expected UserWarning naming lease_duration=30; "
+            f"got {[str(r.message) for r in records]}"
+        )
+
+    def test_infinite_lease_no_warning(self) -> None:
+        """Infinite lease_duration=-1 must not emit the non-renewal warning."""
+        with warnings.catch_warnings(record=True) as records:
+            warnings.simplefilter("always")
+            _make_lock(lease_duration=-1)
+        matching = [
+            r
+            for r in records
+            if issubclass(r.category, UserWarning)
+            and "does not renew leases in the background" in str(r.message)
+        ]
+        assert not matching, (
+            f"Infinite lease must not warn; got {[str(r.message) for r in matching]}"
         )


### PR DESCRIPTION
## Summary

`AzureBlobLeaseThreadLock` uses the Azure Blob lease API to coordinate a per-thread lock across Function App instances, but the class does **not** renew leases in the background. The class docstring framed lease auto-expiry as a crash-recovery mechanism, which is accurate for crashed hosts but silently misleading for long-running successful executions.

If a graph execution exceeds `lease_duration` seconds (default `60`, the max finite value Azure allows), the lease silently releases mid-execution and another Function App instance can acquire the same `(graph_name, thread_id)` lock, allowing concurrent writes to single-writer checkpointers — the exact race the lock is supposed to prevent.

Adding background renewal is a larger code change and is deferred to a follow-up. This PR implements the **"docs + warn now"** hardening.

## Changes

- **`src/azure_functions_langgraph/locks/azure_blob.py`**
  - Module docstring bullet: now states "This class never renews leases" and describes the mid-execution race.
  - Class docstring: new `.. warning::` callout describing the non-renewal trade-off and recommending `lease_duration=-1` for long executions.
  - `lease_duration` Args block: expanded to lead with "Because this class does not renew leases in the background".
  - `__init__`: emits `warnings.warn(..., UserWarning, stacklevel=2)` when `lease_duration != -1`, naming the actual value.
- **`tests/test_locks_azure_blob.py`**
  - Module-level `pytestmark = pytest.mark.filterwarnings("ignore:...:UserWarning")` so existing tests using the default finite lease stay clean.
  - New `TestFiniteLeaseWarning` class with 3 tests:
    - default finite lease emits the warning
    - explicit finite lease (`30`) emits the warning and names the value
    - infinite lease (`-1`) does not emit the warning
- **`docs/production-guide.md`**
  - "Distributed thread locking" section: new blockquote callout for the non-renewal caveat, recommending `lease_duration=-1` for long executions and mentioning the `UserWarning`.
  - Scale-out matrix: `AzureBlobLeaseThreadLock` row updated to note "no background renewal" and to recommend `lease_duration=-1` for long executions.

## Verification

- `make check-all` — 930 passed, 6 skipped (integration tests, expected). Coverage: **95.24%** (floor: 95%). Bandit: 0 issues.
- `azure_blob.py` file coverage: **96%**.

## Out of scope

- Background lease renewal implementation. Tracked as a follow-up.
- `README.md` polish — the class docstring plus `docs/production-guide.md` cover every user-facing surface.

Closes #247
