### PR TITLE
ci: document coverage-gate vs compat-smoke split in ci-test.yml

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -36,7 +36,6 @@ jobs:
         # `fail_under = 95` settings from pyproject.toml and fails the build if
         # coverage drops below 95% on any Python version.
         run: make check-all
-        run: make check-all
 
       - name: Verify coverage output
         run: ls -lh coverage.xml
@@ -80,5 +79,4 @@ jobs:
         # (and the fail_under gate) for this pinned langgraph==1.0.0 run. Because
         # it is a separate job from the coverage-enforcing matrix above, it
         # cannot mask coverage regressions -- the matrix job still enforces 95%.
-        run: pytest tests/ --no-cov -q
         run: pytest tests/ --no-cov -q

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -31,6 +31,11 @@ jobs:
           make install
 
       - name: Run full quality checks
+        # This matrix job (Python 3.10-3.14) is the coverage gate: `make
+        # check-all` -> `make test` -> pytest, which picks up the `--cov` +
+        # `fail_under = 95` settings from pyproject.toml and fails the build if
+        # coverage drops below 95% on any Python version.
+        run: make check-all
         run: make check-all
 
       - name: Verify coverage output
@@ -71,4 +76,9 @@ jobs:
         run: pip show langgraph langgraph-sdk | grep -E '^(Name|Version):'
 
       - name: Run tests against minimum langgraph
+        # Compatibility smoke only: `--no-cov` intentionally disables coverage
+        # (and the fail_under gate) for this pinned langgraph==1.0.0 run. Because
+        # it is a separate job from the coverage-enforcing matrix above, it
+        # cannot mask coverage regressions -- the matrix job still enforces 95%.
+        run: pytest tests/ --no-cov -q
         run: pytest tests/ --no-cov -q


### PR DESCRIPTION
## Summary

Resolves the single acceptance item in the test-suite quality review (#265): **confirm the `langgraph==1.0.0` compat job's `--no-cov` run is intentional and that the primary matrix job enforces the 95% gate.** This is a static/verify-only pass — no test behavior changes, only clarifying comments.

## Verification (findings)

- **Coverage gate lives in the matrix job.** `test` (Python 3.10–3.14) runs `make check-all → make test → hatch run test → pytest`, which picks up `[tool.pytest.ini_options] addopts = "--cov=src/... -m 'not e2e'"` and `[tool.coverage.report] fail_under = 95`. Any Python version dropping below 95% fails the build.
- **Compat job's `--no-cov` is intentional and safe.** `langgraph-min` pins `langgraph==1.0.0` and runs `pytest tests/ --no-cov -q` as a compatibility smoke. Because it is a **separate job** from the coverage-enforcing matrix, disabling coverage there **cannot mask coverage regressions** — the matrix job remains the gate.

Conclusion: the current split is correct. The finding is confirmed; no functional change is warranted.

## Changes

- `.github/workflows/ci-test.yml` — added two clarifying comments documenting the gate-vs-smoke split (above `make check-all` and above the compat `pytest --no-cov`).

## Validation

- `python -c "import yaml; yaml.safe_load(...)"` — workflow YAML parses.

Closes #265
