### PR TITLE
fix(openapi): wrap invoke/stream models in transport envelope (#349)

### DIFF
--- a/src/azure_functions_langgraph/app.py
+++ b/src/azure_functions_langgraph/app.py
@@ -29,11 +29,15 @@ from azure_functions_langgraph._validation import (
 )
 from azure_functions_langgraph.contracts import (
     AppMetadata,
-    GraphInfo,
-    HealthResponse,
-    HealthStatus,
-    RegisteredGraphMetadata,
+GraphInfo,
+HealthResponse,
+HealthStatus,
+RegisteredGraphMetadata,
     RouteMetadata,
+    _is_model_type,
+    build_invoke_request_model,
+    build_invoke_response_model,
+    build_stream_request_model,
 )
 from azure_functions_langgraph.locks import InProcessThreadLock, ThreadLock
 from azure_functions_langgraph.protocols import InvocableGraph, StatefulGraph
@@ -78,10 +82,18 @@ def _resolve_endpoint_spec(reg: _GraphRegistration, endpoint: str) -> _EndpointS
     :class:`RouteMetadata`), so the two never drift.
     """
     if endpoint == "invoke":
-        return _EndpointSpec(reg.request_model, reg.response_model, ())
+        # Wrap the graph input/output models in the transport envelope so the
+        # generated OpenAPI matches the runtime wire contract ({input, config}
+        # -> {output}); see issue #349 and ``_handlers.handle_invoke``.
+        return _EndpointSpec(
+            build_invoke_request_model(reg.request_model),
+            build_invoke_response_model(reg.response_model),
+            (),
+        )
     if endpoint == "stream":
-        # Stream responses are SSE, not a single JSON body.
-        return _EndpointSpec(reg.request_model, None, ())
+        # Stream responses are SSE, not a single JSON body, so only the request
+        # envelope ({input, config, stream_mode}) is described.
+        return _EndpointSpec(build_stream_request_model(reg.request_model), None, ())
     if endpoint == "state":
         return _EndpointSpec(
             None,
@@ -96,6 +108,21 @@ def _resolve_endpoint_spec(reg: _GraphRegistration, endpoint: str) -> _EndpointS
             ),
         )
     return _EndpointSpec()  # defensive: unknown endpoint type carries no models
+
+
+def _validate_optional_model(model: Optional[type[Any]], label: str) -> None:
+    """Reject a non-``BaseModel`` *model* early, unless it is ``None``.
+
+    ``request_model``/``response_model`` are wrapped in the transport envelope
+    for metadata generation (issue #349), and the wrapper silently falls back to
+    the generic envelope for non-model inputs. Validating here keeps the failure
+    fast and close to the caller's ``register()`` call instead of masking a bad
+    model as a generic envelope.
+    """
+    if model is not None and not _is_model_type(model):
+        raise TypeError(
+            f"{label} must be a Pydantic BaseModel subclass, got {model!r}"
+        )
 
 
 @dataclass
@@ -241,11 +268,15 @@ class LangGraphApp:
                 (used by the metadata / bridge API, not for runtime validation).
 
         Raises:
-            TypeError: If *graph* does not satisfy the required protocol.
+            TypeError: If *graph* does not satisfy the required protocol, or if
+                ``request_model``/``response_model`` is provided but is not a
+                Pydantic ``BaseModel`` subclass.
             ValueError: If *name* is already registered or invalid.
         """
         if not isinstance(graph, InvocableGraph):
             raise TypeError(f"Graph must have an invoke() method. Got {type(graph).__name__}")
+        _validate_optional_model(request_model, "request_model")
+        _validate_optional_model(response_model, "response_model")
         name_err = validate_graph_name(name)
         if name_err:
             raise ValueError(name_err)

--- a/src/azure_functions_langgraph/contracts.py
+++ b/src/azure_functions_langgraph/contracts.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from types import MappingProxyType
-from typing import Any, Mapping, Optional
+from typing import Any, Mapping, Optional, TypeGuard
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, create_model
 
 
 class InvokeRequest(BaseModel):
@@ -38,6 +38,93 @@ class InvokeResponse(BaseModel):
 
     output: dict[str, Any] = Field(description="Graph output state")
 
+# ------------------------------------------------------------------
+# Transport-envelope model builders (issue #349)
+#
+# The native ``invoke``/``stream`` routes always speak the transport
+# envelope on the wire: ``{"input": ..., "config": ...}`` in, ``{"output":
+# ...}`` out (see ``_handlers.handle_invoke``). A user-supplied
+# ``request_model``/``response_model`` describes the graph INPUT/OUTPUT
+# payload — i.e. the *inner* schema — not the HTTP body. These builders wrap
+# the caller's model inside the transport envelope so generated OpenAPI
+# metadata matches the runtime contract instead of documenting the bare inner
+# model. When no model is supplied, the generic ``dict``-typed envelope
+# (``InvokeRequest``/``StreamRequest``/``InvokeResponse``) is used, which is
+# still the honest wire contract.
+# ------------------------------------------------------------------
+
+
+def _is_model_type(model: object) -> TypeGuard[type[BaseModel]]:
+    """Return ``True`` if *model* is a Pydantic ``BaseModel`` subclass."""
+    return isinstance(model, type) and issubclass(model, BaseModel)
+
+
+def build_invoke_request_model(input_model: Optional[type[Any]]) -> type[BaseModel]:
+    """Wrap a graph-input model in the ``invoke`` transport envelope.
+
+    Returns a model equivalent to ``{"input": <input_model>, "config"?: ...}``.
+    Falls back to the generic :class:`InvokeRequest` when *input_model* is not a
+    Pydantic model. ``input`` is always required, so the request body itself is
+    required regardless of the inner model's field optionality.
+    """
+    if _is_model_type(input_model):
+        return create_model(
+            f"InvokeRequest_{input_model.__name__}",
+            input=(input_model, Field(description="Input to the graph")),
+            config=(
+                Optional[dict[str, Any]],
+                Field(
+                    default=None,
+                    description="LangGraph config, e.g. {'configurable': {'thread_id': '...'}}",
+                ),
+            ),
+        )
+    return InvokeRequest
+
+
+def build_invoke_response_model(output_model: Optional[type[Any]]) -> type[BaseModel]:
+    """Wrap a graph-output model in the ``invoke`` response envelope.
+
+    Returns a model equivalent to ``{"output": <output_model>}``. Falls back to
+    the generic :class:`InvokeResponse` when *output_model* is not a Pydantic
+    model.
+    """
+    if _is_model_type(output_model):
+        return create_model(
+            f"InvokeResponse_{output_model.__name__}",
+            output=(output_model, Field(description="Graph output state")),
+        )
+    return InvokeResponse
+
+
+def build_stream_request_model(input_model: Optional[type[Any]]) -> type[BaseModel]:
+    """Wrap a graph-input model in the ``stream`` transport envelope.
+
+    Returns a model equivalent to
+    ``{"input": <input_model>, "config"?: ..., "stream_mode"?: ...}``. Falls back
+    to the generic :class:`StreamRequest` when *input_model* is not a Pydantic
+    model.
+    """
+    if _is_model_type(input_model):
+        return create_model(
+            f"StreamRequest_{input_model.__name__}",
+            input=(input_model, Field(description="Input to the graph")),
+            config=(
+                Optional[dict[str, Any]],
+                Field(
+                    default=None,
+                    description="LangGraph config, e.g. {'configurable': {'thread_id': '...'}}",
+                ),
+            ),
+            stream_mode=(
+                str,
+                Field(
+                    default="values",
+                    description="Stream mode: 'values', 'updates', 'messages', or 'custom'",
+                ),
+            ),
+        )
+    return StreamRequest
 
 class GraphInfo(BaseModel):
     """Information about a registered graph."""

--- a/tests/test_endpoint_metadata.py
+++ b/tests/test_endpoint_metadata.py
@@ -18,6 +18,13 @@ from azure_functions_langgraph._endpoint import (
     set_endpoint_metadata,
 )
 from azure_functions_langgraph.app import LangGraphApp, _EndpointSpec, _resolve_endpoint_spec
+from azure_functions_langgraph.contracts import (
+    InvokeRequest,
+    InvokeResponse,
+    build_invoke_request_model,
+    build_invoke_response_model,
+    build_stream_request_model,
+)
 from tests.conftest import FakeCompiledGraph, FakeStatefulGraph
 
 
@@ -77,15 +84,19 @@ class TestEndpointNamespaceOnHandlers:
 
         payload = _endpoint_meta(invoke_fn)
         assert payload["version"] == ENDPOINT_METADATA_VERSION
-        assert payload["request_body"] == RequestBody.model_json_schema(
+        # The wire contract is the transport envelope ({input, config} ->
+        # {output}), not the bare user model; see issue #349.
+        assert payload["request_body"] == build_invoke_request_model(
+            RequestBody
+        ).model_json_schema(
             by_alias=True, ref_template="#/$defs/{model}", mode="validation"
         )
-        # user_id is required (no default) -> request body required.
+        # ``input`` is always required -> request body required.
         assert payload["request_body_required"] is True
         assert payload["parameters"] == []
         assert payload["responses"] == {
             "200": {
-                "schema": ResponseBody.model_json_schema(
+                "schema": build_invoke_response_model(ResponseBody).model_json_schema(
                     by_alias=True, ref_template="#/$defs/{model}", mode="serialization"
                 )
             }
@@ -131,9 +142,19 @@ class TestEndpointNamespaceOnHandlers:
         invoke_fn = _get_registered_functions(app.function_app)["aflg_agent_invoke"]
 
         payload = _endpoint_meta(invoke_fn)
-        assert payload["request_body"] is None
-        assert payload["request_body_required"] is False
-        assert payload["responses"] is None
+        # With no user models the generic envelope is still the honest wire
+        # contract ({input, config} -> {output}); see issue #349.
+        assert payload["request_body"] == InvokeRequest.model_json_schema(
+            by_alias=True, ref_template="#/$defs/{model}", mode="validation"
+        )
+        assert payload["request_body_required"] is True
+        assert payload["responses"] == {
+            "200": {
+                "schema": InvokeResponse.model_json_schema(
+                    by_alias=True, ref_template="#/$defs/{model}", mode="serialization"
+                )
+            }
+        }
         assert payload["parameters"] == []
 
     def test_endpoint_namespace_preserves_langgraph_namespace(self) -> None:
@@ -249,14 +270,25 @@ class TestResolveEndpointSpec:
     def test_invoke_spec(self) -> None:
         reg = _make_reg(request_model=RequestBody, response_model=ResponseBody)
         spec = _resolve_endpoint_spec(reg, "invoke")
-        assert spec.request_model is RequestBody
-        assert spec.response_model is ResponseBody
+        # invoke wraps the models in the transport envelope (issue #349).
+        assert spec.request_model is not None
+        assert spec.request_model.model_json_schema() == build_invoke_request_model(
+            RequestBody
+        ).model_json_schema()
+        assert spec.response_model is not None
+        assert spec.response_model.model_json_schema() == build_invoke_response_model(
+            ResponseBody
+        ).model_json_schema()
         assert spec.parameters == ()
 
     def test_stream_spec(self) -> None:
         reg = _make_reg(request_model=RequestBody, response_model=ResponseBody)
         spec = _resolve_endpoint_spec(reg, "stream")
-        assert spec.request_model is RequestBody
+        # stream wraps the request in the transport envelope (issue #349).
+        assert spec.request_model is not None
+        assert spec.request_model.model_json_schema() == build_stream_request_model(
+            RequestBody
+        ).model_json_schema()
         assert spec.response_model is None
         assert spec.parameters == ()
 

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -166,8 +166,17 @@ class TestGetAppMetadata:
         meta = app.get_app_metadata()
 
         invoke_route = meta.graphs["agent"].routes[0]
-        assert invoke_route.request_model is MyRequest
-        assert invoke_route.response_model is MyResponse
+        # invoke routes wrap the user models in the transport envelope so the
+        # metadata matches the runtime wire contract; see issue #349.
+        assert invoke_route.request_model is not None
+        req_schema = invoke_route.request_model.model_json_schema()
+        assert req_schema["required"] == ["input"]
+        assert req_schema["properties"]["input"]["$ref"] == "#/$defs/MyRequest"
+        assert "MyRequest" in req_schema["$defs"]
+        assert invoke_route.response_model is not None
+        resp_schema = invoke_route.response_model.model_json_schema()
+        assert resp_schema["properties"]["output"]["$ref"] == "#/$defs/MyResponse"
+        assert "MyResponse" in resp_schema["$defs"]
 
     def test_stream_route_has_no_response_model(self) -> None:
         """Stream routes should not have response_model (SSE, not JSON)."""

--- a/tests/test_openapi_bridge.py
+++ b/tests/test_openapi_bridge.py
@@ -157,8 +157,12 @@ class TestRegisterWithOpenapi:
         assert invoke_kwargs["request_body"] is not None
         assert invoke_kwargs["request_body"]["required"] is True
         schema = invoke_kwargs["request_body"]["content"]["application/json"]["schema"]
+        # The request body is the transport envelope; the user model is nested
+        # under ``input`` (issue #349).
         assert "properties" in schema
-        assert "query" in schema["properties"]
+        assert "input" in schema["properties"]
+        assert schema["properties"]["input"]["$ref"] == "#/$defs/ChatRequest"
+        assert "query" in schema["$defs"]["ChatRequest"]["properties"]
 
     def test_registers_with_response_model(self) -> None:
         class ChatResponse(BaseModel):
@@ -187,7 +191,13 @@ class TestRegisterWithOpenapi:
             if c.kwargs.get("path") == "/api/graphs/agent/invoke"
         ]
         assert len(invoke_calls) == 1
-        assert invoke_calls[0].kwargs["response_model"] is ChatResponse
+        # The response model is wrapped in the ``{output: ...}`` envelope so the
+        # generated spec matches the runtime wire contract (issue #349).
+        response_model = invoke_calls[0].kwargs["response_model"]
+        assert response_model is not None
+        resp_schema = response_model.model_json_schema()
+        assert resp_schema["properties"]["output"]["$ref"] == "#/$defs/ChatResponse"
+        assert "ChatResponse" in resp_schema["$defs"]
 
     def test_invoke_only_omits_stream(self) -> None:
         app = LangGraphApp()
@@ -334,20 +344,16 @@ class TestValidateModel:
             _validate_model("not a class", "response_model")
 
     def test_response_model_validated_during_registration(self) -> None:
-        """response_model should be validated when register_with_openapi is called."""
+        """A non-model response_model is rejected fast at register() time.
+
+        Enveloping (issue #349) would otherwise silently coerce a bad model into
+        the generic ``{output: ...}`` envelope, so ``register()`` validates the
+        user model up front instead of masking the error.
+        """
         app = LangGraphApp()
-        app.register(
-            graph=FakeCompiledGraph(),
-            name="agent",
-            response_model=dict,
-        )
-
-        mock_register = MagicMock()
-        mock_openapi_module = MagicMock()
-        mock_openapi_module.register_openapi_metadata = mock_register
-
-        with patch.dict("sys.modules", {"azure_functions_openapi": mock_openapi_module}):
-            from azure_functions_langgraph.openapi import register_with_openapi
-
-            with pytest.raises(TypeError, match="response_model must be a Pydantic BaseModel"):
-                register_with_openapi(app)
+        with pytest.raises(TypeError, match="response_model must be a Pydantic BaseModel"):
+            app.register(
+                graph=FakeCompiledGraph(),
+                name="agent",
+                response_model=dict,
+            )


### PR DESCRIPTION
## Summary
- Generated OpenAPI metadata for the native `invoke`/`stream` routes now matches the runtime wire contract: the user's `request_model`/`response_model` are wrapped in the transport envelope (`{input, config}` in, `{output}` out) instead of being documented as the bare inner model.
- The wrapping happens in the shared `_resolve_endpoint_spec` resolver — the single source of truth for both the `endpoint` metadata namespace and the deprecated `openapi.py` bridge — so both OpenAPI surfaces are fixed at once and cannot drift.
- When no model is supplied, the generic `dict`-typed envelope (`InvokeRequest`/`StreamRequest`/`InvokeResponse`) is used, which is still the honest wire contract. Because `input` is always required, the request body is now correctly reported as `required: true`.
- A non-`BaseModel` `request_model`/`response_model` now fails fast at `register()` time (previously validated lazily in the bridge), since the envelope wrapper would otherwise silently coerce a bad model into the generic envelope.

## Details
New envelope builders in `contracts.py` (`build_invoke_request_model`, `build_invoke_response_model`, `build_stream_request_model`) use `pydantic.create_model`, guarded by a `TypeGuard`-typed `_is_model_type` for strict-mypy narrowing. Fixes the transport-envelope mismatch (review findings A + B).

## Verification
- `hatch run pytest --cov` — all tests pass, coverage **96.62%** (>= 95% gate)
- `hatch run lint` — clean (ruff)
- `hatch run typecheck` — clean (mypy strict)

Closes #349