### PR TITLE
chore(deps): cap azure-functions below 2.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,9 @@ classifiers = [
 ]
 
 dependencies = [
-    "azure-functions>=1.17,<3",
+    # Cap below 2.0.0: azure-functions v2 may change worker function-indexing
+    # behavior this package relies on. See knowledge#46 / dx#8.
+    "azure-functions>=1.17,<2.0.0",
     "langgraph>=1.0,<2.0",
     "pydantic>=2.0,<3.0",
 ]


### PR DESCRIPTION
## Context
Unifies the `azure-functions` upper bound across the DX Toolkit at `<2.0.0`. azure-functions v2 may change worker function-indexing behavior this package relies on. Follow-up item from the dx#8 umbrella.

## Changes
- `pyproject.toml`: `azure-functions>=1.17,<3` → `>=1.17,<2.0.0`, with rationale comment referencing knowledge#46 / dx#8.

## Verification
- `make check-all` → EXIT=0.

Refs yeongseon/azure-functions-python-dx#8