### PR TITLE
chore: ignore agent orchestration state (.sisyphus/, .omc/)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,7 @@ examples/e2e_app/.python_packages/
 
 # Review
 .venv-review/
+
+# Agent orchestration state
+.sisyphus/
+.omc/


### PR DESCRIPTION
## Summary
- Ignore local agent orchestration directories (`.sisyphus/`, `.omc/`) so they never get committed.
- Preventive hygiene; no tracked files removed.

Closes #306