### PR TITLE
feat(endpoint): write shared endpoint metadata namespace (#294)

### DIFF
--- a/src/azure_functions_langgraph/_endpoint.py
+++ b/src/azure_functions_langgraph/_endpoint.py
@@ -42,8 +42,13 @@ _REF_TEMPLATE = "#/$defs/{model}"
 _SchemaMode = Literal["validation", "serialization"]
 
 
-class EndpointMetadata(TypedDict, total=False):
-    """Shape of ``_azure_functions_metadata["endpoint"]`` (schema version 1)."""
+class EndpointMetadata(TypedDict):
+    """Shape of ``_azure_functions_metadata["endpoint"]`` (schema version 1).
+
+    Total: ``build_endpoint_metadata`` always emits every key, and consumers
+    index them directly, so all fields are required by the cross-package
+    contract.
+    """
 
     version: int
     request_body: dict[str, Any] | None
@@ -52,7 +57,7 @@ class EndpointMetadata(TypedDict, total=False):
     responses: dict[str, dict[str, Any]] | None
 
 
-def _is_model_type(model: type[BaseModel] | None) -> TypeGuard[type[BaseModel]]:
+def _is_model_type(model: object) -> TypeGuard[type[BaseModel]]:
     """Return ``True`` if *model* is a Pydantic ``BaseModel`` subclass."""
     return isinstance(model, type) and issubclass(model, BaseModel)
 

--- a/src/azure_functions_langgraph/_endpoint.py
+++ b/src/azure_functions_langgraph/_endpoint.py
@@ -1,0 +1,120 @@
+"""Builder for the cross-package ``endpoint`` metadata namespace.
+
+Toolkit convention (shared across the Azure Functions Python DX Toolkit):
+handlers carry an ``_azure_functions_metadata`` dict keyed by a package-owned
+*namespace* string, so sibling packages (e.g. ``azure-functions-openapi``) can
+discover metadata **without importing this package**.
+
+The ``"endpoint"`` namespace is the shared, OpenAPI-ready contract. Unlike the
+``"langgraph"`` namespace (which carries package-internal data), the
+``endpoint`` payload is entirely *self-contained* JSON Schema: the consumer
+needs no import of this package and no access to the user's model classes.
+
+The payload shape and canonicalization rules are pinned by the shared endpoint
+SPEC owned by ``azure-functions-validation``. This module intentionally
+*replicates* that contract (it is NOT shared via a runtime dependency); keep the
+``version`` field, the ``by_alias``/``ref_template``/``mode`` canonicalization,
+and the merge-without-clobber semantics identical to the sibling packages.
+
+Ref: https://github.com/yeongseon/azure-functions-validation-python/issues/270
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal, TypedDict, TypeGuard
+
+from pydantic import BaseModel
+
+#: Convention attribute name shared across all toolkit packages.
+METADATA_ATTR = "_azure_functions_metadata"
+
+#: Namespace owned by the shared endpoint contract.
+ENDPOINT_NAMESPACE = "endpoint"
+
+#: Schema version for the ``endpoint`` namespace payload.
+ENDPOINT_METADATA_VERSION = 1
+
+#: Pydantic ref template pinned by the SPEC so ``$defs`` stay unresolved and the
+#: consumer (openapi) remains the sole ``$ref``-collision authority.
+_REF_TEMPLATE = "#/$defs/{model}"
+
+#: Pydantic JSON-Schema generation modes (request vs response canonicalization).
+_SchemaMode = Literal["validation", "serialization"]
+
+
+class EndpointMetadata(TypedDict, total=False):
+    """Shape of ``_azure_functions_metadata["endpoint"]`` (schema version 1)."""
+
+    version: int
+    request_body: dict[str, Any] | None
+    request_body_required: bool
+    parameters: list[dict[str, Any]]
+    responses: dict[str, dict[str, Any]] | None
+
+
+def _is_model_type(model: type[BaseModel] | None) -> TypeGuard[type[BaseModel]]:
+    """Return ``True`` if *model* is a Pydantic ``BaseModel`` subclass."""
+    return isinstance(model, type) and issubclass(model, BaseModel)
+
+
+def _model_schema(model: type[BaseModel], mode: _SchemaMode) -> dict[str, Any]:
+    """Generate a model's JSON Schema using the SPEC-pinned canonicalization."""
+    return model.model_json_schema(
+        by_alias=True,
+        ref_template=_REF_TEMPLATE,
+        mode=mode,
+    )
+
+
+def build_endpoint_metadata(
+    *,
+    request_model: type[BaseModel] | None,
+    response_model: type[BaseModel] | None,
+    parameters: list[dict[str, Any]] | None = None,
+    success_status_code: int = 200,
+) -> EndpointMetadata:
+    """Build the ``endpoint`` namespace payload for a single HTTP route.
+
+    ``request_body`` is the request model's JSON Schema in ``"validation"`` mode;
+    ``responses`` maps the success status code to the response model's JSON Schema
+    in ``"serialization"`` mode. ``parameters`` is passed through verbatim (each
+    entry is a self-contained OpenAPI parameter object).
+    """
+    if _is_model_type(request_model):
+        request_body: dict[str, Any] | None = _model_schema(request_model, "validation")
+        request_body_required = any(
+            field.is_required() for field in request_model.model_fields.values()
+        )
+    else:
+        request_body = None
+        request_body_required = False
+
+    if _is_model_type(response_model):
+        status = str(success_status_code or 200)
+        responses: dict[str, dict[str, Any]] | None = {
+            status: {"schema": _model_schema(response_model, "serialization")}
+        }
+    else:
+        responses = None
+
+    payload: EndpointMetadata = {
+        "version": ENDPOINT_METADATA_VERSION,
+        "request_body": request_body,
+        "request_body_required": request_body_required,
+        "parameters": list(parameters) if parameters else [],
+        "responses": responses,
+    }
+    return payload
+
+
+def set_endpoint_metadata(handler: Any, payload: EndpointMetadata) -> None:
+    """Merge the ``endpoint`` namespace onto *handler* without clobbering others.
+
+    Reads any pre-existing convention attribute (e.g. the ``langgraph`` namespace
+    already written by :func:`set_langgraph_metadata`), merges in *payload* under
+    the ``endpoint`` namespace, and writes the result back onto *handler*.
+    """
+    existing = getattr(handler, METADATA_ATTR, None)
+    base: dict[str, Any] = dict(existing) if isinstance(existing, dict) else {}
+    base[ENDPOINT_NAMESPACE] = payload
+    setattr(handler, METADATA_ATTR, base)

--- a/src/azure_functions_langgraph/app.py
+++ b/src/azure_functions_langgraph/app.py
@@ -10,6 +10,10 @@ import warnings
 
 import azure.functions as func
 
+from azure_functions_langgraph._endpoint import (
+    build_endpoint_metadata,
+    set_endpoint_metadata,
+)
 from azure_functions_langgraph._handlers import (
     handle_invoke,
     handle_state,
@@ -52,6 +56,44 @@ class _GraphRegistration:
     auth_level: Optional[func.AuthLevel] = None
     request_model: Optional[type[Any]] = None
     response_model: Optional[type[Any]] = None
+
+
+@dataclass(frozen=True)
+class _EndpointSpec:
+    """Resolved request/response models and parameters for one route type."""
+
+    request_model: Optional[type[Any]] = None
+    response_model: Optional[type[Any]] = None
+    parameters: tuple[dict[str, Any], ...] = ()
+
+
+def _resolve_endpoint_spec(reg: _GraphRegistration, endpoint: str) -> _EndpointSpec:
+    """Resolve the (request_model, response_model, parameters) triple for a route.
+
+    Single source of truth shared by :meth:`LangGraphApp._register_route` (which
+    writes the ``endpoint`` metadata namespace) and
+    :meth:`LangGraphApp.get_app_metadata` (which builds the public
+    :class:`RouteMetadata`), so the two never drift.
+    """
+    if endpoint == "invoke":
+        return _EndpointSpec(reg.request_model, reg.response_model, ())
+    if endpoint == "stream":
+        # Stream responses are SSE, not a single JSON body.
+        return _EndpointSpec(reg.request_model, None, ())
+    if endpoint == "state":
+        return _EndpointSpec(
+            None,
+            None,
+            (
+                {
+                    "name": "thread_id",
+                    "in": "path",
+                    "required": True,
+                    "schema": {"type": "string"},
+                },
+            ),
+        )
+    return _EndpointSpec()  # defensive: unknown endpoint type carries no models
 
 
 @dataclass
@@ -344,6 +386,18 @@ class LangGraphApp:
         }
         set_langgraph_metadata(handler, _payload)
 
+        # Attach the shared, self-contained ``endpoint`` namespace consumed by
+        # azure-functions-openapi (issue #294; umbrella validation#270).
+        spec = _resolve_endpoint_spec(reg, endpoint)
+        set_endpoint_metadata(
+            handler,
+            build_endpoint_metadata(
+                request_model=spec.request_model,
+                response_model=spec.response_model,
+                parameters=list(spec.parameters),
+            ),
+        )
+
         app.function_name(name=fn_name)(
             app.route(route=route, methods=methods, auth_level=effective_auth)(handler)
         )
@@ -420,42 +474,38 @@ class LangGraphApp:
         for reg in self._registrations.values():
             routes: list[RouteMetadata] = []
             # invoke route
+            invoke_spec = _resolve_endpoint_spec(reg, "invoke")
             routes.append(
                 RouteMetadata(
                     path=self._metadata_path(_ROUTE_INVOKE.format(name=reg.name)),
                     method="POST",
                     summary=f"Invoke graph '{reg.name}'",
-                    request_model=reg.request_model,
-                    response_model=reg.response_model,
+                    request_model=invoke_spec.request_model,
+                    response_model=invoke_spec.response_model,
                 )
             )
             # stream route (if enabled)
             if self._has_stream_route(reg):
+                stream_spec = _resolve_endpoint_spec(reg, "stream")
                 routes.append(
                     RouteMetadata(
                         path=self._metadata_path(_ROUTE_STREAM.format(name=reg.name)),
                         method="POST",
                         summary=f"Stream graph '{reg.name}'",
-                        request_model=reg.request_model,
+                        request_model=stream_spec.request_model,
                         # Stream responses are SSE, not a single JSON body
                     )
                 )
             # state route — use same capability test as _build_function_app
             if self._has_state_route(reg):
+                state_spec = _resolve_endpoint_spec(reg, "state")
                 routes.append(
                     RouteMetadata(
                         path=self._metadata_path(_ROUTE_STATE.format(name=reg.name)),
                         method="GET",
                         summary=f"Get thread state for '{reg.name}'",
-                        parameters=(
-                            MappingProxyType(
-                                {
-                                    "name": "thread_id",
-                                    "in": "path",
-                                    "required": True,
-                                    "schema": {"type": "string"},
-                                }
-                            ),
+                        parameters=tuple(
+                            MappingProxyType(param) for param in state_spec.parameters
                         ),
                     )
                 )

--- a/src/azure_functions_langgraph/openapi.py
+++ b/src/azure_functions_langgraph/openapi.py
@@ -32,6 +32,15 @@ def register_with_openapi(app: LangGraphApp) -> int:
     calls :func:`azure_functions_openapi.register_openapi_metadata` for each
     route.
 
+    .. deprecated:: 0.6.0
+        Request/response *shape* now also flows through the shared
+        ``_azure_functions_metadata["endpoint"]`` namespace, which
+        ``azure-functions-openapi`` reads directly from each handler (see
+        issue #294; umbrella azure-functions-validation#270). This bridge is
+        retained through the deprecation cycle to keep supplying documentation
+        metadata (``summary``/``description``/``tags``) that the endpoint
+        namespace intentionally does not carry.
+
     Args:
         app: A :class:`LangGraphApp` instance with graphs already registered.
 

--- a/tests/test_endpoint_metadata.py
+++ b/tests/test_endpoint_metadata.py
@@ -1,0 +1,287 @@
+"""Tests for the shared ``endpoint`` metadata namespace (issue #294).
+
+``LangGraphApp`` writes ``_azure_functions_metadata["endpoint"]`` onto each
+per-graph HTTP handler so ``azure-functions-openapi`` can generate an OpenAPI
+spec directly from the handler, without importing this package. The payload is a
+*self-contained* JSON-Schema contract replicated from ``azure-functions-validation``.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from pydantic import BaseModel, Field
+
+from azure_functions_langgraph._endpoint import (
+    ENDPOINT_METADATA_VERSION,
+    build_endpoint_metadata,
+    set_endpoint_metadata,
+)
+from azure_functions_langgraph.app import LangGraphApp, _EndpointSpec, _resolve_endpoint_spec
+from tests.conftest import FakeCompiledGraph, FakeStatefulGraph
+
+
+class RequestBody(BaseModel):
+    """Request model with an alias and a required + optional field."""
+
+    user_id: int = Field(alias="userId")
+    note: str = "hello"
+
+
+class OptionalBody(BaseModel):
+    """Request model whose fields are all optional."""
+
+    note: str = "hi"
+
+
+class ResponseBody(BaseModel):
+    """Response model."""
+
+    message: str
+
+
+def _endpoint_meta(handler: object) -> dict[str, Any]:
+    metadata = getattr(handler, "_azure_functions_metadata", None)
+    assert isinstance(metadata, dict)
+    assert "endpoint" in metadata
+    payload = metadata["endpoint"]
+    assert isinstance(payload, dict)
+    return payload
+
+
+def _get_registered_functions(func_app: object) -> dict[str, object]:
+    functions: dict[str, object] = {}
+    builders = getattr(func_app, "_function_builders", [])
+    for builder in builders:
+        fn = getattr(builder, "_function", None)
+        if fn is not None:
+            fn_name = getattr(fn, "get_function_name", lambda: None)()
+            user_fn = getattr(fn, "get_user_function", lambda: None)()
+            if fn_name and user_fn:
+                functions[fn_name] = user_fn
+    return functions
+
+
+class TestEndpointNamespaceOnHandlers:
+    """The endpoint namespace is attached to per-graph handlers with correct shape."""
+
+    def test_invoke_handler_has_endpoint_metadata(self) -> None:
+        app = LangGraphApp()
+        app.register(
+            graph=FakeCompiledGraph(),
+            name="agent",
+            request_model=RequestBody,
+            response_model=ResponseBody,
+        )
+        invoke_fn = _get_registered_functions(app.function_app)["aflg_agent_invoke"]
+
+        payload = _endpoint_meta(invoke_fn)
+        assert payload["version"] == ENDPOINT_METADATA_VERSION
+        assert payload["request_body"] == RequestBody.model_json_schema(
+            by_alias=True, ref_template="#/$defs/{model}", mode="validation"
+        )
+        # user_id is required (no default) -> request body required.
+        assert payload["request_body_required"] is True
+        assert payload["parameters"] == []
+        assert payload["responses"] == {
+            "200": {
+                "schema": ResponseBody.model_json_schema(
+                    by_alias=True, ref_template="#/$defs/{model}", mode="serialization"
+                )
+            }
+        }
+
+    def test_stream_handler_has_request_body_but_no_responses(self) -> None:
+        app = LangGraphApp()
+        app.register(
+            graph=FakeCompiledGraph(),
+            name="agent",
+            request_model=RequestBody,
+            response_model=ResponseBody,
+        )
+        stream_fn = _get_registered_functions(app.function_app)["aflg_agent_stream"]
+
+        payload = _endpoint_meta(stream_fn)
+        # Stream reuses the request model but streams SSE (no single JSON response).
+        assert payload["request_body"] is not None
+        assert payload["responses"] is None
+        assert payload["parameters"] == []
+
+    def test_state_handler_has_thread_id_path_param_only(self) -> None:
+        app = LangGraphApp()
+        app.register(
+            graph=FakeStatefulGraph(),
+            name="stateful",
+            request_model=RequestBody,
+            response_model=ResponseBody,
+        )
+        state_fn = _get_registered_functions(app.function_app)["aflg_stateful_state"]
+
+        payload = _endpoint_meta(state_fn)
+        assert payload["request_body"] is None
+        assert payload["request_body_required"] is False
+        assert payload["responses"] is None
+        assert payload["parameters"] == [
+            {"name": "thread_id", "in": "path", "required": True, "schema": {"type": "string"}}
+        ]
+
+    def test_endpoint_metadata_with_no_models(self) -> None:
+        app = LangGraphApp()
+        app.register(graph=FakeCompiledGraph(), name="agent")
+        invoke_fn = _get_registered_functions(app.function_app)["aflg_agent_invoke"]
+
+        payload = _endpoint_meta(invoke_fn)
+        assert payload["request_body"] is None
+        assert payload["request_body_required"] is False
+        assert payload["responses"] is None
+        assert payload["parameters"] == []
+
+    def test_endpoint_namespace_preserves_langgraph_namespace(self) -> None:
+        app = LangGraphApp()
+        app.register(graph=FakeCompiledGraph(), name="agent")
+        invoke_fn = _get_registered_functions(app.function_app)["aflg_agent_invoke"]
+
+        metadata = getattr(invoke_fn, "_azure_functions_metadata")
+        assert "langgraph" in metadata
+        assert "endpoint" in metadata
+        assert metadata["langgraph"]["graph_name"] == "agent"
+
+
+class TestBuildEndpointMetadata:
+    """Unit coverage for the replicated builder."""
+
+    def test_request_body_required_true_when_field_required(self) -> None:
+        payload = build_endpoint_metadata(request_model=RequestBody, response_model=None)
+        assert payload["request_body_required"] is True
+
+    def test_request_body_required_false_when_all_optional(self) -> None:
+        payload = build_endpoint_metadata(request_model=OptionalBody, response_model=None)
+        assert payload["request_body"] is not None
+        assert payload["request_body_required"] is False
+
+    def test_success_status_code_key(self) -> None:
+        payload = build_endpoint_metadata(
+            request_model=None, response_model=ResponseBody, success_status_code=201
+        )
+        assert payload["responses"] is not None
+        assert set(payload["responses"]) == {"201"}
+
+    def test_success_status_code_falls_back_to_200(self) -> None:
+        payload = build_endpoint_metadata(
+            request_model=None, response_model=ResponseBody, success_status_code=0
+        )
+        assert payload["responses"] is not None
+        assert set(payload["responses"]) == {"200"}
+
+    def test_parameters_passed_through(self) -> None:
+        params = [{"name": "q", "in": "query", "required": False, "schema": {"type": "string"}}]
+        payload = build_endpoint_metadata(
+            request_model=None, response_model=None, parameters=params
+        )
+        assert payload["parameters"] == params
+
+    def test_non_model_inputs_are_ignored(self) -> None:
+        payload = build_endpoint_metadata(
+            request_model="not-a-model",  # type: ignore[arg-type]
+            response_model=object,  # type: ignore[arg-type]
+        )
+        assert payload["request_body"] is None
+        assert payload["responses"] is None
+
+    def test_by_alias_and_ref_template_fidelity(self) -> None:
+        class Nested(BaseModel):
+            value: int
+
+        class Wrapper(BaseModel):
+            item: Nested
+            tag: str = Field(alias="tagName")
+
+        payload = build_endpoint_metadata(request_model=Wrapper, response_model=None)
+        schema = payload["request_body"]
+        assert schema is not None
+        # by_alias -> property uses the serialization alias.
+        assert "tagName" in schema["properties"]
+        # ref_template -> nested model referenced via #/$defs/{model}.
+        assert schema["properties"]["item"]["$ref"] == "#/$defs/Nested"
+
+
+class TestSetEndpointMetadata:
+    """The merge helper does not clobber sibling namespaces."""
+
+    def test_merge_preserves_other_namespaces(self) -> None:
+        def handler() -> None:
+            pass
+
+        setattr(handler, "_azure_functions_metadata", {"langgraph": {"version": 1}})
+        set_endpoint_metadata(
+            handler, build_endpoint_metadata(request_model=None, response_model=None)
+        )
+
+        metadata = getattr(handler, "_azure_functions_metadata")
+        assert "langgraph" in metadata
+        assert "endpoint" in metadata
+
+    def test_merge_on_bare_handler(self) -> None:
+        def handler() -> None:
+            pass
+
+        set_endpoint_metadata(
+            handler, build_endpoint_metadata(request_model=None, response_model=None)
+        )
+        metadata = getattr(handler, "_azure_functions_metadata")
+        assert set(metadata) == {"endpoint"}
+
+    def test_merge_ignores_non_dict_existing_attr(self) -> None:
+        def handler() -> None:
+            pass
+
+        setattr(handler, "_azure_functions_metadata", "not-a-dict")
+        set_endpoint_metadata(
+            handler, build_endpoint_metadata(request_model=None, response_model=None)
+        )
+        metadata = getattr(handler, "_azure_functions_metadata")
+        assert set(metadata) == {"endpoint"}
+
+
+class TestResolveEndpointSpec:
+    """The shared resolver is the single source of truth for both writers."""
+
+    def test_invoke_spec(self) -> None:
+        reg = _make_reg(request_model=RequestBody, response_model=ResponseBody)
+        spec = _resolve_endpoint_spec(reg, "invoke")
+        assert spec.request_model is RequestBody
+        assert spec.response_model is ResponseBody
+        assert spec.parameters == ()
+
+    def test_stream_spec(self) -> None:
+        reg = _make_reg(request_model=RequestBody, response_model=ResponseBody)
+        spec = _resolve_endpoint_spec(reg, "stream")
+        assert spec.request_model is RequestBody
+        assert spec.response_model is None
+        assert spec.parameters == ()
+
+    def test_state_spec(self) -> None:
+        reg = _make_reg(request_model=RequestBody, response_model=ResponseBody)
+        spec = _resolve_endpoint_spec(reg, "state")
+        assert spec.request_model is None
+        assert spec.response_model is None
+        assert spec.parameters == (
+            {"name": "thread_id", "in": "path", "required": True, "schema": {"type": "string"}},
+        )
+
+    def test_unknown_spec_is_empty(self) -> None:
+        reg = _make_reg(request_model=RequestBody, response_model=ResponseBody)
+        spec = _resolve_endpoint_spec(reg, "unknown")
+        assert spec == _EndpointSpec()
+
+
+def _make_reg(*, request_model: Optional[type[Any]], response_model: Optional[type[Any]]) -> Any:
+    """Build a LangGraphApp registration record via the public register() API."""
+    app = LangGraphApp()
+    app.register(
+        graph=FakeStatefulGraph(),
+        name="agent",
+        request_model=request_model,
+        response_model=response_model,
+    )
+    return app._registrations["agent"]


### PR DESCRIPTION
## Context

Implements azure-functions-langgraph#294 as part of the endpoint-metadata convergence umbrella (azure-functions-validation#270). The langgraph app now writes a shared `endpoint` metadata namespace onto each generated route handler, so downstream OpenAPI tooling can derive request/response schemas and parameters directly from the handler metadata rather than the legacy `register_with_openapi` bridge.

## What changed

- **NEW `_endpoint.py`** — replicated (no runtime dependency on validation/openapi) endpoint-metadata builder:
  - `EndpointMetadata` TypedDict + constants (`ENDPOINT_NAMESPACE="endpoint"`, `ENDPOINT_METADATA_VERSION=1`).
  - `build_endpoint_metadata(*, request_model, response_model, parameters=None, success_status_code=200)` — emits exactly `{version, request_body, request_body_required, parameters, responses}` using `model_json_schema(by_alias=True, ref_template="#/$defs/{model}", mode=...)` (`mode="validation"` for requests, `mode="serialization"` for responses).
  - `set_endpoint_metadata(handler, payload)` — non-clobbering merge under the `endpoint` namespace.
- **`app.py`** — added `_EndpointSpec` + single shared `_resolve_endpoint_spec(reg, endpoint)` helper (Option c) used by BOTH `_register_route` (attaches metadata right after `set_langgraph_metadata`) and `get_app_metadata`. Scope is per-graph routes only (invoke/stream/state); health/app-level routes excluded.
- **`openapi.py`** — `register_with_openapi` marked `.. deprecated:: 0.6.0` (bridge behaviour untouched).
- **Tests** — `tests/test_endpoint_metadata.py` (19 tests): handler-namespace attachment, `build_endpoint_metadata` unit coverage, merge semantics, and `_resolve_endpoint_spec` per-endpoint behaviour.

## Design & review

- Oracle design gate: confirmed payload shape (no path/method/summary/tags — those come from the AF `@app.route` binding and the existing bridge), replication over runtime dep, and the shared-helper (Option c) DRY resolution.
- Oracle review gate: **92 — SHIP** (two non-blocking notes only).

## Validation

- `make check-all` green: mypy strict clean, ruff clean, bandit clean.
- 978 passed / 6 skipped, coverage 96.57% (gate 95%).

Refs #294, azure-functions-validation#270