### PR TITLE
docs: consolidate official documentation URL onto yeongseon.dev

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: Documentation
-    url: https://yeongseon.github.io/azure-functions-langgraph-python/
+    url: https://yeongseon.dev/azure-functions-python/langgraph/
     about: Check our documentation for usage guides and examples

--- a/README.ja.md
+++ b/README.ja.md
@@ -10,7 +10,7 @@
 [![Security Scans](https://github.com/yeongseon/azure-functions-langgraph-python/actions/workflows/security.yml/badge.svg)](https://github.com/yeongseon/azure-functions-langgraph-python/actions/workflows/security.yml)
 [![codecov](https://codecov.io/gh/yeongseon/azure-functions-langgraph/branch/main/graph/badge.svg)](https://codecov.io/gh/yeongseon/azure-functions-langgraph)
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit)](https://pre-commit.com/)
-[![Docs](https://img.shields.io/badge/docs-gh--pages-blue)](https://yeongseon.github.io/azure-functions-langgraph-python/)
+[![Docs](https://img.shields.io/badge/docs-yeongseon.dev-blue)](https://yeongseon.dev/azure-functions-python/langgraph/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 この文書の言語: [한국어](README.ko.md) | **日本語** | [简体中文](README.zh-CN.md) | [English](README.md)

--- a/README.ko.md
+++ b/README.ko.md
@@ -10,7 +10,7 @@
 [![Security Scans](https://github.com/yeongseon/azure-functions-langgraph-python/actions/workflows/security.yml/badge.svg)](https://github.com/yeongseon/azure-functions-langgraph-python/actions/workflows/security.yml)
 [![codecov](https://codecov.io/gh/yeongseon/azure-functions-langgraph/branch/main/graph/badge.svg)](https://codecov.io/gh/yeongseon/azure-functions-langgraph)
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit)](https://pre-commit.com/)
-[![Docs](https://img.shields.io/badge/docs-gh--pages-blue)](https://yeongseon.github.io/azure-functions-langgraph-python/)
+[![Docs](https://img.shields.io/badge/docs-yeongseon.dev-blue)](https://yeongseon.dev/azure-functions-python/langgraph/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 이 문서의 언어: **한국어** | [日本語](README.ja.md) | [简体中文](README.zh-CN.md) | [English](README.md)

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![Security Scans](https://github.com/yeongseon/azure-functions-langgraph-python/actions/workflows/security.yml/badge.svg)](https://github.com/yeongseon/azure-functions-langgraph-python/actions/workflows/security.yml)
 [![codecov](https://codecov.io/gh/yeongseon/azure-functions-langgraph-python/branch/main/graph/badge.svg)](https://codecov.io/gh/yeongseon/azure-functions-langgraph-python)
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit)](https://pre-commit.com/)
-[![Docs](https://img.shields.io/badge/docs-gh--pages-blue)](https://yeongseon.github.io/azure-functions-langgraph-python/)
+[![Docs](https://img.shields.io/badge/docs-yeongseon.dev-blue)](https://yeongseon.dev/azure-functions-python/langgraph/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 Read this in: [한국어](README.ko.md) | [日本語](README.ja.md) | [简体中文](README.zh-CN.md)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -10,7 +10,7 @@
 [![Security Scans](https://github.com/yeongseon/azure-functions-langgraph-python/actions/workflows/security.yml/badge.svg)](https://github.com/yeongseon/azure-functions-langgraph-python/actions/workflows/security.yml)
 [![codecov](https://codecov.io/gh/yeongseon/azure-functions-langgraph/branch/main/graph/badge.svg)](https://codecov.io/gh/yeongseon/azure-functions-langgraph)
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit)](https://pre-commit.com/)
-[![Docs](https://img.shields.io/badge/docs-gh--pages-blue)](https://yeongseon.github.io/azure-functions-langgraph-python/)
+[![Docs](https://img.shields.io/badge/docs-yeongseon.dev-blue)](https://yeongseon.dev/azure-functions-python/langgraph/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 本文档语言: [한국어](README.ko.md) | [日本語](README.ja.md) | **简体中文** | [English](README.md)

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -5,21 +5,21 @@
 Part of the **Azure Functions Python DX Toolkit**. Deploy compiled LangGraph graphs as Azure Functions HTTP endpoints with minimal boilerplate, bringing agentic LLM workflows to serverless Azure. Install from PyPI with `pip install azure-functions-langgraph`.
 
 ## Getting Started
-- [Installation](https://yeongseon.github.io/azure-functions-langgraph-python/installation/): Install the package.
-- [Quickstart](https://yeongseon.github.io/azure-functions-langgraph-python/getting-started/): Minimal end-to-end example.
-- [Configuration](https://yeongseon.github.io/azure-functions-langgraph-python/configuration/): Configure graph deployment.
+- [Installation](https://yeongseon.dev/azure-functions-python/langgraph/installation/): Install the package.
+- [Quickstart](https://yeongseon.dev/azure-functions-python/langgraph/getting-started/): Minimal end-to-end example.
+- [Configuration](https://yeongseon.dev/azure-functions-python/langgraph/configuration/): Configure graph deployment.
 
 ## User Guide
-- [Usage](https://yeongseon.github.io/azure-functions-langgraph-python/usage/): Decorator reference and graph wiring.
-- [Architecture](https://yeongseon.github.io/azure-functions-langgraph-python/architecture/): How graphs map to endpoints.
+- [Usage](https://yeongseon.dev/azure-functions-python/langgraph/usage/): Decorator reference and graph wiring.
+- [Architecture](https://yeongseon.dev/azure-functions-python/langgraph/architecture/): How graphs map to endpoints.
 
 ## Deployment
-- [Choose a Plan](https://yeongseon.github.io/azure-functions-langgraph-python/choose-a-plan/): Hosting options.
-- [Deploy to Azure](https://yeongseon.github.io/azure-functions-langgraph-python/deployment/): Deployment guide.
-- [Production Guide](https://yeongseon.github.io/azure-functions-langgraph-python/production-guide/): Production hardening.
+- [Choose a Plan](https://yeongseon.dev/azure-functions-python/langgraph/choose-a-plan/): Hosting options.
+- [Deploy to Azure](https://yeongseon.dev/azure-functions-python/langgraph/deployment/): Deployment guide.
+- [Production Guide](https://yeongseon.dev/azure-functions-python/langgraph/production-guide/): Production hardening.
 
 ## Reference
-- [API Reference](https://yeongseon.github.io/azure-functions-langgraph-python/api/): Public API surface.
-- [Simple Agent Example](https://yeongseon.github.io/azure-functions-langgraph-python/examples/simple_agent/): End-to-end agent.
-- [FAQ](https://yeongseon.github.io/azure-functions-langgraph-python/faq/): Frequently asked questions.
-- [Troubleshooting](https://yeongseon.github.io/azure-functions-langgraph-python/troubleshooting/): Common issues and fixes.
+- [API Reference](https://yeongseon.dev/azure-functions-python/langgraph/api/): Public API surface.
+- [Simple Agent Example](https://yeongseon.dev/azure-functions-python/langgraph/examples/simple_agent/): End-to-end agent.
+- [FAQ](https://yeongseon.dev/azure-functions-python/langgraph/faq/): Frequently asked questions.
+- [Troubleshooting](https://yeongseon.dev/azure-functions-python/langgraph/troubleshooting/): Common issues and fixes.

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -8,7 +8,7 @@
 - Version: 0.5.0
 - Python: >=3.10, <3.15
 - License: MIT
-- Docs: https://yeongseon.github.io/azure-functions-langgraph-python/
+- Docs: https://yeongseon.dev/azure-functions-python/langgraph/
 - Repository: https://github.com/yeongseon/azure-functions-langgraph-python
 - Azure Functions programming model: v2
 

--- a/llms.txt
+++ b/llms.txt
@@ -8,7 +8,7 @@
 - Version: 0.5.0
 - Python: >=3.10, <3.15
 - License: MIT
-- Docs: https://yeongseon.github.io/azure-functions-langgraph-python/
+- Docs: https://yeongseon.dev/azure-functions-python/langgraph/
 - Repository: https://github.com/yeongseon/azure-functions-langgraph-python
 
 ## What It Does
@@ -49,11 +49,11 @@ app = gapp.function_app  # export this
 
 ## Documentation
 
-- [Getting Started](https://yeongseon.github.io/azure-functions-langgraph-python/getting-started/)
-- [API Reference](https://yeongseon.github.io/azure-functions-langgraph-python/api/)
-- [Architecture](https://yeongseon.github.io/azure-functions-langgraph-python/architecture/)
-- [Deployment Guide](https://yeongseon.github.io/azure-functions-langgraph-python/deployment/)
-- [Troubleshooting](https://yeongseon.github.io/azure-functions-langgraph-python/troubleshooting/)
+- [Getting Started](https://yeongseon.dev/azure-functions-python/langgraph/getting-started/)
+- [API Reference](https://yeongseon.dev/azure-functions-python/langgraph/api/)
+- [Architecture](https://yeongseon.dev/azure-functions-python/langgraph/architecture/)
+- [Deployment Guide](https://yeongseon.dev/azure-functions-python/langgraph/deployment/)
+- [Troubleshooting](https://yeongseon.dev/azure-functions-python/langgraph/troubleshooting/)
 
 ## Ecosystem
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,7 @@
 site_name: Azure Functions LangGraph
 site_description: Deploy LangGraph agents as Azure Functions HTTP endpoints
 site_author: Yeongseon Choe
-site_url: https://yeongseon.github.io/azure-functions-langgraph-python/
+site_url: https://yeongseon.dev/azure-functions-python/langgraph/
 repo_url: https://github.com/yeongseon/azure-functions-langgraph-python
 edit_uri: edit/main/docs/
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,8 +31,8 @@ dependencies = [
 ]
 
 [project.urls]
-Homepage = "https://yeongseon.github.io/azure-functions-langgraph-python/"
-Documentation = "https://yeongseon.github.io/azure-functions-langgraph-python/"
+Homepage = "https://yeongseon.dev/azure-functions-python/langgraph/"
+Documentation = "https://yeongseon.dev/azure-functions-python/langgraph/"
 Repository = "https://github.com/yeongseon/azure-functions-langgraph-python"
 Issues = "https://github.com/yeongseon/azure-functions-langgraph-python/issues"
 


### PR DESCRIPTION
## Summary
Consolidates the LangGraph package's official documentation URL onto the canonical domain `https://yeongseon.dev/azure-functions-python/langgraph/`, replacing the old GitHub Pages host (`yeongseon.github.io/azure-functions-langgraph-python`).

Changed surfaces:
- `pyproject.toml` — `Homepage` / `Documentation` (Repository/Issues stay on GitHub)
- `mkdocs.yml` — `site_url` only (repo_url/edit_uri stay on GitHub)
- `.github/ISSUE_TEMPLATE/config.yml` docs link
- README badge (`docs-gh--pages` → `docs-yeongseon.dev`) + doc links across all locales (en/ja/ko/zh-CN)

27 URL occurrences across 10 files, single old-host prefix; subpaths/anchors preserved.

## Verification
- `mkdocs build --strict` passes (INFO-only).
- All new-URL subpaths sampled return **200**; sitemap live; root serves real MkDocs Material with self-referential canonical.
- Every removed line was a github.io→yeongseon.dev (or badge) swap.

## Notes
- Repository/Issues and mkdocs `repo_url`/`edit_uri` intentionally remain on GitHub.

Closes #325