### PR TITLE
ci: normalize release-gate action pins to canonical SHAs

### DIFF
--- a/.github/workflows/e2e-azure.yml
+++ b/.github/workflows/e2e-azure.yml
@@ -55,7 +55,7 @@ jobs:
           echo "st=${ST}"   >> "$GITHUB_OUTPUT"
 
       - name: Azure login (OIDC)
-        uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3.0.0
+        uses: azure/login@f5d393ae46f8fde4be8b75f32e3fc50e654ad0ca # v3.0.1
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -167,7 +167,7 @@ jobs:
     if: always()
     steps:
       - name: Azure login (OIDC)
-        uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3.0.0
+        uses: azure/login@f5d393ae46f8fde4be8b75f32e3fc50e654ad0ca # v3.0.1
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}


### PR DESCRIPTION
## Summary
- Bump `azure/login` `532459ea # v3.0.0` → `f5d393ae # v3.0.1` (both occurrences in `e2e-azure.yml`); proven green in validation/doctor/logging real-Azure runs.
- checkout/upload-artifact pins already canonical in this repo.

Closes #313 · Refs yeongseon/azure-functions-validation-python#306