### PR TITLE
refactor(metadata): type the langgraph cross-package metadata contract

### DIFF
--- a/src/azure_functions_langgraph/_metadata.py
+++ b/src/azure_functions_langgraph/_metadata.py
@@ -1,0 +1,66 @@
+"""Typed cross-package metadata contract for the ``langgraph`` namespace.
+
+Toolkit convention (shared across the Azure Functions Python DX Toolkit):
+handlers carry an ``_azure_functions_metadata`` dict keyed by a package-owned
+*namespace* string, so sibling packages can discover metadata **without
+importing this package**.
+
+This module gives the ``"langgraph"`` namespace payload a checked ``TypedDict``
+shape plus a single merge helper. The contract is intentionally *replicated*
+across toolkit packages (not shared via a runtime dependency); keep the
+``_BaseMetadata`` ``version`` field and the merge-without-clobber semantics
+identical to the sibling packages.
+
+Ref: https://github.com/yeongseon/azure-functions-langgraph-python/issues/269
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable, TypedDict, cast
+
+#: Convention attribute name shared across all toolkit packages.
+METADATA_ATTR = "_azure_functions_metadata"
+
+#: Namespace owned by this package.
+NAMESPACE = "langgraph"
+
+#: Schema version for the ``langgraph`` namespace payload.
+LANGGRAPH_METADATA_VERSION = 1
+
+
+class _BaseMetadata(TypedDict):
+    """Fields common to every toolkit namespace payload."""
+
+    version: int
+
+
+class LangGraphMetadata(_BaseMetadata):
+    """Shape of ``_azure_functions_metadata["langgraph"]`` (schema version 1)."""
+
+    graph_name: str
+    endpoint: str
+
+
+def set_langgraph_metadata(
+    fn: Callable[..., Any],
+    payload: LangGraphMetadata,
+) -> None:
+    """Merge the ``langgraph`` namespace onto ``fn`` without clobbering others.
+
+    Reads any pre-existing convention attribute, merges in ``payload`` under
+    the ``langgraph`` namespace, and writes the result back onto ``fn``.
+    """
+    existing = getattr(fn, METADATA_ATTR, None)
+    base: dict[str, Any] = dict(existing) if isinstance(existing, dict) else {}
+    base[NAMESPACE] = payload
+    setattr(fn, METADATA_ATTR, base)
+
+
+def read_langgraph_metadata(func: Any) -> LangGraphMetadata | None:
+    """Return the typed ``langgraph`` namespace payload, or ``None`` if absent."""
+    md = getattr(func, METADATA_ATTR, None)
+    if isinstance(md, dict):
+        entry = md.get(NAMESPACE)
+        if isinstance(entry, dict):
+            return cast("LangGraphMetadata", entry)
+    return None

--- a/src/azure_functions_langgraph/app.py
+++ b/src/azure_functions_langgraph/app.py
@@ -15,6 +15,11 @@ from azure_functions_langgraph._handlers import (
     handle_state,
     handle_stream,
 )
+from azure_functions_langgraph._metadata import (
+    LangGraphMetadata,
+    read_langgraph_metadata,
+    set_langgraph_metadata,
+)
 from azure_functions_langgraph._validation import (
     validate_graph_name,
 )
@@ -34,20 +39,6 @@ _ROUTE_HEALTH = "health"
 _ROUTE_INVOKE = "graphs/{name}/invoke"
 _ROUTE_STREAM = "graphs/{name}/stream"
 _ROUTE_STATE = "graphs/{name}/threads/{{thread_id}}/state"
-_TOOLKIT_META_ATTR = "_azure_functions_metadata"
-
-
-def _merge_toolkit_metadata(
-    fn: Callable[..., Any],
-    namespace: str,
-    payload: dict[str, Any],
-) -> None:
-    """Merge toolkit metadata into the convention attribute, preserving other namespaces."""
-    existing: dict[str, Any] = getattr(fn, _TOOLKIT_META_ATTR, {})
-    if not isinstance(existing, dict):
-        existing = {}
-    existing = {**existing, namespace: payload}
-    setattr(fn, _TOOLKIT_META_ATTR, existing)
 
 
 @dataclass
@@ -346,15 +337,12 @@ class LangGraphApp:
         def handler(req: func.HttpRequest) -> func.HttpResponse:
             return handler_impl(req, captured_reg)
 
-        _merge_toolkit_metadata(
-            handler,
-            "langgraph",
-            {
-                "version": 1,
-                "graph_name": reg.name,
-                "endpoint": endpoint,
-            },
-        )
+        _payload: LangGraphMetadata = {
+            "version": 1,
+            "graph_name": reg.name,
+            "endpoint": endpoint,
+        }
+        set_langgraph_metadata(handler, _payload)
 
         app.function_name(name=fn_name)(
             app.route(route=route, methods=methods, auth_level=effective_auth)(handler)
@@ -504,9 +492,5 @@ def get_langgraph_metadata(func: Any) -> dict[str, Any] | None:
 
     Returns ``None`` if the function has no langgraph metadata attached.
     """
