### PR TITLE
refactor(platform): extract shared SSE overflow guard in _runs.py

### DIFF
--- a/src/azure_functions_langgraph/platform/_common.py
+++ b/src/azure_functions_langgraph/platform/_common.py
@@ -12,6 +12,7 @@ from azure_functions_langgraph._validation import (
     validate_graph_name,
     validate_input_structure,
 )
+from azure_functions_langgraph.platform._sse import format_end_event, format_error_event
 from azure_functions_langgraph.platform.contracts import (
     Assistant,
     Checkpoint,
@@ -77,6 +78,29 @@ def _normalize_stream_mode(
             "Provide a single stream_mode string or a one-element list.",
         )
     return raw_mode, None
+
+def _check_stream_overflow(
+    chunks: list[str],
+    buffered_bytes: int,
+    chunk_bytes: int,
+    max_bytes: int,
+) -> bool:
+    """Guard the buffered SSE size cap shared by every streaming route.
+
+    Returns ``True`` when appending *chunk_bytes* would push the buffer past
+    *max_bytes*; on overflow the standard error + end events are appended to
+    *chunks* so the caller can release any locks and emit the SSE response.
+    Pass ``chunk_bytes=0`` for the initial metadata-only check.
+    """
+    if buffered_bytes + chunk_bytes > max_bytes:
+        chunks.append(
+            format_error_event(
+                f"stream response exceeded max buffered size ({max_bytes} bytes)"
+            )
+        )
+        chunks.append(format_end_event())
+        return True
+    return False
 
 
 _UNSUPPORTED_FIELDS: dict[str, str] = {

--- a/src/azure_functions_langgraph/platform/_runs.py
+++ b/src/azure_functions_langgraph/platform/_runs.py
@@ -14,6 +14,7 @@ from azure_functions_langgraph.platform._common import (
     _build_sse_response,
     _build_threaded_config,
     _build_threadless_config,
+    _check_stream_overflow,
     _get_threadless_graph,
     _normalize_stream_mode,
     _parse_run_create,
@@ -186,13 +187,7 @@ def register_run_routes(
         chunks.append(meta_chunk)
         buffered_bytes += len(meta_chunk.encode())
 
-        if buffered_bytes > max_bytes:
-            chunks.append(
-                format_error_event(
-                    f"stream response exceeded max buffered size ({max_bytes} bytes)"
-                )
-            )
-            chunks.append(format_end_event())
+        if _check_stream_overflow(chunks, buffered_bytes, 0, max_bytes):
             _release_thread_run_lock(deps, thread_id, status="error")
             return _build_sse_response(
                 chunks,
@@ -206,12 +201,7 @@ def register_run_routes(
             ):
                 chunk = format_data_event(stream_mode, event)
                 chunk_bytes = len(chunk.encode())
-                if buffered_bytes + chunk_bytes > max_bytes:
-                    err_chunk = format_error_event(
-                        f"stream response exceeded max buffered size ({max_bytes} bytes)"
-                    )
-                    chunks.append(err_chunk)
-                    chunks.append(format_end_event())
+                if _check_stream_overflow(chunks, buffered_bytes, chunk_bytes, max_bytes):
                     _release_thread_run_lock(deps, thread_id, status="error")
                     return _build_sse_response(
                         chunks,
@@ -331,13 +321,7 @@ def register_run_routes(
         chunks.append(meta_chunk)
         buffered_bytes += len(meta_chunk.encode())
 
-        if buffered_bytes > max_bytes:
-            chunks.append(
-                format_error_event(
-                    f"stream response exceeded max buffered size ({max_bytes} bytes)"
-                )
-            )
-            chunks.append(format_end_event())
+        if _check_stream_overflow(chunks, buffered_bytes, 0, max_bytes):
             return _build_sse_response(
                 chunks,
                 content_location=f"/api/runs/{run_id}",
@@ -350,12 +334,7 @@ def register_run_routes(
             ):
                 chunk = format_data_event(stream_mode, event)
                 chunk_bytes = len(chunk.encode())
-                if buffered_bytes + chunk_bytes > max_bytes:
-                    err_chunk = format_error_event(
-                        f"stream response exceeded max buffered size ({max_bytes} bytes)"
-                    )
-                    chunks.append(err_chunk)
-                    chunks.append(format_end_event())
+                if _check_stream_overflow(chunks, buffered_bytes, chunk_bytes, max_bytes):
                     return _build_sse_response(
                         chunks,
                         content_location=f"/api/runs/{run_id}",


### PR DESCRIPTION
## Summary
- Adds `_check_stream_overflow(chunks, buffered_bytes, chunk_bytes, max_bytes)` to `platform/_common.py`, which appends the standard error + end SSE events and reports overflow.
- Applies it at the four buffered-size cap checks across `runs_stream` and `runs_stream_threadless`, replacing the repeated append blocks. Lock-release stays handler-specific; the byte cap and behavior are unchanged.
- Completes the SSE portion of #269 (the shared `_build_sse_response` builder and `_normalize_stream_mode` landed earlier in #273).

## Verification
- `ruff check` clean, `mypy` clean (60 files).
- Full suite: 959 passed, 6 skipped, coverage 96.39% (gate 95%); `_runs.py` at 98%.

Part of #269