### PR TITLE
refactor(platform): extract shared SSE response + stream_mode helpers

### DIFF
--- a/src/azure_functions_langgraph/platform/_common.py
+++ b/src/azure_functions_langgraph/platform/_common.py
@@ -29,6 +29,51 @@ def _platform_error(status_code: int, detail: str) -> func.HttpResponse:
     )
 
 
+def _build_sse_response(
+    chunks: list[str],
+    *,
+    content_location: str,
+) -> func.HttpResponse:
+    """Build the buffered SSE ``HttpResponse`` shared by all streaming routes.
+
+    Every platform streaming exit path emits the same ``text/event-stream``
+    response with identical headers, differing only in ``Content-Location``.
+    """
+    return func.HttpResponse(
+        body="".join(chunks),
+        mimetype="text/event-stream",
+        status_code=200,
+        headers={
+            "Cache-Control": "no-cache",
+            "X-Accel-Buffering": "no",
+            "Content-Location": content_location,
+        },
+    )
+
+
+def _normalize_stream_mode(
+    raw_mode: Any,
+) -> tuple[Any, func.HttpResponse | None]:
+    """Normalize a ``RunCreate.stream_mode`` value to a single mode.
+
+    Returns ``(stream_mode, None)`` on success. A one-element list collapses to
+    its single element, an empty list defaults to ``"values"``, and a
+    multi-element list returns ``(None, 501_response)`` since multi-stream-mode
+    is unsupported. Non-list values pass through unchanged.
+    """
+    if isinstance(raw_mode, list):
+        if len(raw_mode) == 1:
+            return raw_mode[0], None
+        if len(raw_mode) == 0:
+            return "values", None
+        return None, _platform_error(
+            501,
+            "Multi-stream-mode is not supported in this release. "
+            "Provide a single stream_mode string or a one-element list.",
+        )
+    return raw_mode, None
+
+
 _UNSUPPORTED_FIELDS: dict[str, str] = {
     "interrupt_before": "Interrupt-before is not supported in this release.",
     "interrupt_after": "Interrupt-after is not supported in this release.",

--- a/src/azure_functions_langgraph/platform/_runs.py
+++ b/src/azure_functions_langgraph/platform/_runs.py
@@ -14,7 +14,9 @@ from azure_functions_langgraph._validation import (
 )
 from azure_functions_langgraph.platform._common import (
     PlatformRouteDeps,
+    _build_sse_response,
     _get_threadless_graph,
+    _normalize_stream_mode,
     _platform_error,
     _preflight_run_create,
     logger,
@@ -198,20 +200,9 @@ def register_run_routes(
         if thread is None:
             return _platform_error(404, f"Thread {thread_id!r} not found")
 
-        raw_mode = run_req.stream_mode
-        if isinstance(raw_mode, list):
-            if len(raw_mode) == 1:
-                stream_mode = raw_mode[0]
-            elif len(raw_mode) == 0:
-                stream_mode = "values"
-            else:
-                return _platform_error(
-                    501,
-                    "Multi-stream-mode is not supported in this release. "
-                    "Provide a single stream_mode string or a one-element list.",
-                )
-        else:
-            stream_mode = raw_mode
+        stream_mode, mode_err = _normalize_stream_mode(run_req.stream_mode)
+        if mode_err is not None:
+            return mode_err
 
         reg = deps.registrations.get(run_req.assistant_id)
         if reg is None:
@@ -283,15 +274,9 @@ def register_run_routes(
             )
             chunks.append(format_end_event())
             _release_thread_run_lock(deps, thread_id, status="error")
-            return func.HttpResponse(
-                body="".join(chunks),
-                mimetype="text/event-stream",
-                status_code=200,
-                headers={
-                    "Cache-Control": "no-cache",
-                    "X-Accel-Buffering": "no",
-                    "Content-Location": f"/api/threads/{thread_id}/runs/{run_id}",
-                },
+            return _build_sse_response(
+                chunks,
+                content_location=f"/api/threads/{thread_id}/runs/{run_id}",
             )
         try:
             for event in reg.graph.stream(
@@ -308,15 +293,9 @@ def register_run_routes(
                     chunks.append(err_chunk)
                     chunks.append(format_end_event())
                     _release_thread_run_lock(deps, thread_id, status="error")
-                    return func.HttpResponse(
-                        body="".join(chunks),
-                        mimetype="text/event-stream",
-                        status_code=200,
-                        headers={
-                            "Cache-Control": "no-cache",
-                            "X-Accel-Buffering": "no",
-                            "Content-Location": f"/api/threads/{thread_id}/runs/{run_id}",
-                        },
+                    return _build_sse_response(
+                        chunks,
+                        content_location=f"/api/threads/{thread_id}/runs/{run_id}",
                     )
                 chunks.append(chunk)
                 buffered_bytes += chunk_bytes
@@ -329,30 +308,18 @@ def register_run_routes(
             _release_thread_run_lock(deps, thread_id, status="error")
             chunks.append(format_error_event("stream processing failed"))
             chunks.append(format_end_event())
-            return func.HttpResponse(
-                body="".join(chunks),
-                mimetype="text/event-stream",
-                status_code=200,
-                headers={
-                    "Cache-Control": "no-cache",
-                    "X-Accel-Buffering": "no",
-                    "Content-Location": f"/api/threads/{thread_id}/runs/{run_id}",
-                },
+            return _build_sse_response(
+                chunks,
+                content_location=f"/api/threads/{thread_id}/runs/{run_id}",
             )
 
         chunks.append(format_end_event())
 
         _release_thread_run_lock(deps, thread_id, status="idle")
 
-        return func.HttpResponse(
-            body="".join(chunks),
-            mimetype="text/event-stream",
-            status_code=200,
-            headers={
-                "Cache-Control": "no-cache",
-                "X-Accel-Buffering": "no",
-                "Content-Location": f"/api/threads/{thread_id}/runs/{run_id}",
-            },
+        return _build_sse_response(
+            chunks,
+            content_location=f"/api/threads/{thread_id}/runs/{run_id}",
         )
 
     @app.function_name(name="aflg_platform_runs_wait_threadless")
@@ -470,20 +437,9 @@ def register_run_routes(
         if preflight is not None:
             return preflight
 
-        raw_mode = run_req.stream_mode
-        if isinstance(raw_mode, list):
-            if len(raw_mode) == 1:
-                stream_mode = raw_mode[0]
-            elif len(raw_mode) == 0:
-                stream_mode = "values"
-            else:
-                return _platform_error(
-                    501,
-                    "Multi-stream-mode is not supported in this release. "
-                    "Provide a single stream_mode string or a one-element list.",
-                )
-        else:
-            stream_mode = raw_mode
+        stream_mode, mode_err = _normalize_stream_mode(run_req.stream_mode)
+        if mode_err is not None:
+            return mode_err
 
         reg = deps.registrations.get(run_req.assistant_id)
         if reg is None:
@@ -548,15 +504,9 @@ def register_run_routes(
                 )
             )
             chunks.append(format_end_event())
-            return func.HttpResponse(
-                body="".join(chunks),
-                mimetype="text/event-stream",
-                status_code=200,
-                headers={
-                    "Cache-Control": "no-cache",
-                    "X-Accel-Buffering": "no",
-                    "Content-Location": f"/api/runs/{run_id}",
-                },
+            return _build_sse_response(
+                chunks,
+                content_location=f"/api/runs/{run_id}",
             )
         try:
             for event in exec_graph.stream(
@@ -572,15 +522,9 @@ def register_run_routes(
                     )
                     chunks.append(err_chunk)
                     chunks.append(format_end_event())
-                    return func.HttpResponse(
-                        body="".join(chunks),
-                        mimetype="text/event-stream",
-                        status_code=200,
-                        headers={
-                            "Cache-Control": "no-cache",
-                            "X-Accel-Buffering": "no",
-                            "Content-Location": f"/api/runs/{run_id}",
-                        },
+                    return _build_sse_response(
+                        chunks,
+                        content_location=f"/api/runs/{run_id}",
                     )
                 chunks.append(chunk)
                 buffered_bytes += chunk_bytes
@@ -591,26 +535,14 @@ def register_run_routes(
             )
             chunks.append(format_error_event("stream processing failed"))
             chunks.append(format_end_event())
-            return func.HttpResponse(
-                body="".join(chunks),
-                mimetype="text/event-stream",
-                status_code=200,
-                headers={
-                    "Cache-Control": "no-cache",
-                    "X-Accel-Buffering": "no",
-                    "Content-Location": f"/api/runs/{run_id}",
-                },
+            return _build_sse_response(
+                chunks,
+                content_location=f"/api/runs/{run_id}",
             )
 
         chunks.append(format_end_event())
 
-        return func.HttpResponse(
-            body="".join(chunks),
-            mimetype="text/event-stream",
-            status_code=200,
-            headers={
-                "Cache-Control": "no-cache",
-                "X-Accel-Buffering": "no",
-                "Content-Location": f"/api/runs/{run_id}",
-            },
+        return _build_sse_response(
+            chunks,
+            content_location=f"/api/runs/{run_id}",
         )

--- a/tests/test_platform_common.py
+++ b/tests/test_platform_common.py
@@ -1,0 +1,62 @@
+"""Tests for platform._common shared helpers (issue #269).
+
+Covers the SSE response builder and stream_mode normalizer extracted to
+de-duplicate the platform run handlers.
+"""
+
+from __future__ import annotations
+
+from azure_functions_langgraph.platform._common import (
+    _build_sse_response,
+    _normalize_stream_mode,
+)
+
+
+class TestBuildSSEResponse:
+    def test_builds_event_stream_response_with_headers(self) -> None:
+        resp = _build_sse_response(
+            ["event: end\ndata: {}\n\n"],
+            content_location="/api/runs/abc",
+        )
+        assert resp.status_code == 200
+        assert resp.mimetype == "text/event-stream"
+        assert resp.headers["Cache-Control"] == "no-cache"
+        assert resp.headers["X-Accel-Buffering"] == "no"
+        assert resp.headers["Content-Location"] == "/api/runs/abc"
+        assert resp.get_body() == b"event: end\ndata: {}\n\n"
+
+    def test_joins_multiple_chunks_in_order(self) -> None:
+        resp = _build_sse_response(
+            ["a", "b", "c"],
+            content_location="/api/threads/t1/runs/r1",
+        )
+        assert resp.get_body() == b"abc"
+        assert resp.headers["Content-Location"] == "/api/threads/t1/runs/r1"
+
+
+class TestNormalizeStreamMode:
+    def test_plain_string_passes_through(self) -> None:
+        mode, err = _normalize_stream_mode("values")
+        assert mode == "values"
+        assert err is None
+
+    def test_none_passes_through(self) -> None:
+        mode, err = _normalize_stream_mode(None)
+        assert mode is None
+        assert err is None
+
+    def test_single_element_list_collapses(self) -> None:
+        mode, err = _normalize_stream_mode(["updates"])
+        assert mode == "updates"
+        assert err is None
+
+    def test_empty_list_defaults_to_values(self) -> None:
+        mode, err = _normalize_stream_mode([])
+        assert mode == "values"
+        assert err is None
+
+    def test_multi_element_list_returns_501(self) -> None:
+        mode, err = _normalize_stream_mode(["values", "updates"])
+        assert mode is None
+        assert err is not None
+        assert err.status_code == 501


### PR DESCRIPTION
## Summary

De-duplicates the platform run handlers by extracting two shared helpers into `platform/_common.py`, addressing the SSE-response cluster from the design review (#256) tracked in the #269 follow-up.

- **`_build_sse_response(chunks, *, content_location)`** — replaces 8 byte-identical `func.HttpResponse(..., mimetype="text/event-stream", ...)` construction sites across `runs_stream` and `runs_stream_threadless` (normal, overflow, and error exit paths). Only `Content-Location` ever differed.
- **`_normalize_stream_mode(raw_mode)`** — replaces the 2 identical `stream_mode` list-normalization blocks (1-element collapse, empty → `"values"`, multi-element → 501).

Behavior-preserving: input validation, byte-cap enforcement, run-lock release, and wire format are untouched.

## Tests
- New `tests/test_platform_common.py` unit-tests both helpers (headers, chunk join, all normalization branches incl. 501).
- `make lint`, `make typecheck` clean; **948 passed**, coverage **95.13%** (>=95 gate).

Part of #269
Part of #256