### PR TITLE
refactor(platform): de-duplicate RunCreate preamble in _runs.py

### DIFF
--- a/src/azure_functions_langgraph/platform/_common.py
+++ b/src/azure_functions_langgraph/platform/_common.py
@@ -7,6 +7,11 @@ from typing import Any
 
 import azure.functions as func
 
+from azure_functions_langgraph._validation import (
+    validate_body_size,
+    validate_graph_name,
+    validate_input_structure,
+)
 from azure_functions_langgraph.platform.contracts import (
     Assistant,
     Checkpoint,
@@ -140,6 +145,122 @@ def _get_threadless_graph(graph: Any) -> Any | None:
             exc_info=True,
         )
         return None
+
+
+def _parse_run_create(
+    req: func.HttpRequest,
+    deps: PlatformRouteDeps,
+    *,
+    require_dict_body: bool,
+) -> RunCreate | func.HttpResponse:
+    """Parse and validate the shared RunCreate request preamble.
+
+    Covers the body-size guard, JSON parse, optional dict-shape guard, model
+    validation, assistant-name validation, and unsupported-feature preflight
+    shared by every ``runs/*`` route. Returns the parsed ``RunCreate`` on
+    success or an ``HttpResponse`` on the first failing check, preserving the
+    exact status-code precedence of the inlined handlers.
+    """
+    raw_body = req.get_body()
+    size_err = validate_body_size(raw_body, deps.max_request_body_bytes)
+    if size_err:
+        return _platform_error(400, size_err)
+
+    try:
+        body = req.get_json()
+    except ValueError:
+        return _platform_error(400, "Invalid JSON body")
+
+    if require_dict_body and not isinstance(body, dict):
+        return _platform_error(400, "Request body must be a JSON object")
+
+    try:
+        run_req = RunCreate.model_validate(body)
+    except Exception as exc:  # noqa: BLE001 - surfaced as a 422 to the client
+        return _platform_error(422, f"Validation error: {exc}")
+
+    name_err = validate_graph_name(run_req.assistant_id)
+    if name_err:
+        return _platform_error(400, name_err)
+
+    preflight = _preflight_run_create(run_req)
+    if preflight is not None:
+        return preflight
+
+    return run_req
+
+
+def _validate_run_io_structure(
+    run_req: RunCreate,
+    deps: PlatformRouteDeps,
+) -> func.HttpResponse | None:
+    """Validate the ``input`` and ``config`` structure depth/breadth limits."""
+    if run_req.input:
+        input_err = validate_input_structure(
+            run_req.input,
+            max_depth=deps.max_input_depth,
+            max_nodes=deps.max_input_nodes,
+        )
+        if input_err:
+            return _platform_error(400, input_err)
+    if run_req.config:
+        config_err = validate_input_structure(
+            run_req.config,
+            max_depth=deps.max_input_depth,
+            max_nodes=deps.max_input_nodes,
+        )
+        if config_err:
+            return _platform_error(400, config_err)
+    return None
+
+
+def _resolve_run_graph(
+    run_req: RunCreate,
+    deps: PlatformRouteDeps,
+) -> Any:
+    """Look up the assistant registration and validate its run I/O structure.
+
+    Returns the registration on success, or an ``HttpResponse`` when the
+    assistant is unknown (404) or the input/config structure is invalid (400).
+    """
+    reg = deps.registrations.get(run_req.assistant_id)
+    if reg is None:
+        return _platform_error(404, f"Assistant {run_req.assistant_id!r} not found")
+    io_err = _validate_run_io_structure(run_req, deps)
+    if io_err is not None:
+        return io_err
+    return reg
+
+
+def _build_threaded_config(run_req: RunCreate, thread_id: str) -> dict[str, Any]:
+    """Build the run config for a thread-scoped run, pinning ``thread_id``."""
+    config: dict[str, Any] = {"configurable": {"thread_id": thread_id}}
+    if run_req.config:
+        user_config = dict(run_req.config)
+        user_configurable = user_config.pop("configurable", {})
+        config["configurable"].update(user_configurable)
+        config["configurable"]["thread_id"] = thread_id
+        config.update(user_config)
+    return config
+
+
+def _build_threadless_config(
+    run_req: RunCreate,
+) -> dict[str, Any] | func.HttpResponse:
+    """Build the run config for a threadless run, rejecting any ``thread_id``.
+
+    Returns ``(config, None)`` on success or ``(None, 422_response)`` when the
+    caller supplied a ``thread_id`` (not permitted for threadless execution).
+    """
+    config: dict[str, Any] = {}
+    if run_req.config:
+        user_config = dict(run_req.config)
+        user_configurable = user_config.pop("configurable", {})
+        config["configurable"] = user_configurable
+        config.update(user_config)
+    if config.get("configurable", {}).get("thread_id") is not None:
+        return _platform_error(422, "thread_id is not allowed on threadless runs")
+    return config
 
 
 def _snapshot_to_thread_state(snapshot: Any, thread_id: str) -> ThreadState:

