### PR TITLE
feat(locks): add background auto-renewal to AzureBlobLeaseThreadLock

### DIFF
--- a/docs/production-guide.md
+++ b/docs/production-guide.md
@@ -286,7 +286,7 @@ The native invoke/stream endpoints (`POST /api/graphs/{name}/invoke` and `.../st
 
 For multi-instance deployments, `LangGraphApp` accepts any object satisfying the [`ThreadLock`](https://github.com/yeongseon/azure-functions-langgraph-python/blob/main/src/azure_functions_langgraph/locks/base.py) protocol via the `thread_lock` constructor argument. The package ships one distributed implementation — `AzureBlobLeaseThreadLock` — which uses **Azure Blob lease compare-and-swap** as the underlying primitive; leases naturally expire (15–60 s) so a crashed host cannot orphan a lock indefinitely.
 
-> ⚠️ **Non-renewal caveat.** `AzureBlobLeaseThreadLock` does **not** renew leases in the background. If graph execution exceeds `lease_duration` seconds, the lease silently expires mid-execution and another instance can acquire the same lock, allowing concurrent writes to single-writer checkpointers. Pass `lease_duration=-1` (infinite) whenever graph execution can exceed 60 seconds (the maximum finite lease Azure allows). Construction emits a `UserWarning` for finite `lease_duration` so the trade-off is visible in test and CI output. Auto-renewal is tracked as a future enhancement.
+> ℹ️ **Background renewal.** `AzureBlobLeaseThreadLock` renews leases in the background by default: a per-instance daemon thread renews every active lease at `lease_duration / 3` intervals until `close()` (or process exit). Pass `auto_renew=False` to opt out — a finite lease then silently expires mid-execution as it did before renewal support, and construction emits a `UserWarning` so the trade-off is visible. Infinite leases (`lease_duration=-1`) never need renewal but must be broken manually if a host crashes.
 
 ```python
 import azure.functions as func
@@ -320,7 +320,7 @@ The Blob backend needs `Storage Blob Data Contributor` on the lock container (or
 | Backend | Distributed? | Infra required | Failure mode | Use case |
 | --- | --- | --- | --- | --- |
 | `InProcessThreadLock` (default) | No | None | Lock lost on worker restart; racing instances get separate locks | Local dev, single-instance production |
-| `AzureBlobLeaseThreadLock` | Yes — Azure Blob lease CAS | One Blob container | Lease expiry (15–60 s) reclaims locks after host crash; **no background renewal**, so finite leases cap safe graph runtime | Multi-instance (Consumption / Elastic Premium); prefer `lease_duration=-1` for long executions |
+| `AzureBlobLeaseThreadLock` | Yes — Azure Blob lease CAS | One Blob container | Lease expiry (15–60 s) reclaims locks after host crash; background daemon thread renews active leases every `lease_duration / 3` s by default, so finite leases do not cap execution time | Multi-instance (Consumption / Elastic Premium); default `lease_duration=60` fits most workloads |
 | Custom `ThreadLock` implementation | Yours to design | Yours to provision | Yours to reason about | Redis, Cosmos DB, Postgres advisory locks, etc. |
 
 **Safety guard — `AZFUNC_LANGGRAPH_LOCK_BACKEND`.** In multi-instance environments, set this environment variable to `distributed` (or any non-empty value other than `inprocess`). When the value indicates a distributed backend is required and `thread_lock` resolves to the default `InProcessThreadLock`, `LangGraphApp.__post_init__` raises `RuntimeError` at construction — turning a silent-race deployment mistake into a fail-fast startup error. Set the value to `inprocess` (or leave it unset) in single-instance environments; the guard passes for any wired custom backend regardless of the environment value.

--- a/src/azure_functions_langgraph/locks/azure_blob.py
+++ b/src/azure_functions_langgraph/locks/azure_blob.py
@@ -10,12 +10,16 @@ Lease semantics recap (see the Azure Blob REST reference for details):
 * A blob can have at most one active lease at any time.
 * Leases can be finite (15-60 seconds) or infinite (``-1``).
 * Attempting to acquire a held lease returns ``409 LeaseAlreadyPresent``.
-* **This class never renews leases** — there is no background renewal
-  task. A finite lease that outlives its ``lease_duration`` silently
-  releases mid-execution and lets another instance acquire the same
-  lock, so pick ``lease_duration`` comfortably above your longest
-  expected graph execution time, or use ``-1`` (infinite) and rely on
-  :meth:`release` running in the request ``finally`` block.
+* This class renews leases in the background by default: a per-instance
+  daemon thread renews every active lease at ``lease_duration / 3``
+  intervals until :meth:`close` (or process exit). Pass
+  ``auto_renew=False`` to opt out — a finite lease then behaves as it
+  did before renewal support: it silently expires mid-execution and
+  lets another instance acquire the same ``(graph_name, thread_id)``
+  lock, and construction emits a :class:`UserWarning` to make the
+  trade-off visible.
+* Infinite leases (``lease_duration=-1``) never need renewal but must
+  be broken manually if a host crashes.
 """
 
 from __future__ import annotations
@@ -33,6 +37,7 @@ logger = logging.getLogger(__name__)
 
 class _BlobLeaseClientProtocol(Protocol):
     def release(self) -> None: ...
+    def renew(self) -> None: ...
 
 
 class _BlobClientProtocol(Protocol):
@@ -56,6 +61,14 @@ _LEASE_DURATION_INFINITE = -1
 _POLL_INTERVAL_MIN = 0.05
 _POLL_INTERVAL_MAX = 0.5
 
+# Renewal cadence: renew each active lease this fraction of lease_duration
+# before expiry. 1/3 leaves two full retries per lease lifetime if a single
+# renewal call fails transiently.
+_LEASE_RENEWAL_FRACTION = 3
+# Deadline for join() when close() stops the renewal thread. Bounded so a
+# stuck Azure call cannot indefinitely block interpreter shutdown.
+_RENEWAL_SHUTDOWN_TIMEOUT = 5.0
+
 
 class AzureBlobLeaseThreadLock:
     """Distributed per-thread lock backed by Azure Blob leases.
@@ -67,15 +80,17 @@ class AzureBlobLeaseThreadLock:
     a dedicated container is fine too.
 
     .. warning::
-        This class does **not** renew Azure Blob leases in the background.
-        If a graph execution exceeds ``lease_duration`` seconds (default 60,
-        the maximum finite value Azure allows), the lease silently expires
-        and another instance can acquire the same ``(graph_name, thread_id)``
+        By default this class renews Azure Blob leases in the background
+        (a per-instance daemon thread renews every active lease at
+        ``lease_duration / 3`` intervals). Pass ``auto_renew=False`` to
+        opt out — construction then emits a :class:`UserWarning` because
+        a finite ``lease_duration`` can silently expire mid-execution and
+        let another instance acquire the same ``(graph_name, thread_id)``
         lock, allowing concurrent writes to single-writer checkpointers.
-        Pass ``lease_duration=-1`` (infinite) whenever graph execution can
-        exceed 60 seconds. Construction emits a :class:`UserWarning` for
-        finite ``lease_duration`` to make the trade-off visible in test and
-        CI output. Auto-renewal is tracked as a future enhancement.
+        Call :meth:`close` for graceful shutdown of the renewal thread
+        when the lock instance is no longer needed; Azure Functions
+        workers do not typically need this because the daemon thread
+        dies when the interpreter exits.
 
     Example:
         >>> from azure.storage.blob import ContainerClient
@@ -94,20 +109,27 @@ class AzureBlobLeaseThreadLock:
             already exist — this class never creates it (that decision
             belongs to app-level infrastructure code).
         lease_duration: Lease length in seconds. Must be 15-60 (finite) or
-            ``-1`` (infinite). Defaults to 60. **Because this class does
-            not renew leases in the background**, a finite ``lease_duration``
-            bounds the maximum safe graph execution time — pick a value
-            comfortably above your longest expected execution or use ``-1``
-            (infinite). Finite leases also auto-expire on the service if
-            :meth:`release` never runs (host crash, scale-in), giving you a
-            crash-recovery mechanism at the cost of the mid-execution race
-            above. Infinite leases require an operator to break them
-            manually when a host crashes. Construction emits a
-            :class:`UserWarning` for finite ``lease_duration`` to make the
-            trade-off visible in test and CI output.
+            ``-1`` (infinite). Defaults to 60. With ``auto_renew=True``
+            (the default), a background daemon thread renews every active
+            lease at ``lease_duration / 3`` intervals, so execution time
+            is no longer bounded by the lease. Set ``auto_renew=False``
+            to disable renewal — a finite lease then silently expires
+            mid-execution and lets another instance acquire the same
+            lock. Finite leases also auto-expire on the service if
+            :meth:`release` never runs (host crash, scale-in), giving you
+            a crash-recovery mechanism. Infinite leases require an
+            operator to break them manually when a host crashes.
         blob_prefix: Prefix applied to every marker blob so lock blobs are
             visually grouped inside the container. Defaults to
             ``"thread-locks/"``.
+        auto_renew: If ``True`` (default), start a per-instance daemon
+            thread that renews every active lease at
+            ``lease_duration / 3`` intervals until :meth:`close` (or
+            process exit). If ``False``, no renewal happens and
+            construction emits a :class:`UserWarning` when
+            ``lease_duration`` is finite, since finite leases will
+            silently expire mid-execution. Ignored for
+            ``lease_duration=-1`` (infinite leases are not renewable).
 
     Thread-safety:
         Safe for concurrent ``acquire`` / ``release`` calls from multiple
@@ -123,6 +145,7 @@ class AzureBlobLeaseThreadLock:
         container_client: _ContainerClientProtocol,
         lease_duration: int = _LEASE_DURATION_MAX,
         blob_prefix: str = "thread-locks/",
+        auto_renew: bool = True,
     ) -> None:
         if lease_duration != _LEASE_DURATION_INFINITE and not (
             _LEASE_DURATION_MIN <= lease_duration <= _LEASE_DURATION_MAX
@@ -180,19 +203,35 @@ class AzureBlobLeaseThreadLock:
         self._active_leases: dict[tuple[str, str], _BlobLeaseClientProtocol] = {}
         self._active_leases_guard = threading.Lock()
 
-        if lease_duration != _LEASE_DURATION_INFINITE:
+        self._auto_renew: bool = auto_renew and lease_duration != _LEASE_DURATION_INFINITE
+        self._closed: bool = False
+        self._shutdown_event: threading.Event = threading.Event()
+        self._renewal_thread: threading.Thread | None = None
+        self._renewal_interval: float = 0.0
+
+        if lease_duration != _LEASE_DURATION_INFINITE and not auto_renew:
             warnings.warn(
-                f"AzureBlobLeaseThreadLock(lease_duration={lease_duration}) is "
-                "finite and this class does not renew leases in the background. "
-                "If a graph execution exceeds lease_duration seconds, the lease "
-                "will silently expire mid-execution and another instance may "
-                "acquire the same (graph_name, thread_id) lock, allowing "
-                "concurrent writes to single-writer checkpointers. Pass "
-                "lease_duration=-1 (infinite) whenever graph execution can "
-                "exceed 60 seconds.",
+                f"AzureBlobLeaseThreadLock(lease_duration={lease_duration}, "
+                "auto_renew=False) is finite and auto-renewal is disabled. "
+                "If a graph execution exceeds lease_duration seconds, the "
+                "lease will silently expire mid-execution and another "
+                "instance may acquire the same (graph_name, thread_id) "
+                "lock, allowing concurrent writes to single-writer "
+                "checkpointers. Enable auto_renew=True (the default) or "
+                "pass lease_duration=-1 (infinite) whenever graph "
+                "execution can exceed 60 seconds.",
                 UserWarning,
                 stacklevel=2,
             )
+
+        if self._auto_renew:
+            self._renewal_interval = lease_duration / _LEASE_RENEWAL_FRACTION
+            self._renewal_thread = threading.Thread(
+                target=self._renewal_worker,
+                name=f"azblob-lease-renew-{id(self):x}",
+                daemon=True,
+            )
+            self._renewal_thread.start()
 
     def _blob_name(self, graph_name: str, thread_id: str) -> str:
         """Return the URL-safe blob path for ``(graph_name, thread_id)``."""
@@ -282,6 +321,74 @@ class AzureBlobLeaseThreadLock:
                 thread_id,
                 exc_info=True,
             )
+
+    def _renew_all_once(self) -> None:
+        """Renew every currently tracked lease exactly once.
+
+        Safe to call from any thread. On per-lease failure, logs a warning
+        and drops that lease from local tracking so :meth:`acquire` can
+        take a fresh lease later (and so a stale entry does not block the
+        local fast-path check indefinitely).
+        """
+        with self._active_leases_guard:
+            snapshot = list(self._active_leases.items())
+        for key, lease in snapshot:
+            try:
+                lease.renew()
+            except Exception:
+                logger.warning(
+                    "Failed to renew Azure Blob lease for %s/%s; dropping "
+                    "from local tracking. Another instance may now acquire "
+                    "this lock.",
+                    key[0],
+                    key[1],
+                    exc_info=True,
+                )
+                with self._active_leases_guard:
+                    # Only pop if this is still the same lease object; a
+                    # concurrent release() may have swapped it out.
+                    if self._active_leases.get(key) is lease:
+                        del self._active_leases[key]
+
+    def _renewal_worker(self) -> None:
+        """Daemon loop: call :meth:`_renew_all_once` every renewal interval."""
+        while not self._shutdown_event.wait(timeout=self._renewal_interval):
+            self._renew_all_once()
+
+    def close(self) -> None:
+        """Stop the renewal thread and release every active lease.
+
+        Idempotent and safe to call from any thread. After :meth:`close`,
+        further :meth:`acquire` calls still work but will not be
+        auto-renewed even if ``auto_renew=True`` was passed to the
+        constructor.
+        """
+        if self._closed:
+            return
+        self._closed = True
+        self._shutdown_event.set()
+        thread = self._renewal_thread
+        if thread is not None and thread.is_alive():
+            thread.join(timeout=_RENEWAL_SHUTDOWN_TIMEOUT)
+        with self._active_leases_guard:
+            remaining = list(self._active_leases.items())
+            self._active_leases.clear()
+        for key, lease in remaining:
+            try:
+                lease.release()
+            except Exception:
+                logger.debug(
+                    "Failed to release blob lease for %s/%s during close",
+                    key[0],
+                    key[1],
+                    exc_info=True,
+                )
+
+    def __del__(self) -> None:  # pragma: no cover - GC timing not deterministic
+        try:
+            self.close()
+        except Exception:  # nosec B110 - GC cleanup; nothing actionable if close() fails during interpreter shutdown
+            pass
 
     def _is_lease_conflict(self, exc: BaseException) -> bool:
         """Return True if *exc* is a lease-already-present conflict."""

--- a/tests/test_locks_azure_blob.py
+++ b/tests/test_locks_azure_blob.py
@@ -11,7 +11,7 @@ import warnings
 import pytest
 
 pytestmark = pytest.mark.filterwarnings(
-    "ignore:.*does not renew leases in the background.*:UserWarning"
+    "ignore:.*auto_renew=False.*:UserWarning"
 )
 
 # ------------------------------------------------------------------
@@ -44,10 +44,20 @@ class MockBlobLease:
     def __init__(self, blob: "MockBlobClient") -> None:
         self._blob = blob
         self.released = False
+        self.renew_count = 0
 
     def release(self) -> None:
         self.released = True
         self._blob._active_lease = None
+
+    def renew(self) -> None:
+        if self.released:
+            raise FakeHttpResponseError(
+                "LeaseIdMismatchWithLeaseOperation",
+                error_code="LeaseIdMismatchWithLeaseOperation",
+                status_code=409,
+            )
+        self.renew_count += 1
 
 
 class MockBlobClient:
@@ -428,50 +438,257 @@ class TestErrorPropagation:
 
 
 class TestFiniteLeaseWarning:
-    """AzureBlobLeaseThreadLock emits UserWarning for finite lease_duration."""
+    """AzureBlobLeaseThreadLock emits UserWarning only when auto_renew=False."""
 
-    def test_default_lease_duration_emits_warning(self) -> None:
-        """Default finite lease_duration=60 emits UserWarning about non-renewal."""
+    def test_default_finite_lease_no_warning(self) -> None:
+        """Default (auto_renew=True) suppresses the finite-lease warning."""
         with warnings.catch_warnings(record=True) as records:
             warnings.simplefilter("always")
-            _make_lock()
-        matching = [
-            r
-            for r in records
-            if issubclass(r.category, UserWarning)
-            and "does not renew leases in the background" in str(r.message)
-        ]
-        assert matching, (
-            f"Expected finite-lease UserWarning; got {[str(r.message) for r in records]}"
+            lock = _make_lock()
+        try:
+            matching = [
+                r
+                for r in records
+                if issubclass(r.category, UserWarning)
+                and "auto_renew=False" in str(r.message)
+            ]
+            assert not matching, (
+                "Default (auto_renew=True) must not warn; got "
+                f"{[str(r.message) for r in matching]}"
+            )
+        finally:
+            lock.close()
+
+    def test_finite_lease_with_auto_renew_false_warns(self) -> None:
+        """auto_renew=False with finite lease emits UserWarning naming the values."""
+        with warnings.catch_warnings(record=True) as records:
+            warnings.simplefilter("always")
+            lock = _make_lock(lease_duration=30, auto_renew=False)
+        try:
+            matching = [
+                r
+                for r in records
+                if issubclass(r.category, UserWarning)
+                and "lease_duration=30" in str(r.message)
+                and "auto_renew=False" in str(r.message)
+            ]
+            assert matching, (
+                "Expected UserWarning naming lease_duration=30 and "
+                f"auto_renew=False; got {[str(r.message) for r in records]}"
+            )
+        finally:
+            lock.close()
+
+    def test_infinite_lease_no_warning_regardless_of_auto_renew(self) -> None:
+        """Infinite lease never warns — auto-renewal is meaningless for -1."""
+        with warnings.catch_warnings(record=True) as records:
+            warnings.simplefilter("always")
+            lock_a = _make_lock(lease_duration=-1)
+            lock_b = _make_lock(lease_duration=-1, auto_renew=False)
+        try:
+            matching = [
+                r
+                for r in records
+                if issubclass(r.category, UserWarning)
+                and "auto_renew" in str(r.message)
+            ]
+            assert not matching, (
+                "Infinite lease must not warn; got "
+                f"{[str(r.message) for r in matching]}"
+            )
+        finally:
+            lock_a.close()
+            lock_b.close()
+
+
+# ------------------------------------------------------------------
+# Background auto-renewal
+# ------------------------------------------------------------------
+
+
+class TestAutoRenewal:
+    """Background auto-renewal for AzureBlobLeaseThreadLock."""
+
+    def test_renewal_thread_starts_by_default(self) -> None:
+        """Default construction with finite lease spawns a daemon thread."""
+        lock = _make_lock()
+        try:
+            assert lock._renewal_thread is not None
+            assert lock._renewal_thread.is_alive()
+            assert lock._renewal_thread.daemon
+            assert lock._auto_renew is True
+            assert lock._renewal_interval == 60 / 3
+        finally:
+            lock.close()
+
+    def test_no_renewal_thread_for_infinite_lease(self) -> None:
+        """Infinite lease_duration=-1 skips the renewal thread."""
+        lock = _make_lock(lease_duration=-1)
+        try:
+            assert lock._renewal_thread is None
+            assert lock._auto_renew is False
+        finally:
+            lock.close()
+
+    def test_no_renewal_thread_when_auto_renew_false(self) -> None:
+        """auto_renew=False skips the renewal thread and emits warning."""
+        with warnings.catch_warnings(record=True) as records:
+            warnings.simplefilter("always")
+            lock = _make_lock(lease_duration=30, auto_renew=False)
+        try:
+            assert lock._renewal_thread is None
+            assert lock._auto_renew is False
+            assert any(
+                issubclass(r.category, UserWarning)
+                and "auto_renew=False" in str(r.message)
+                for r in records
+            )
+        finally:
+            lock.close()
+
+    def test_renew_all_once_renews_every_active_lease(self) -> None:
+        """_renew_all_once() calls .renew() on every tracked lease exactly once."""
+        container = MockContainerClient()
+        lock = _make_lock(container, auto_renew=False)  # no background thread
+        try:
+            lock.acquire("graph", "t1")
+            lock.acquire("graph", "t2")
+            lease1 = lock._active_leases[("graph", "t1")]
+            lease2 = lock._active_leases[("graph", "t2")]
+            lock._renew_all_once()
+            assert lease1.renew_count == 1
+            assert lease2.renew_count == 1
+            lock._renew_all_once()
+            assert lease1.renew_count == 2
+            assert lease2.renew_count == 2
+        finally:
+            lock.close()
+
+    def test_renew_all_once_drops_lease_on_failure(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """When renew() raises, the lease is removed from _active_leases."""
+        container = MockContainerClient()
+        lock = _make_lock(container, auto_renew=False)
+        try:
+            lock.acquire("graph", "t1")
+            lease = lock._active_leases[("graph", "t1")]
+
+            def _raise() -> None:
+                raise RuntimeError("simulated renewal failure")
+
+            lease.renew = _raise
+
+            with caplog.at_level(
+                "WARNING", logger="azure_functions_langgraph.locks.azure_blob"
+            ):
+                lock._renew_all_once()
+
+            assert ("graph", "t1") not in lock._active_leases
+            assert any(
+                "Failed to renew Azure Blob lease" in rec.getMessage()
+                for rec in caplog.records
+            )
+        finally:
+            lock.close()
+
+    def test_renew_all_once_skips_stale_lease_on_failure(self) -> None:
+        """If lease is concurrently released after snapshot, no KeyError on cleanup."""
+        container = MockContainerClient()
+        lock = _make_lock(container, auto_renew=False)
+        try:
+            lock.acquire("graph", "t1")
+            lease = lock._active_leases[("graph", "t1")]
+
+            def _release_then_raise() -> None:
+                # Simulate a race: another thread releases the lock while we
+                # were mid-renew. When our failure handler re-locks, the dict
+                # entry is gone and the identity check must skip the del.
+                lock.release("graph", "t1")
+                raise RuntimeError("simulated failure after concurrent release")
+
+            lease.renew = _release_then_raise
+            lock._renew_all_once()  # snapshot has entry; dict is empty after renew()
+            assert ("graph", "t1") not in lock._active_leases
+        finally:
+            lock.close()
+
+    def test_renewal_thread_actually_renews_in_background(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The live daemon thread renews leases at the configured interval."""
+        # Force sub-second cadence by inflating the renewal fraction so the
+        # computed interval (lease_duration / fraction) is small.
+        monkeypatch.setattr(
+            "azure_functions_langgraph.locks.azure_blob._LEASE_RENEWAL_FRACTION",
+            600,
         )
+        container = MockContainerClient()
+        lock = _make_lock(container, lease_duration=15)
+        try:
+            assert lock._renewal_interval == pytest.approx(15 / 600)
+            lock.acquire("graph", "t1")
+            lease = lock._active_leases[("graph", "t1")]
+            deadline = time.monotonic() + 3.0
+            while time.monotonic() < deadline:
+                if lease.renew_count >= 3:
+                    break
+                time.sleep(0.02)
+            assert lease.renew_count >= 3, (
+                f"Expected ≥3 renewals, got {lease.renew_count}"
+            )
+        finally:
+            lock.close()
 
-    def test_explicit_finite_lease_emits_warning(self) -> None:
-        """Explicit finite lease_duration=30 emits UserWarning naming the value."""
-        with warnings.catch_warnings(record=True) as records:
-            warnings.simplefilter("always")
-            _make_lock(lease_duration=30)
-        matching = [
-            r
-            for r in records
-            if issubclass(r.category, UserWarning)
-            and "lease_duration=30" in str(r.message)
-        ]
-        assert matching, (
-            f"Expected UserWarning naming lease_duration=30; "
-            f"got {[str(r.message) for r in records]}"
-        )
+    def test_close_stops_renewal_thread(self) -> None:
+        """close() sets shutdown event and joins the renewal thread."""
+        lock = _make_lock()
+        thread = lock._renewal_thread
+        assert thread is not None
+        assert thread.is_alive()
+        lock.close()
+        thread.join(timeout=2.0)
+        assert not thread.is_alive()
+        assert lock._closed is True
 
-    def test_infinite_lease_no_warning(self) -> None:
-        """Infinite lease_duration=-1 must not emit the non-renewal warning."""
-        with warnings.catch_warnings(record=True) as records:
-            warnings.simplefilter("always")
-            _make_lock(lease_duration=-1)
-        matching = [
-            r
-            for r in records
-            if issubclass(r.category, UserWarning)
-            and "does not renew leases in the background" in str(r.message)
-        ]
-        assert not matching, (
-            f"Infinite lease must not warn; got {[str(r.message) for r in matching]}"
+    def test_close_releases_active_leases(self) -> None:
+        """close() releases every tracked lease."""
+        container = MockContainerClient()
+        lock = _make_lock(container)
+        lock.acquire("graph", "t1")
+        lock.acquire("graph", "t2")
+        leases = list(lock._active_leases.values())
+        assert len(leases) == 2
+        lock.close()
+        for lease in leases:
+            assert lease.released
+        assert not lock._active_leases
+
+    def test_close_idempotent(self) -> None:
+        """Repeated close() calls are safe no-ops."""
+        lock = _make_lock()
+        lock.close()
+        lock.close()
+        lock.close()  # third call must not raise
+        assert lock._closed is True
+
+    def test_close_swallows_release_errors(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """close() swallows exceptions from individual lease.release() calls."""
+        container = MockContainerClient()
+        lock = _make_lock(container)
+        lock.acquire("graph", "t1")
+        lease = lock._active_leases[("graph", "t1")]
+
+        def _raise() -> None:
+            raise RuntimeError("simulated release failure during close")
+
+        lease.release = _raise
+        with caplog.at_level(
+            "DEBUG", logger="azure_functions_langgraph.locks.azure_blob"
+        ):
+            lock.close()  # must not raise
+        assert any(
+            "during close" in rec.getMessage() for rec in caplog.records
         )


### PR DESCRIPTION
## Summary

Follow-up to #247 (docs+warn baseline). Actually fix the silent mid-execution lease expiry that #247 warned about by renewing leases in the background.

- New `auto_renew: bool = True` constructor parameter on `AzureBlobLeaseThreadLock`.
- When enabled (default) with a finite `lease_duration`, a per-instance daemon thread renews every active lease at `lease_duration / 3` intervals until `close()` or process exit.
- New `close()` method for graceful shutdown; idempotent, safe from any thread. `__del__` calls it best-effort.
- Backward-compat: default `True` prevents the silent-race data-loss path #247 warned about. Set `auto_renew=False` to keep the historic behaviour — construction then re-emits a `UserWarning` (updated wording references the new opt-out flag).
- Infinite leases (`lease_duration=-1`) never spawn a thread — nothing to renew.

## Design notes

**Cadence.** `lease_duration / 3` leaves two full retries per lease lifetime if a single renewal call fails transiently. 60 s → renew every 20 s; 15 s → renew every 5 s.

**Thread safety.** The renewal worker takes a snapshot of `_active_leases` under the existing guard, iterates outside the guard (renewals are I/O-bound and must not block `acquire`/`release`), and re-locks only to drop failed leases. An identity check (`self._active_leases.get(key) is lease`) before `del` prevents `KeyError` when a concurrent `release()` swapped or removed the entry mid-cycle.

**Failure policy.** If `lease.renew()` raises, the lease is dropped from local tracking so subsequent `acquire()` calls can take a fresh lease and so a stale entry does not block the local fast-path check indefinitely. Another instance may then acquire the lock — this is strictly better than silently missing the expiry.

**Protocol extension.** `_BlobLeaseClientProtocol` now requires `renew() -> None`, matching `azure.storage.blob.BlobLeaseClient.renew`.

## Tests

`MockBlobLease.renew()` added (raises `LeaseIdMismatchWithLeaseOperation` when already released, otherwise increments `renew_count`). `TestFiniteLeaseWarning` rewritten around the new opt-out semantics.

New `TestAutoRenewal` covers:

- Thread starts by default; skipped for infinite lease; skipped when `auto_renew=False` (with warning).
- `_renew_all_once()` renews every active lease.
- Failure path: renewal exception drops lease from tracking + logs warning.
- Concurrent-release race: identity check prevents `KeyError` when the dict entry was removed after the snapshot.
- Live daemon thread actually renews at inflated cadence (`monkeypatch _LEASE_RENEWAL_FRACTION=600` → sub-second interval).
- `close()` sets shutdown event, joins the thread, releases every tracked lease, is idempotent, and swallows individual release errors.

## Docs

- `azure_blob.py` module docstring bullet flipped from "never renews" to "renews in the background by default".
- Class WARNING callout softened to describe the opt-out path.
- `docs/production-guide.md`: blockquote updated (ℹ️ Background renewal); scale-out matrix row updated (finite leases no longer cap execution time by default).

## Validation

- `make check-all`: **941 passed, 6 skipped** (integration), **95.31% coverage** (floor 95%). `locks/azure_blob.py` at 97%.
- Bandit clean (new `# nosec B110` on `__del__` cleanup `pass` explained inline).

Closes #249