-    toolkit_meta = getattr(func, _TOOLKIT_META_ATTR, None)
-    if isinstance(toolkit_meta, dict):
-        meta = toolkit_meta.get("langgraph")
-        if isinstance(meta, dict):
-            return meta
-    return None
+    meta = read_langgraph_metadata(func)
+    return dict(meta) if meta is not None else None

--- a/tests/test_metadata_contract.py
+++ b/tests/test_metadata_contract.py
@@ -1,0 +1,91 @@
+"""Tests for the typed cross-package metadata contract (``_metadata``)."""
+
+from __future__ import annotations
+
+from azure_functions_langgraph._metadata import (
+    LANGGRAPH_METADATA_VERSION,
+    METADATA_ATTR,
+    NAMESPACE,
+    LangGraphMetadata,
+    read_langgraph_metadata,
+    set_langgraph_metadata,
+)
+
+
+def _payload() -> LangGraphMetadata:
+    return {"version": 1, "graph_name": "agent", "endpoint": "invoke"}
+
+
+class TestContractConstants:
+    def test_attr_name_is_toolkit_convention(self) -> None:
+        assert METADATA_ATTR == "_azure_functions_metadata"
+
+    def test_namespace_is_langgraph(self) -> None:
+        assert NAMESPACE == "langgraph"
+
+    def test_version_constant(self) -> None:
+        assert LANGGRAPH_METADATA_VERSION == 1
+
+
+class TestSetLangGraphMetadata:
+    def test_writes_payload_onto_fn(self) -> None:
+        def fn() -> None:
+            pass
+
+        set_langgraph_metadata(fn, _payload())
+        assert getattr(fn, METADATA_ATTR) == {"langgraph": _payload()}
+
+    def test_seeds_from_existing_namespaces(self) -> None:
+        def fn() -> None:
+            pass
+
+        setattr(fn, METADATA_ATTR, {"db": {"version": 1, "bindings": []}})
+        set_langgraph_metadata(fn, _payload())
+
+        meta = getattr(fn, METADATA_ATTR)
+        assert meta["db"] == {"version": 1, "bindings": []}
+        assert meta["langgraph"] == _payload()
+
+    def test_ignores_non_dict_existing_attr(self) -> None:
+        def fn() -> None:
+            pass
+
+        setattr(fn, METADATA_ATTR, "not-a-dict")
+        set_langgraph_metadata(fn, _payload())
+        assert getattr(fn, METADATA_ATTR) == {"langgraph": _payload()}
+
+
+class TestReadLangGraphMetadata:
+    def test_returns_payload_when_present(self) -> None:
+        def fn() -> None:
+            pass
+
+        setattr(fn, METADATA_ATTR, {"langgraph": _payload()})
+        assert read_langgraph_metadata(fn) == _payload()
+
+    def test_returns_none_when_attr_missing(self) -> None:
+        def fn() -> None:
+            pass
+
+        assert read_langgraph_metadata(fn) is None
+
+    def test_returns_none_when_attr_not_dict(self) -> None:
+        def fn() -> None:
+            pass
+
+        setattr(fn, METADATA_ATTR, "not-a-dict")
+        assert read_langgraph_metadata(fn) is None
+
+    def test_returns_none_when_namespace_absent(self) -> None:
+        def fn() -> None:
+            pass
+
+        setattr(fn, METADATA_ATTR, {"db": {"version": 1}})
+        assert read_langgraph_metadata(fn) is None
+
+    def test_returns_none_when_namespace_not_dict(self) -> None:
+        def fn() -> None:
+            pass
+
+        setattr(fn, METADATA_ATTR, {"langgraph": "not-a-dict"})
+        assert read_langgraph_metadata(fn) is None


### PR DESCRIPTION
## Summary
Introduces a typed `_azure_functions_metadata` contract for the langgraph namespace, replacing the ad-hoc dict merge.

- Add `src/azure_functions_langgraph/_metadata.py` defining `LangGraphMetadata` (TypedDict), namespace/version constants, and `set_langgraph_metadata` / `read_langgraph_metadata` helpers.
- Refactor `app.py` to route route-registration metadata through the typed helper and read via `read_langgraph_metadata` (removes the old `_TOOLKIT_META_ATTR` + `_merge_toolkit_metadata`).
- Add `tests/test_metadata_contract.py`.

Behavior-preserving; payload shape (`version`, `graph_name`, `endpoint`) is unchanged. TypedDict kept internal (not exported) to avoid public-API churn.

Part of #269