### PR TITLE
docs: add discoverability metadata (pepy badge + llms.txt)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -1,6 +1,7 @@
 # Azure Functions LangGraph
 
 [![PyPI](https://img.shields.io/pypi/v/azure-functions-langgraph.svg)](https://pypi.org/project/azure-functions-langgraph/)
+[![Downloads](https://static.pepy.tech/badge/azure-functions-langgraph/month)](https://pepy.tech/project/azure-functions-langgraph)
 [![Python Version](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12%20%7C%203.13%20%7C%203.14-blue)](https://pypi.org/project/azure-functions-langgraph/)
 [![CI](https://github.com/yeongseon/azure-functions-langgraph-python/actions/workflows/ci-test.yml/badge.svg)](https://github.com/yeongseon/azure-functions-langgraph-python/actions/workflows/ci-test.yml)
 [![Release](https://github.com/yeongseon/azure-functions-langgraph-python/actions/workflows/publish-pypi.yml/badge.svg)](https://github.com/yeongseon/azure-functions-langgraph-python/actions/workflows/publish-pypi.yml)

--- a/README.ko.md
+++ b/README.ko.md
@@ -1,6 +1,7 @@
 # Azure Functions LangGraph
 
 [![PyPI](https://img.shields.io/pypi/v/azure-functions-langgraph.svg)](https://pypi.org/project/azure-functions-langgraph/)
+[![Downloads](https://static.pepy.tech/badge/azure-functions-langgraph/month)](https://pepy.tech/project/azure-functions-langgraph)
 [![Python Version](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12%20%7C%203.13%20%7C%203.14-blue)](https://pypi.org/project/azure-functions-langgraph/)
 [![CI](https://github.com/yeongseon/azure-functions-langgraph-python/actions/workflows/ci-test.yml/badge.svg)](https://github.com/yeongseon/azure-functions-langgraph-python/actions/workflows/ci-test.yml)
 [![Release](https://github.com/yeongseon/azure-functions-langgraph-python/actions/workflows/publish-pypi.yml/badge.svg)](https://github.com/yeongseon/azure-functions-langgraph-python/actions/workflows/publish-pypi.yml)

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 
 [![PyPI](https://img.shields.io/pypi/v/azure-functions-langgraph.svg)](https://pypi.org/project/azure-functions-langgraph/)
+[![Downloads](https://static.pepy.tech/badge/azure-functions-langgraph/month)](https://pepy.tech/project/azure-functions-langgraph)
 [![Python Version](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12%20%7C%203.13%20%7C%203.14-blue)](https://pypi.org/project/azure-functions-langgraph/)
 [![CI](https://github.com/yeongseon/azure-functions-langgraph-python/actions/workflows/ci-test.yml/badge.svg)](https://github.com/yeongseon/azure-functions-langgraph-python/actions/workflows/ci-test.yml)
 [![Release](https://github.com/yeongseon/azure-functions-langgraph-python/actions/workflows/publish-pypi.yml/badge.svg)](https://github.com/yeongseon/azure-functions-langgraph-python/actions/workflows/publish-pypi.yml)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,6 +1,7 @@
 # Azure Functions LangGraph
 
 [![PyPI](https://img.shields.io/pypi/v/azure-functions-langgraph.svg)](https://pypi.org/project/azure-functions-langgraph/)
+[![Downloads](https://static.pepy.tech/badge/azure-functions-langgraph/month)](https://pepy.tech/project/azure-functions-langgraph)
 [![Python Version](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12%20%7C%203.13%20%7C%203.14-blue)](https://pypi.org/project/azure-functions-langgraph/)
 [![CI](https://github.com/yeongseon/azure-functions-langgraph-python/actions/workflows/ci-test.yml/badge.svg)](https://github.com/yeongseon/azure-functions-langgraph-python/actions/workflows/ci-test.yml)
 [![Release](https://github.com/yeongseon/azure-functions-langgraph-python/actions/workflows/publish-pypi.yml/badge.svg)](https://github.com/yeongseon/azure-functions-langgraph-python/actions/workflows/publish-pypi.yml)

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -1,0 +1,25 @@
+# Azure Functions LangGraph
+
+> LangGraph integration for Azure Functions Python v2 — deploy compiled graphs as HTTP endpoints.
+
+Part of the **Azure Functions Python DX Toolkit**. Deploy compiled LangGraph graphs as Azure Functions HTTP endpoints with minimal boilerplate, bringing agentic LLM workflows to serverless Azure. Install from PyPI with `pip install azure-functions-langgraph`.
+
+## Getting Started
+- [Installation](https://yeongseon.github.io/azure-functions-langgraph-python/installation/): Install the package.
+- [Quickstart](https://yeongseon.github.io/azure-functions-langgraph-python/getting-started/): Minimal end-to-end example.
+- [Configuration](https://yeongseon.github.io/azure-functions-langgraph-python/configuration/): Configure graph deployment.
+
+## User Guide
+- [Usage](https://yeongseon.github.io/azure-functions-langgraph-python/usage/): Decorator reference and graph wiring.
+- [Architecture](https://yeongseon.github.io/azure-functions-langgraph-python/architecture/): How graphs map to endpoints.
+
+## Deployment
+- [Choose a Plan](https://yeongseon.github.io/azure-functions-langgraph-python/choose-a-plan/): Hosting options.
+- [Deploy to Azure](https://yeongseon.github.io/azure-functions-langgraph-python/deployment/): Deployment guide.
+- [Production Guide](https://yeongseon.github.io/azure-functions-langgraph-python/production-guide/): Production hardening.
+
+## Reference
+- [API Reference](https://yeongseon.github.io/azure-functions-langgraph-python/api/): Public API surface.
+- [Simple Agent Example](https://yeongseon.github.io/azure-functions-langgraph-python/examples/simple_agent/): End-to-end agent.
+- [FAQ](https://yeongseon.github.io/azure-functions-langgraph-python/faq/): Frequently asked questions.
+- [Troubleshooting](https://yeongseon.github.io/azure-functions-langgraph-python/troubleshooting/): Common issues and fixes.


### PR DESCRIPTION
## Summary

Discoverability improvements (no code changes):

- **pepy.tech monthly download badge** added to `README.md` and locale READMEs (after the PyPI badge).
- **`docs/llms.txt`** added — an llmstxt.org-style summary served at the gh-pages site root (`/llms.txt`) with curated links to key docs.

## Verification
- `mkdocs build` succeeds; `llms.txt` present at site root.


Closes #271
