### PR TITLE
fix(deps): pin azure-functions to >=1.17,<3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "azure-functions",
+    "azure-functions>=1.17,<3",
     "langgraph>=1.0,<2.0",
     "pydantic>=2.0,<3.0",
 ]


### PR DESCRIPTION
## Summary
- Pin `azure-functions` runtime dependency to `>=1.17,<3` (was unbounded), matching the documented floor and guarding against a future breaking major.

## Verification
- `make check-all` passes (tests + coverage >=95% + security scan).

Closes #299