--- a/src/azure_functions_langgraph/platform/_runs.py
+++ b/src/azure_functions_langgraph/platform/_runs.py
@@ -7,18 +7,18 @@ import uuid
 import azure.functions as func
 
 from azure_functions_langgraph._validation import (
-    validate_body_size,
-    validate_graph_name,
-    validate_input_structure,
     validate_thread_id,
 )
 from azure_functions_langgraph.platform._common import (
     PlatformRouteDeps,
     _build_sse_response,
+    _build_threaded_config,
+    _build_threadless_config,
     _get_threadless_graph,
     _normalize_stream_mode,
+    _parse_run_create,
     _platform_error,
-    _preflight_run_create,
+    _resolve_run_graph,
     logger,
 )
 from azure_functions_langgraph.platform._sse import (
@@ -27,7 +27,7 @@ from azure_functions_langgraph.platform._sse import (
     format_error_event,
     format_metadata_event,
 )
-from azure_functions_langgraph.platform.contracts import RunCreate, ThreadStatus
+from azure_functions_langgraph.platform.contracts import ThreadStatus
 from azure_functions_langgraph.protocols import StreamableGraph
 
 
@@ -68,52 +68,18 @@ def register_run_routes(
         if tid_err:
             return _platform_error(400, tid_err)
 
-        raw_body = req.get_body()
-        size_err = validate_body_size(raw_body, deps.max_request_body_bytes)
-        if size_err:
-            return _platform_error(400, size_err)
-
-        try:
-            body = req.get_json()
-        except ValueError:
-            return _platform_error(400, "Invalid JSON body")
-
-        try:
-            run_req = RunCreate.model_validate(body)
-        except Exception as exc:
-            return _platform_error(422, f"Validation error: {exc}")
-
-        name_err = validate_graph_name(run_req.assistant_id)
-        if name_err:
-            return _platform_error(400, name_err)
-        preflight = _preflight_run_create(run_req)
-        if preflight is not None:
-            return preflight
+        parsed = _parse_run_create(req, deps, require_dict_body=False)
+        if isinstance(parsed, func.HttpResponse):
+            return parsed
+        run_req = parsed
 
         thread = deps.thread_store.get(thread_id)
         if thread is None:
             return _platform_error(404, f"Thread {thread_id!r} not found")
 
-        reg = deps.registrations.get(run_req.assistant_id)
-        if reg is None:
-            return _platform_error(404, f"Assistant {run_req.assistant_id!r} not found")
-
-        if run_req.input:
-            input_err = validate_input_structure(
-                run_req.input,
-                max_depth=deps.max_input_depth,
-                max_nodes=deps.max_input_nodes,
-            )
-            if input_err:
-                return _platform_error(400, input_err)
-        if run_req.config:
-            config_err = validate_input_structure(
-                run_req.config,
-                max_depth=deps.max_input_depth,
-                max_nodes=deps.max_input_nodes,
-            )
-            if config_err:
-                return _platform_error(400, config_err)
+        reg = _resolve_run_graph(run_req, deps)
+        if isinstance(reg, func.HttpResponse):
+            return reg
 
         try:
             locked = deps.thread_store.try_acquire_run_lock(
@@ -131,13 +97,7 @@ def register_run_routes(
                 f"Concurrent runs are not supported (multitask_strategy=reject).",
             )
 
-        config: dict[str, Any] = {"configurable": {"thread_id": thread_id}}
-        if run_req.config:
-            user_config = dict(run_req.config)
-            user_configurable = user_config.pop("configurable", {})
-            config["configurable"].update(user_configurable)
-            config["configurable"]["thread_id"] = thread_id
-            config.update(user_config)
+        config = _build_threaded_config(run_req, thread_id)
 
         graph_input = run_req.input or {}
         try:
@@ -174,27 +134,10 @@ def register_run_routes(
         if tid_err:
             return _platform_error(400, tid_err)
 
-        raw_body = req.get_body()
-        size_err = validate_body_size(raw_body, deps.max_request_body_bytes)
-        if size_err:
-            return _platform_error(400, size_err)
-
-        try:
-            body = req.get_json()
-        except ValueError:
-            return _platform_error(400, "Invalid JSON body")
-
-        try:
-            run_req = RunCreate.model_validate(body)
-        except Exception as exc:
-            return _platform_error(422, f"Validation error: {exc}")
-
-        name_err = validate_graph_name(run_req.assistant_id)
-        if name_err:
-            return _platform_error(400, name_err)
-        preflight = _preflight_run_create(run_req)
-        if preflight is not None:
-            return preflight
+        parsed = _parse_run_create(req, deps, require_dict_body=False)
+        if isinstance(parsed, func.HttpResponse):
+            return parsed
+        run_req = parsed
 
         thread = deps.thread_store.get(thread_id)
         if thread is None:
@@ -204,26 +147,9 @@ def register_run_routes(
         if mode_err is not None:
             return mode_err
 
-        reg = deps.registrations.get(run_req.assistant_id)
-        if reg is None:
-            return _platform_error(404, f"Assistant {run_req.assistant_id!r} not found")
-
-        if run_req.input:
-            input_err = validate_input_structure(
-                run_req.input,
-                max_depth=deps.max_input_depth,
-                max_nodes=deps.max_input_nodes,
-            )
-            if input_err:
-                return _platform_error(400, input_err)
-        if run_req.config:
-            config_err = validate_input_structure(
-                run_req.config,
-                max_depth=deps.max_input_depth,
-                max_nodes=deps.max_input_nodes,
-            )
-            if config_err:
-                return _platform_error(400, config_err)
+        reg = _resolve_run_graph(run_req, deps)
+        if isinstance(reg, func.HttpResponse):
+            return reg
 
         if not isinstance(reg.graph, StreamableGraph):
             return _platform_error(
@@ -247,13 +173,7 @@ def register_run_routes(
                 f"Concurrent runs are not supported (multitask_strategy=reject).",
             )
 
-        config: dict[str, Any] = {"configurable": {"thread_id": thread_id}}
-        if run_req.config:
-            user_config = dict(run_req.config)
-            user_configurable = user_config.pop("configurable", {})
-            config["configurable"].update(user_configurable)
-            config["configurable"]["thread_id"] = thread_id
-            config.update(user_config)
+        config = _build_threaded_config(run_req, thread_id)
 
         run_id = str(uuid.uuid4())
 
@@ -325,51 +245,14 @@ def register_run_routes(
     @app.function_name(name="aflg_platform_runs_wait_threadless")
     @app.route(route="runs/wait", methods=["POST"], auth_level=auth)
     def runs_wait_threadless(req: func.HttpRequest) -> func.HttpResponse:
-        raw_body = req.get_body()
-        size_err = validate_body_size(raw_body, deps.max_request_body_bytes)
-        if size_err:
-            return _platform_error(400, size_err)
+        parsed = _parse_run_create(req, deps, require_dict_body=True)
+        if isinstance(parsed, func.HttpResponse):
+            return parsed
+        run_req = parsed
 
-        try:
-            body = req.get_json()
-        except ValueError:
-            return _platform_error(400, "Invalid JSON body")
-
-        if not isinstance(body, dict):
-            return _platform_error(400, "Request body must be a JSON object")
-
-        try:
-            run_req = RunCreate.model_validate(body)
-        except Exception as exc:
-            return _platform_error(422, f"Validation error: {exc}")
-
-        name_err = validate_graph_name(run_req.assistant_id)
-        if name_err:
-            return _platform_error(400, name_err)
-        preflight = _preflight_run_create(run_req)
-        if preflight is not None:
-            return preflight
-
-        reg = deps.registrations.get(run_req.assistant_id)
-        if reg is None:
-            return _platform_error(404, f"Assistant {run_req.assistant_id!r} not found")
-
-        if run_req.input:
-            input_err = validate_input_structure(
-                run_req.input,
-                max_depth=deps.max_input_depth,
-                max_nodes=deps.max_input_nodes,
-            )
-            if input_err:
-                return _platform_error(400, input_err)
-        if run_req.config:
-            config_err = validate_input_structure(
-                run_req.config,
-                max_depth=deps.max_input_depth,
-                max_nodes=deps.max_input_nodes,
-            )
-            if config_err:
-                return _platform_error(400, config_err)
+        reg = _resolve_run_graph(run_req, deps)
+        if isinstance(reg, func.HttpResponse):
+            return reg
 
         exec_graph = _get_threadless_graph(reg.graph)
         if exec_graph is None:
@@ -379,15 +262,9 @@ def register_run_routes(
                 f"be disabled for threadless execution.",
             )
 
-        config: dict[str, Any] = {}
-        if run_req.config:
-            user_config = dict(run_req.config)
-            user_configurable = user_config.pop("configurable", {})
-            config["configurable"] = user_configurable
-            config.update(user_config)
-
-        if config.get("configurable", {}).get("thread_id") is not None:
-            return _platform_error(422, "thread_id is not allowed on threadless runs")
+        config = _build_threadless_config(run_req)
+        if isinstance(config, func.HttpResponse):
+            return config
 
         graph_input = run_req.input or {}
         try:
@@ -412,55 +289,18 @@ def register_run_routes(
     @app.function_name(name="aflg_platform_runs_stream_threadless")
     @app.route(route="runs/stream", methods=["POST"], auth_level=auth)
     def runs_stream_threadless(req: func.HttpRequest) -> func.HttpResponse:
-        raw_body = req.get_body()
-        size_err = validate_body_size(raw_body, deps.max_request_body_bytes)
-        if size_err:
-            return _platform_error(400, size_err)
-
-        try:
-            body = req.get_json()
-        except ValueError:
-            return _platform_error(400, "Invalid JSON body")
-
-        if not isinstance(body, dict):
-            return _platform_error(400, "Request body must be a JSON object")
-
-        try:
-            run_req = RunCreate.model_validate(body)
-        except Exception as exc:
-            return _platform_error(422, f"Validation error: {exc}")
-
-        name_err = validate_graph_name(run_req.assistant_id)
-        if name_err:
-            return _platform_error(400, name_err)
-        preflight = _preflight_run_create(run_req)
-        if preflight is not None:
-            return preflight
+        parsed = _parse_run_create(req, deps, require_dict_body=True)
+        if isinstance(parsed, func.HttpResponse):
+            return parsed
+        run_req = parsed
 
         stream_mode, mode_err = _normalize_stream_mode(run_req.stream_mode)
         if mode_err is not None:
             return mode_err
 
-        reg = deps.registrations.get(run_req.assistant_id)
-        if reg is None:
-            return _platform_error(404, f"Assistant {run_req.assistant_id!r} not found")
-
-        if run_req.input:
-            input_err = validate_input_structure(
-                run_req.input,
-                max_depth=deps.max_input_depth,
-                max_nodes=deps.max_input_nodes,
-            )
-            if input_err:
-                return _platform_error(400, input_err)
-        if run_req.config:
-            config_err = validate_input_structure(
-                run_req.config,
-                max_depth=deps.max_input_depth,
-                max_nodes=deps.max_input_nodes,
-            )
-            if config_err:
-                return _platform_error(400, config_err)
+        reg = _resolve_run_graph(run_req, deps)
+        if isinstance(reg, func.HttpResponse):
+            return reg
 
         exec_graph = _get_threadless_graph(reg.graph)
         if exec_graph is None:
@@ -476,15 +316,9 @@ def register_run_routes(
                 f"Graph {run_req.assistant_id!r} does not support streaming",
             )
 
-        config: dict[str, Any] = {}
-        if run_req.config:
-            user_config = dict(run_req.config)
-            user_configurable = user_config.pop("configurable", {})
-            config["configurable"] = user_configurable
-            config.update(user_config)
-
-        if config.get("configurable", {}).get("thread_id") is not None:
-            return _platform_error(422, "thread_id is not allowed on threadless runs")
+        config = _build_threadless_config(run_req)
+        if isinstance(config, func.HttpResponse):
+            return config
 
         run_id = str(uuid.uuid4())
 

--- a/tests/test_platform_routes.py
+++ b/tests/test_platform_routes.py
@@ -2937,7 +2937,7 @@ class TestCoverageBoostRunsThreads:
     def test_runs_stream_config_validation_failure(
         self, store: InMemoryThreadStore, monkeypatch: Any
     ) -> None:
-        import azure_functions_langgraph.platform._runs as runs_module
+        import azure_functions_langgraph.platform._common as runs_module
 
         app = _build_platform_app(graphs={"agent": FakeCompiledGraph()}, store=store)
         thread = store.create()
@@ -2956,7 +2956,7 @@ class TestCoverageBoostRunsThreads:
     def test_runs_wait_threadless_config_validation_failure(
         self, store: InMemoryThreadStore, monkeypatch: Any
     ) -> None:
-        import azure_functions_langgraph.platform._runs as runs_module
+        import azure_functions_langgraph.platform._common as runs_module
 
         app = _build_platform_app(graphs={"agent": FakeCompiledGraph()}, store=store)
         monkeypatch.setattr(


### PR DESCRIPTION
## Summary
Implements the first checklist item of #269: de-duplicating the 4× `RunCreate` preamble in `platform/_runs.py`.

Extracts into `platform/_common.py`:
- `_parse_run_create(req, deps, *, require_dict_body)` — body-size guard → JSON parse → optional dict-shape guard → `RunCreate.model_validate` → assistant-name validation → unsupported-feature preflight.
- `_resolve_run_graph(run_req, deps)` — assistant registration lookup (404) + input/config structure validation (400).
- `_validate_run_io_structure(run_req, deps)` — input/config depth/breadth limits.
- `_build_threaded_config(run_req, thread_id)` and `_build_threadless_config(run_req)` — config assembly (threadless variant rejects `thread_id` with 422).

All four handlers (`runs_wait`, `runs_stream`, `runs_wait_threadless`, `runs_stream_threadless`) now share these helpers.

## Behavior preservation
- Exact status-code **precedence** is preserved: thread-lookup (404) and `stream_mode` (422/501) checks stay inline in the threaded handlers between the parse and resolve steps, so error ordering is unchanged.
- Helpers return a `value | HttpResponse` union; callers narrow via `isinstance(..., func.HttpResponse)` — no `assert`, no `type: ignore`.

## Verification
- `ruff check src tests` — clean
- `hatch run typecheck` (mypy `src tests`) — clean
- `hatch run test` — **948 passed, 6 skipped**, total coverage **95.64%** (gate 95%).
- Two route tests that monkeypatched `_runs.validate_input_structure` updated to patch the relocated symbol in `_common`.

Part of #269