### PR TITLE
ci: add tiered pre-publish runtime gate with real-Azure certification

### DIFF
--- a/.github/workflows/e2e-azure.yml
+++ b/.github/workflows/e2e-azure.yml
@@ -37,7 +37,7 @@ jobs:
       resource_group: ${{ steps.names.outputs.rg }}
 
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ inputs.ref || github.ref }}
 

--- a/.github/workflows/e2e-azure.yml
+++ b/.github/workflows/e2e-azure.yml
@@ -1,0 +1,184 @@
+name: e2e-azure
+
+# Azure Release Certification. Dispatch-only: deploys the release commit's own
+# source to a real Azure Functions host, runs the live e2e suite against the
+# native LangGraph routes, and records an azure-cert artifact for the exact
+# release commit + version. The publish-pypi.yml verify-azure-certification gate
+# requires a fresh, matching certification before it will publish.
+#
+# Unlike a PyPI-pinned example, the deployed app installs a wheel built from the
+# checked-out ref (see the "Bundle candidate wheel" step), so this certifies the
+# EXACT candidate under release — not the last-published PyPI version.
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: Release commit SHA (or ref) to certify
+        required: false
+        type: string
+      version:
+        description: Expected package version (must match source __version__)
+        required: false
+        type: string
+
+permissions:
+  id-token: write
+  contents: read
+
+env:
+  AZURE_LOCATION: ${{ vars.AZURE_LOCATION || 'koreacentral' }}
+  REPO_SHORT: langgraph
+
+jobs:
+  deploy_and_test:
+    name: Deploy & Test
+    runs-on: ubuntu-latest
+    outputs:
+      resource_group: ${{ steps.names.outputs.rg }}
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+
+      - name: Compute resource names
+        id: names
+        run: |
+          RUN="${GITHUB_RUN_ID}${GITHUB_RUN_ATTEMPT}"
+          RG="rg-af-e2e-${REPO_SHORT}-${RUN}"
+          APP="af-e2e-${REPO_SHORT}-${RUN}"
+          # Storage name: lowercase alphanumeric, max 24 chars
+          ST="stafe2e${RUN}"
+          ST="${ST:0:24}"
+          echo "rg=${RG}"   >> "$GITHUB_OUTPUT"
+          echo "app=${APP}" >> "$GITHUB_OUTPUT"
+          echo "st=${ST}"   >> "$GITHUB_OUTPUT"
+
+      - name: Azure login (OIDC)
+        uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3.0.0
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Create Resource Group
+        run: |
+          az group create \
+            --name "${{ steps.names.outputs.rg }}" \
+            --location "$AZURE_LOCATION" \
+            --tags purpose=e2e repo=azure-functions-langgraph run="${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+
+      - name: Deploy infra (Bicep)
+        run: |
+          az deployment group create \
+            --resource-group "${{ steps.names.outputs.rg }}" \
+            --template-file infra/main.bicep \
+            --parameters \
+                location="$AZURE_LOCATION" \
+                functionAppName="${{ steps.names.outputs.app }}" \
+                storageName="${{ steps.names.outputs.st }}" \
+                enableAppInsights=false
+
+      - name: Set up Python 3.10
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.10"
+
+      - name: Install Azure Functions Core Tools
+        run: |
+          curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > /tmp/microsoft.gpg
+          sudo install -o root -g root -m 644 /tmp/microsoft.gpg /etc/apt/trusted.gpg.d/
+          sudo sh -c 'echo "deb [arch=amd64] https://packages.microsoft.com/repos/microsoft-ubuntu-$(lsb_release -cs)-prod $(lsb_release -cs) main" > /etc/apt/sources.list.d/dotnetdev.list'
+          sudo apt-get update
+          sudo apt-get install -y azure-functions-core-tools-4
+
+      - name: Bundle candidate wheel into the deploy payload
+        run: |
+          # Build a wheel from THIS ref and inject it into the deployed app's
+          # requirements so the Azure remote build runs the candidate source
+          # under certification — never the PyPI release.
+          python -m pip install --upgrade pip build
+          python -m build --wheel --outdir dist
+          WHEEL=$(ls dist/azure_functions_langgraph-*.whl | head -n1)
+          echo "Built candidate wheel: $WHEEL"
+          mkdir -p examples/e2e_app/wheels
+          cp "$WHEEL" examples/e2e_app/wheels/
+          BASENAME=$(basename "$WHEEL")
+          echo "./wheels/${BASENAME}" >> examples/e2e_app/requirements.txt
+          echo "---- examples/e2e_app/requirements.txt ----"
+          cat examples/e2e_app/requirements.txt
+
+      - name: Install library from source + test deps
+        run: |
+          pip install -e ".[dev]"
+          pip install requests
+
+      - name: Publish function app
+        working-directory: examples/e2e_app
+        timeout-minutes: 30
+        run: |
+          func azure functionapp publish "${{ steps.names.outputs.app }}" --python --build remote
+
+      - name: Run e2e tests
+        env:
+          E2E_BASE_URL: https://${{ steps.names.outputs.app }}.azurewebsites.net
+        run: |
+          # Clear the repo's default addopts (which force '-m "not e2e"' and
+          # coverage) so the e2e-marked suite is actually collected.
+          pytest tests/e2e -v -m e2e -o addopts=""
+
+      - name: Record certification
+        run: |
+          SHA=$(git rev-parse HEAD)
+          FILE_VERSION=$(grep -Po '(?<=__version__ = ")[^"]*' src/azure_functions_langgraph/__init__.py)
+          REQ_VERSION="${{ inputs.version }}"
+          if [ -n "$REQ_VERSION" ] && [ "$REQ_VERSION" != "$FILE_VERSION" ]; then
+            echo "::error ::Requested certification version ($REQ_VERSION) != source version ($FILE_VERSION)"
+            exit 1
+          fi
+          VERSION="${REQ_VERSION:-$FILE_VERSION}"
+          mkdir -p cert
+          cat > cert/certification.json <<EOF
+          {
+            "package": "azure-functions-langgraph",
+            "version": "$VERSION",
+            "commit": "$SHA",
+            "ref": "${{ inputs.ref || github.ref }}",
+            "workflow": "e2e-azure.yml",
+            "run_id": "${{ github.run_id }}",
+            "result": "success",
+            "certified_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          }
+          EOF
+          cat cert/certification.json
+
+      - name: Upload certification record
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: azure-cert
+          path: cert/
+          if-no-files-found: error
+          retention-days: 30
+
+  cleanup:
+    name: Cleanup Azure Resources
+    runs-on: ubuntu-latest
+    needs: [deploy_and_test]
+    if: always()
+    steps:
+      - name: Azure login (OIDC)
+        uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3.0.0
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Delete Resource Group
+        run: |
+          RG="${{ needs.deploy_and_test.outputs.resource_group }}"
+          if [ -n "$RG" ]; then
+            echo "Deleting resource group: $RG"
+            az group delete --name "$RG" --yes --no-wait
+          else
+            echo "No resource group to delete."
+          fi

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -39,7 +39,7 @@ jobs:
       version: ${{ steps.version.outputs.version }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
 
@@ -85,7 +85,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
 
@@ -109,7 +109,7 @@ jobs:
       actions: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
 

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -14,16 +14,32 @@ on:
 
 permissions:
   contents: read
-  id-token: write
 
+# Verify-before-publish gate (see AGENTS.md):
+#   build -> lib-tests -> verify-azure-certification -> publish
+# Tiered runtime verification before any PyPI upload:
+#   * lib-tests            : the library's own unit suite (against the built wheel).
+#   * verify-azure-certification : requires the EXACT release commit to have passed a real-Azure
+#                            deploy+live-e2e certification (e2e-azure.yml) that is fresh and
+#                            version/SHA-matched. Real Azure is certified per release, not per publish.
+# Unlike the sibling repos, this package has NO cookbook host-smoke tier: the real-Azure e2e
+# (e2e-azure.yml) deploys this package's own example app and exercises the native LangGraph HTTP
+# routes (health/invoke/stream). That IS the package-native runtime proof, and the candidate is
+# certified from a wheel built off the release ref (not the last-published PyPI build), so a
+# runtime regression in the release commit cannot slip through to PyPI.
+# The publish job uploads the EXACT artifact that was tested; it never rebuilds.
+# A tag whose gate fails is a failed release candidate: the version stays
+# unpublished. Recover by fixing forward and cutting the next patch tag
+# (never move a tag that may already have been consumed).
 jobs:
-  build-and-publish:
+  build:
+    name: Build & verify version
     runs-on: ubuntu-latest
-    environment: pypi
-
+    outputs:
+      version: ${{ steps.version.outputs.version }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
         with:
           ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
 
@@ -38,6 +54,7 @@ jobs:
           pip install build
 
       - name: Check if tag matches __version__
+        id: version
         run: |
           TAG_NAME="${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}"
           VERSION_FROM_FILE=$(grep -Po '(?<=__version__ = ")[^"]*' src/azure_functions_langgraph/__init__.py)
@@ -49,9 +66,130 @@ jobs:
             echo "::error ::Version in __init__.py ($VERSION_FROM_FILE) does not match git tag ($TAG_VERSION)"
             exit 1
           fi
+          echo "version=$TAG_VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Build distribution packages
         run: python -m build
+
+      - name: Upload distribution artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: dist
+          path: dist/
+          if-no-files-found: error
+          retention-days: 5
+
+  lib-tests:
+    name: Library tests
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Install Hatch
+        run: pip install hatch
+
+      - name: Run test suite
+        run: hatch run test
+
+  verify-azure-certification:
+    name: Verify Azure release certification
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
+
+      - name: Resolve release commit
+        id: commit
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Locate successful Azure certification for this commit
+        id: cert
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          COMMIT: ${{ steps.commit.outputs.sha }}
+        run: |
+          # A release may only publish if the EXACT commit was certified against
+          # real Azure by the trusted certification workflow (see e2e-azure.yml).
+          RUN_ID=$(gh run list \
+            --workflow e2e-azure.yml \
+            --json databaseId,headSha,conclusion \
+            --limit 50 \
+            --jq "[.[] | select(.headSha==\"$COMMIT\" and .conclusion==\"success\")] | first | .databaseId")
+          if [ -z "$RUN_ID" ] || [ "$RUN_ID" = "null" ]; then
+            echo "::error ::No successful Azure certification run found for commit $COMMIT. Dispatch the 'e2e-azure' workflow on this release commit before publishing."
+            exit 1
+          fi
+          echo "Found certification run: $RUN_ID"
+          echo "run_id=$RUN_ID" >> "$GITHUB_OUTPUT"
+
+      - name: Download certification record
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: azure-cert
+          path: cert
+          run-id: ${{ steps.cert.outputs.run_id }}
+          github-token: ${{ github.token }}
+
+      - name: Assert certification matches this release
+        env:
+          COMMIT: ${{ steps.commit.outputs.sha }}
+          VERSION: ${{ needs.build.outputs.version }}
+          FRESHNESS_DAYS: "14"
+        run: |
+          python3 - "$COMMIT" "$VERSION" "$FRESHNESS_DAYS" <<'PY'
+          import json, sys, datetime, pathlib
+          commit, version, fresh_days = sys.argv[1], sys.argv[2], int(sys.argv[3])
+          cert = json.loads(pathlib.Path("cert/certification.json").read_text())
+          def fail(m):
+              print(f"::error ::{m}")
+              sys.exit(1)
+          if cert.get("result") != "success":
+              fail("certification result is not success")
+          if cert.get("package") != "azure-functions-langgraph":
+              fail(f"cert package {cert.get('package')} != azure-functions-langgraph")
+          if cert.get("commit") != commit:
+              fail(f"cert commit {cert.get('commit')} != release commit {commit}")
+          if cert.get("version") != version:
+              fail(f"cert version {cert.get('version')} != release version {version}")
+          ts = cert.get("certified_at")
+          if not ts:
+              fail("cert missing certified_at")
+          certified = datetime.datetime.fromisoformat(ts.replace("Z", "+00:00"))
+          age = datetime.datetime.now(datetime.timezone.utc) - certified
+          if age > datetime.timedelta(days=fresh_days):
+              fail(f"certification is stale: {age.days}d > {fresh_days}d")
+          print(f"Azure certification verified: {version}@{commit[:12]} certified {age.days}d ago")
+          PY
+
+  publish:
+    name: Publish to PyPI
+    needs: [build, lib-tests, verify-azure-certification]
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+    steps:
+      - name: Download tested distribution artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: dist
+          path: dist
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,16 +81,27 @@ When splitting a large piece of work into focused issues, keep the umbrella open
 - `make release VERSION=x.y.z` — set explicit version, update changelog, tag, and push
 - `make tag-release VERSION=x.y.z` — create and push an annotated tag (used internally by release targets)
 
+### Tiered runtime verification (what gates a release)
+
+Release verification is layered; each tier is a **pre-publish gate**, not a post-publish check. No version reaches PyPI until every tier passes:
+
+| Tier | Runs where | Catches |
+| --- | --- | --- |
+| `lib-tests` | publish-pypi.yml (per publish) | library unit regressions (against the built wheel) |
+| `verify-azure-certification` | publish-pypi.yml (per publish) | requires a fresh, SHA+version-matched **real-Azure** certification for the exact release commit |
+| Azure Release Certification (`e2e-azure.yml`) | `workflow_dispatch`, per release | cloud-only drift — deploys this package's own `examples/e2e_app/` to real Azure (Y1 Consumption), runs the native LangGraph HTTP e2e (health/invoke/stream), and records a certification artifact keyed by commit SHA + version. **Certified per release, not per publish.** |
+
+Unlike the sibling repos, this package has **no** cookbook host-smoke tier. The real-Azure e2e deploys this package's own example app and exercises the native LangGraph routes, so it *is* the package-native runtime proof. Critically, the certification builds the candidate **wheel from the release ref** and bundles it into the example app (`examples/e2e_app/wheels/`), so Azure certifies the release commit's source — not the last-published PyPI build.
+
 ### Flow
 1. `make release-patch` (or `-minor` / `-major`) on `main`
 2. This runs: `hatch version` → `git commit` → `make changelog` → `git commit` → `git tag` → `git push`
-3. Tag push triggers **Publish to PyPI** GitHub Actions workflow automatically.
-4. Update `docs/changelog.md` separately if needed (different format from `CHANGELOG.md`).
-5. **Verify the release against the dogfood cookbook.** Once **Publish to PyPI** succeeds, confirm the downstream consumer still passes on the freshly published version:
-   - In [`azure-functions-cookbook-python`](https://github.com/yeongseon/azure-functions-cookbook-python), upgrade to the new release (`hatch run pip install -U "azure-functions-langgraph>=X.Y,<1"`) and run `make test`.
-   - Treat any new `RuntimeWarning`/`DeprecationWarning` surfaced by this library during the cookbook run as a release-blocking signal — decorator-order and API-drift problems are reported as warnings, so a clean run (zero warnings from this package) is part of the release gate.
-   - If the cookbook pins a lower bound (`azure-functions-langgraph>=X.Y,<1`), bump it to the new minor in the same verification PR so examples are tested against the version they advertise.
-   - A release is **not** considered done until the cookbook passes on the published version.
+3. **Real-Azure certification (required once per release, before the final publish).** Before (or immediately after) pushing the release tag, dispatch the **Azure Release Certification** workflow on the exact release commit and version:
+   - `gh workflow run e2e-azure.yml --ref main -f ref=<release-sha> -f version=<x.y.z>`
+   - The run deploys `examples/e2e_app/` (with a wheel built from `<release-sha>`) to real Azure, executes the live e2e suite (health/invoke/stream), and uploads the `azure-cert` artifact (keyed by commit SHA + version).
+4. Tag push triggers the **Publish to PyPI** workflow. The `publish` job runs only after `build → lib-tests → verify-azure-certification` all pass, and it uploads the exact artifact that was built (it never rebuilds). `verify-azure-certification` requires a successful, SHA+version-matched, non-stale (<14 day) certification for the release commit; without it the publish gate fails and the version stays unpublished.
+5. Update `docs/changelog.md` separately if needed (different format from `CHANGELOG.md`).
+6. **Failed-gate recovery (stuck tag).** A git tag is immutable and may already have been consumed, so if the gate fails do **not** move or reuse the tag. Fix forward on `main` and cut the next patch tag (`make release-patch`). The unpublished version number is simply skipped.
 
 ## Branch Hygiene
 

--- a/examples/e2e_app/README.md
+++ b/examples/e2e_app/README.md
@@ -1,0 +1,18 @@
+# e2e_app — real-Azure certification app
+
+This app exists **only** for the release gate. The `e2e-azure` GitHub workflow
+deploys it to a temporary Azure Functions Consumption host, runs `tests/e2e`
+against it, records an `azure-cert` artifact, then deletes the resource group.
+
+It differs from the user-facing `examples/simple_agent` in two ways:
+
+1. **Candidate under test.** `requirements.txt` does not pin
+   `azure-functions-langgraph`. The workflow builds a wheel from the release
+   commit, drops it in `wheels/`, and appends the local wheel path so the
+   deployed host runs the exact source being certified (not the PyPI release).
+2. **Native routes only.** `LangGraphApp()` is created without
+   `platform_compat`, so no Blob/Table storage is required — the graph name is
+   `e2e_agent`.
+
+To reproduce locally you must first place a built wheel in `wheels/` and add it
+to `requirements.txt`, then `func start`.

--- a/examples/e2e_app/function_app.py
+++ b/examples/e2e_app/function_app.py
@@ -1,0 +1,28 @@
+"""E2E certification Function App for azure-functions-langgraph.
+
+Deployed to a real Azure Functions Consumption host by the e2e-azure workflow.
+Exposes only the NATIVE LangGraph routes (no platform_compat), which require
+only AzureWebJobsStorage:
+
+    GET  /api/health
+    POST /api/graphs/e2e_agent/invoke
+    POST /api/graphs/e2e_agent/stream
+"""
+
+import azure.functions as func
+
+from graph import compiled_graph
+
+from azure_functions_langgraph import LangGraphApp
+
+# Anonymous auth so the certification suite can call invoke/stream without
+# extracting a function key. This is a throwaway, single-release e2e host with
+# no sensitive data; the explicit ANONYMOUS opt-in emits an intended UserWarning.
+langgraph_app = LangGraphApp(auth_level=func.AuthLevel.ANONYMOUS)
+langgraph_app.register(
+    graph=compiled_graph,
+    name="e2e_agent",
+    description="Two-node greeting agent used for real-Azure e2e certification",
+)
+
+app = langgraph_app.function_app

--- a/examples/e2e_app/graph.py
+++ b/examples/e2e_app/graph.py
@@ -7,9 +7,7 @@ The graph performs NO LLM call: ``greet`` -> ``farewell``.
 
 from __future__ import annotations
 
-from typing import Any
-
-from typing_extensions import TypedDict
+from typing import Any, TypedDict
 
 
 class AgentState(TypedDict):

--- a/examples/e2e_app/graph.py
+++ b/examples/e2e_app/graph.py
@@ -1,0 +1,43 @@
+"""Two-node greeting graph used by the real-Azure e2e certification.
+
+Purpose-built for `tests/e2e` — kept separate from the user-facing
+`examples/simple_agent` so docs can evolve without breaking the release gate.
+The graph performs NO LLM call: ``greet`` -> ``farewell``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from typing_extensions import TypedDict
+
+
+class AgentState(TypedDict):
+    messages: list[dict[str, str]]
+    greeting: str
+
+
+def greet(state: AgentState) -> dict[str, Any]:
+    """First node — generates a greeting."""
+    user_msg = state["messages"][-1]["content"] if state["messages"] else "stranger"
+    return {"greeting": f"Hello, {user_msg}!"}
+
+
+def farewell(state: AgentState) -> dict[str, Any]:
+    """Second node — appends farewell to messages."""
+    return {
+        "messages": state["messages"]
+        + [{"role": "assistant", "content": f"{state['greeting']} Goodbye!"}]
+    }
+
+
+from langgraph.graph import END, START, StateGraph  # noqa: E402
+
+builder = StateGraph(AgentState)
+builder.add_node("greet", greet)
+builder.add_node("farewell", farewell)
+builder.add_edge(START, "greet")
+builder.add_edge("greet", "farewell")
+builder.add_edge("farewell", END)
+
+compiled_graph = builder.compile()

--- a/examples/e2e_app/host.json
+++ b/examples/e2e_app/host.json
@@ -1,0 +1,15 @@
+{
+  "version": "2.0",
+  "logging": {
+    "applicationInsights": {
+      "samplingSettings": {
+        "isEnabled": true,
+        "excludedTypes": "Request"
+      }
+    }
+  },
+  "extensionBundle": {
+    "id": "Microsoft.Azure.Functions.ExtensionBundle",
+    "version": "[4.*, 5.0.0)"
+  }
+}

--- a/examples/e2e_app/requirements.txt
+++ b/examples/e2e_app/requirements.txt
@@ -1,0 +1,12 @@
+# Do not include azure-functions-worker in this file
+# The Python Worker is managed by the Azure Functions platform.
+#
+# NOTE: azure-functions-langgraph is intentionally NOT listed here.
+# The e2e-azure workflow builds a wheel from the release commit and injects a
+# local path (./wheels/azure_functions_langgraph-<version>-py3-none-any.whl)
+# into this file before `func azure functionapp publish`, so the deployed app
+# runs the EXACT candidate source under certification — never the PyPI release.
+
+azure-functions
+langgraph>=1.0,<2.0
+langchain-core>=1.0,<2.0

--- a/examples/e2e_app/wheels/.gitignore
+++ b/examples/e2e_app/wheels/.gitignore
@@ -1,0 +1,4 @@
+# Built wheels are dropped here by the e2e-azure workflow before deploy.
+# Keep the directory tracked, but never commit built wheels.
+*.whl
+!.gitignore

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -1,0 +1,104 @@
+// infra/main.bicep
+// Minimal Azure resources for real-Azure e2e certification.
+// Creates: Storage Account + Function App (Consumption / Linux / Python 3.10).
+//
+// The certified example (examples/e2e_app) exercises the native LangGraph
+// routes (/api/health, /api/graphs/<name>/invoke, /api/graphs/<name>/stream),
+// which need only AzureWebJobsStorage. Platform-compatible routes
+// (/api/threads, /api/runs) would additionally require a Blob container and a
+// Table; they are intentionally out of scope for this baseline certification.
+//
+// Usage:
+//   az deployment group create -g <rg> -f infra/main.bicep \
+//     -p functionAppName=<name> storageName=<name> location=<loc>
+
+@description('Azure region for all resources.')
+param location string = resourceGroup().location
+
+@description('Name of the Function App (must be globally unique).')
+param functionAppName string
+
+@description('Name of the Storage Account (3-24 lowercase alphanumeric).')
+param storageName string
+
+@description('Enable Application Insights (set true for logging e2e).')
+param enableAppInsights bool = false
+
+@description('Name of the Application Insights instance (used when enableAppInsights=true).')
+param appInsightsName string = '${functionAppName}-ai'
+
+// ── Storage Account ────────────────────────────────────────────────────────
+resource storageAccount 'Microsoft.Storage/storageAccounts@2023-01-01' = {
+  name: storageName
+  location: location
+  sku: { name: 'Standard_LRS' }
+  kind: 'StorageV2'
+  properties: {
+    minimumTlsVersion: 'TLS1_2'
+    allowBlobPublicAccess: false
+  }
+}
+
+var storageConnectionString = 'DefaultEndpointsProtocol=https;AccountName=${storageAccount.name};EndpointSuffix=${environment().suffixes.storage};AccountKey=${storageAccount.listKeys().keys[0].value}'
+
+// ── App Insights (optional) ────────────────────────────────────────────────
+resource appInsights 'Microsoft.Insights/components@2020-02-02' = if (enableAppInsights) {
+  name: appInsightsName
+  location: location
+  kind: 'web'
+  properties: {
+    Application_Type: 'web'
+    RetentionInDays: 30
+  }
+}
+
+// ── Consumption Hosting Plan ───────────────────────────────────────────────
+resource hostingPlan 'Microsoft.Web/serverfarms@2023-01-01' = {
+  name: '${functionAppName}-plan'
+  location: location
+  sku: {
+    name: 'Y1'
+    tier: 'Dynamic'
+  }
+  kind: 'linux'
+  properties: {
+    reserved: true
+  }
+}
+
+// ── Function App ───────────────────────────────────────────────────────────
+resource functionApp 'Microsoft.Web/sites@2023-01-01' = {
+  name: functionAppName
+  location: location
+  kind: 'functionapp,linux'
+  properties: {
+    serverFarmId: hostingPlan.id
+    siteConfig: {
+      linuxFxVersion: 'Python|3.10'
+      appSettings: concat(
+        [
+          { name: 'AzureWebJobsStorage', value: storageConnectionString }
+          { name: 'FUNCTIONS_EXTENSION_VERSION', value: '~4' }
+          { name: 'FUNCTIONS_WORKER_RUNTIME', value: 'python' }
+          { name: 'SCM_DO_BUILD_DURING_DEPLOYMENT', value: 'true' }
+        ],
+        enableAppInsights
+          ? [
+              {
+                name: 'APPLICATIONINSIGHTS_CONNECTION_STRING'
+                value: appInsights.properties.ConnectionString
+              }
+            ]
+          : []
+      )
+    }
+    httpsOnly: true
+  }
+}
+
+// ── Outputs ────────────────────────────────────────────────────────────────
+output functionAppName string = functionApp.name
+output defaultHostName string = functionApp.properties.defaultHostName
+output appInsightsConnectionString string = enableAppInsights
+  ? appInsights.properties.ConnectionString
+  : ''

--- a/tests/e2e/__init__.py
+++ b/tests/e2e/__init__.py
@@ -1,0 +1,1 @@
+"""E2E test package (real-Azure)."""

--- a/tests/e2e/test_langgraph_e2e.py
+++ b/tests/e2e/test_langgraph_e2e.py
@@ -43,7 +43,7 @@ def warmup() -> None:
     while time.time() < deadline:
         try:
             r = requests.get(_url("/api/health"), timeout=15)
-            if r.status_code < 500:
+            if r.status_code == 200:
                 return
         except requests.RequestException as exc:  # pragma: no cover - network
             last_exc = exc
@@ -94,17 +94,17 @@ def test_stream_emits_events() -> None:
         stream=True,
     )
     assert r.status_code == 200, r.text
-    saw_data = False
+    saw_json_frame = False
     for raw in r.iter_lines(decode_unicode=True):
         if not raw:
             continue
         if raw.startswith("data:"):
-            saw_data = True
             data = raw[len("data:") :].strip()
             if data and data != "{}":
-                # Any well-formed SSE data frame proves the stream route runs.
+                # A JSON-decodable SSE data frame proves the stream route runs.
                 try:
                     json.loads(data)
                 except json.JSONDecodeError:
-                    pass
-    assert saw_data, "stream produced no SSE data frames"
+                    continue
+                saw_json_frame = True
+    assert saw_json_frame, "stream produced no JSON-decodable SSE data frames"

--- a/tests/e2e/test_langgraph_e2e.py
+++ b/tests/e2e/test_langgraph_e2e.py
@@ -1,0 +1,110 @@
+"""Real-Azure end-to-end tests for azure-functions-langgraph.
+
+These exercise the NATIVE LangGraph routes on a live Azure Functions host that
+was deployed from the release commit's own source (see the e2e-azure workflow
+and examples/e2e_app). They are the runtime-behavior proof behind the release
+gate's Azure certification.
+
+Usage::
+
+    E2E_BASE_URL=https://<app>.azurewebsites.net pytest tests/e2e -v -m e2e
+
+Every test is marked ``e2e`` and skips automatically when ``E2E_BASE_URL`` is
+unset (so ordinary unit runs, which exclude ``-m e2e``, never hit the network).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+
+import pytest
+import requests
+
+BASE_URL = os.environ.get("E2E_BASE_URL", "").rstrip("/")
+SKIP_REASON = "E2E_BASE_URL not set — skipping real-Azure e2e tests"
+GRAPH = "e2e_agent"
+
+pytestmark = pytest.mark.e2e
+
+
+def _url(path: str) -> str:
+    return f"{BASE_URL}{path}"
+
+
+@pytest.fixture(scope="session", autouse=True)
+def warmup() -> None:
+    """Retry /api/health until the Consumption cold-start finishes (max 3 min)."""
+    if not BASE_URL:
+        pytest.skip(SKIP_REASON)
+    deadline = time.time() + 180
+    last_exc: Exception | None = None
+    while time.time() < deadline:
+        try:
+            r = requests.get(_url("/api/health"), timeout=15)
+            if r.status_code < 500:
+                return
+        except requests.RequestException as exc:  # pragma: no cover - network
+            last_exc = exc
+        time.sleep(5)
+    raise AssertionError(f"Function App never became healthy: {last_exc}")
+
+
+@pytest.mark.skipif(not BASE_URL, reason=SKIP_REASON)
+def test_health_lists_registered_graph() -> None:
+    r = requests.get(_url("/api/health"), timeout=30)
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body.get("status") == "ok", body
+    names = {g.get("name") for g in body.get("graphs", [])}
+    assert GRAPH in names, body
+
+
+@pytest.mark.skipif(not BASE_URL, reason=SKIP_REASON)
+def test_invoke_runs_the_graph() -> None:
+    payload = {
+        "input": {"messages": [{"role": "human", "content": "World"}], "greeting": ""},
+        "config": {"configurable": {"thread_id": "e2e-invoke-001"}},
+    }
+    r = requests.post(
+        _url(f"/api/graphs/{GRAPH}/invoke"),
+        json=payload,
+        timeout=60,
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    output = body.get("output", body)
+    # greet -> "Hello, World!"; farewell appends "... Goodbye!"
+    assert output.get("greeting") == "Hello, World!", body
+    contents = [m.get("content") for m in output.get("messages", [])]
+    assert any("Goodbye!" in (c or "") for c in contents), body
+
+
+@pytest.mark.skipif(not BASE_URL, reason=SKIP_REASON)
+def test_stream_emits_events() -> None:
+    payload = {
+        "input": {"messages": [{"role": "human", "content": "World"}], "greeting": ""},
+        "config": {"configurable": {"thread_id": "e2e-stream-001"}},
+    }
+    r = requests.post(
+        _url(f"/api/graphs/{GRAPH}/stream"),
+        json=payload,
+        timeout=60,
+        stream=True,
+    )
+    assert r.status_code == 200, r.text
+    saw_data = False
+    for raw in r.iter_lines(decode_unicode=True):
+        if not raw:
+            continue
+        if raw.startswith("data:"):
+            saw_data = True
+            data = raw[len("data:") :].strip()
+            if data and data != "{}":
+                # Any well-formed SSE data frame proves the stream route runs.
+                try:
+                    json.loads(data)
+                except json.JSONDecodeError:
+                    pass
+    assert saw_data, "stream produced no SSE data frames"


### PR DESCRIPTION
## Context

Ports the tiered pre-publish runtime verification gate piloted in [`azure-functions-validation`](https://github.com/yeongseon/azure-functions-validation-python) to this repository, as part of the Phase B rollout (umbrella #305, #308). The gate ensures no version reaches PyPI without both a library-test pass and a **real-Azure certification of the exact release commit**.

Unlike the sibling Phase A repos (db #229, doctor #256, logging #319, openapi #413), this package has **no cookbook host-smoke tier**: the cookbook HTTP examples do not import it. Instead, the real-Azure e2e deploys this package's *own* example app and exercises the native LangGraph routes — so it *is* the package-native runtime proof. This required **net-new** Azure infra + example + e2e authoring (nothing to retrofit).

Workflows are **vendored per-repo** (no reusable workflows), matching the agreed rollout model, and use the same pinned action SHAs + cert-record contract as the sibling repos.

## What changed

- **`.github/workflows/publish-pypi.yml`** — restructured the single `build-and-publish` job into a `build → lib-tests → verify-azure-certification → publish` gate. `publish` uploads the exact tested artifact (never rebuilds) and only runs after a fresh, SHA+version-matched Azure certification is verified.
- **`.github/workflows/e2e-azure.yml`** *(net-new)* — dispatch-only Azure Release Certification. Builds a wheel **from the release ref**, injects it into the example app's `requirements.txt`, deploys to a real Y1 Consumption host, runs the live native e2e (health/invoke/stream), and records an `azure-cert` artifact keyed by commit SHA + version. Certifies the candidate source, **not** the last-published PyPI build.
- **`infra/main.bicep`** *(net-new)* — Y1 Consumption Function App (Python 3.10) + Storage.
- **`examples/e2e_app/`** *(net-new)* — dedicated certification app: native routes only, anonymous auth (throwaway host), graph name `e2e_agent`, wheel-bundling requirements.
- **`tests/e2e/`** *(net-new)* — live health/invoke/stream assertions (`-m e2e`, auto-skip unless `E2E_BASE_URL` is set).
- **`AGENTS.md`** — documents the tiered runtime verification gate + release flow.

## Acceptance Checklist

- [x] `hatch run test` passes (978 passed, e2e deselected, coverage 96.57%)
- [x] Both workflow YAMLs parse (`yaml.safe_load`)
- [x] e2e tests auto-skip when `E2E_BASE_URL` is unset (no network in unit runs)
- [x] Certification builds the wheel from the ref (not PyPI) so the candidate commit is what Azure certifies
- [x] `publish` gated on `[build, lib-tests, verify-azure-certification]`
- [ ] Gate jobs are tag-triggered, so they do not run on this PR; first exercised on the next release tag + `e2e-azure.yml` dispatch

## Out of scope

- Phase B siblings `durable-graph` and `knowledge` (tracked separately under #305)
- Phase C cross-repo drift lint (#306)

## References

- Umbrella: #305 (Phase B), #308 (Phase A)
- Siblings: #229 (db), #256 (doctor), #319 (logging), #413 (openapi)