### PR TITLE
chore: drop stale noqa directives

### DIFF
--- a/src/azure_functions_langgraph/checkpointers/cosmos.py
+++ b/src/azure_functions_langgraph/checkpointers/cosmos.py
@@ -94,7 +94,7 @@ def create_cosmos_checkpointer(
         ImportError: If ``langgraph-checkpoint-cosmosdb`` is not installed.
             Install via the ``cosmos`` extra.
     """
-    global _USE_MARKER_FALLBACK  # noqa: PLW0603
+    global _USE_MARKER_FALLBACK
 
     # --- Credential resolution ---
     if key is not None and credential is not None:
@@ -189,9 +189,9 @@ def create_cosmos_checkpointer(
         except TypeError:
             # Upstream uses __slots__ without __weakref__; fall back to marker
             _USE_MARKER_FALLBACK = True
-            saver._managed_by_cosmos_helper = True  # noqa: SLF001
+            saver._managed_by_cosmos_helper = True
     else:
-        saver._managed_by_cosmos_helper = True  # noqa: SLF001
+        saver._managed_by_cosmos_helper = True
 
     return saver
 
@@ -233,7 +233,7 @@ def close_cosmos_checkpointer(saver: CosmosDBSaver) -> None:
                 close_fn()
 
     # Mark closed
-    saver._cosmos_helper_closed = True  # noqa: SLF001
+    saver._cosmos_helper_closed = True
 
     # Remove from tracking
     _managed_savers.discard(saver)

--- a/src/azure_functions_langgraph/platform/_common.py
+++ b/src/azure_functions_langgraph/platform/_common.py
@@ -200,7 +200,7 @@ def _parse_run_create(
 
     try:
         run_req = RunCreate.model_validate(body)
-    except Exception as exc:  # noqa: BLE001 - surfaced as a 422 to the client
+    except Exception as exc:
         return _platform_error(422, f"Validation error: {exc}")
 
     name_err = validate_graph_name(run_req.assistant_id)

--- a/src/azure_functions_langgraph/platform/_runs.py
+++ b/src/azure_functions_langgraph/platform/_runs.py
@@ -47,7 +47,7 @@ def _release_thread_run_lock(
             thread_id,
             status,
         )
-    except Exception:  # noqa: BLE001
+    except Exception:
         logger.exception(
             "Unexpected error releasing run lock for thread %s (target status: %s)",
             thread_id,


### PR DESCRIPTION
## Context
Part of the cross-repo legacy/dead-code cleanup (safe deletions only). These `# noqa` codes are no longer triggered under the repo's ruff configuration (`select = ["E", "F", "I"]`), so they suppress nothing and only add noise.

## Changes
Comment-only edits (6 insertions / 6 deletions), no logic changes:
- `checkpointers/cosmos.py`: drop stale `SLF001` (×3)
- `platform/_common.py`: drop stale `PLW0603`
- `platform/_runs.py`: drop stale `BLE001` (×2)

## Acceptance Checklist
- [x] `make check-all` passes locally (ruff, tests, bandit)
- [x] `ruff check src` → All checks passed
- [x] No behavioral change (comment-only edits)

## Out of scope
- False-positive "dead code" (Protocol stub signatures, tested public API) intentionally left untouched.
- A pre-existing flaky test (`test_get_next_version`) is unrelated to this change and left as-is.