### PR TITLE
docs: document Release Process in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,3 +65,20 @@ When splitting a large piece of work into focused issues, keep the umbrella open
 - `make lint`
 - `make typecheck`
 - `make build`
+
+## Release Process
+- Version is managed via `hatch` (dynamic from `src/azure_functions_langgraph/__init__.py`).
+- **Do NOT manually edit version strings.** Use the Makefile targets below. The public-API test reads `__version__` against `importlib.metadata.version(...)`, so no test changes are needed when bumping.
+
+### Commands
+- `make release-patch` — bump patch version, update changelog, tag, and push
+- `make release-minor` — bump minor version, update changelog, tag, and push
+- `make release-major` — bump major version, update changelog, tag, and push
+- `make release VERSION=x.y.z` — set explicit version, update changelog, tag, and push
+- `make tag-release VERSION=x.y.z` — create and push an annotated tag (used internally by release targets)
+
+### Flow
+1. `make release-patch` (or `-minor` / `-major`) on `main`
+2. This runs: `hatch version` → `git commit` → `make changelog` → `git commit` → `git tag` → `git push`
+3. Tag push triggers **Publish to PyPI** GitHub Actions workflow automatically.
+4. Update `docs/changelog.md` separately if needed (different format from `CHANGELOG.md`).


### PR DESCRIPTION
## Summary
- Adds a `## Release Process` section to `AGENTS.md` documenting the hatch-managed release flow and Makefile targets.
- Copied verbatim from the canonical openapi `AGENTS.md`, adapting only the `src/` package path.

Closes #254