### PR TITLE
feat(platform): warn on unknown platform request fields with opt-in strict mode

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -43,7 +43,7 @@ get a clear failure rather than silent drift.
 
 | SDK call | Support | Notes |
 |---|---|---|
-| `threads.create` | ✅ Full | `metadata` accepted; `ttl` silently dropped (`extra="ignore"`). |
+| `threads.create` | ✅ Full | `metadata` accepted; `ttl` dropped (`extra="ignore"`) with a warning — see the unknown-field note under Runs. |
 | `threads.get` | ✅ Full | |
 | `threads.update` | ✅ Full | Only `metadata` updates — matches SDK `PATCH` shape. |
 | `threads.delete` | ✅ Full | Also clears persisted state when a checkpointer is wired. |
@@ -88,12 +88,22 @@ Derived from `_preflight_run_create()` in `platform/_common.py`.
 | `after_seconds` | ❌ `501` |
 | `if_not_exists` | ❌ `501` |
 | `feedback_keys` | ❌ `501` |
-| Other unknown fields | Silently dropped (`extra="ignore"`) |
+| Other unknown fields | Dropped (`extra="ignore"`) but logged + a `UserWarning` is emitted; set `AZFUNC_LANGGRAPH_PLATFORM_STRICT=1` to reject with `400` instead |
 
 > **Why explicit 501 rather than silent drop?** Concurrent runs on the same
 > thread are rejected with `409` (`multitask_strategy=reject`). Other
 > unsupported features must surface immediately so SDK callers do not silently
 > lose semantics — see `_preflight_run_create()`.
+>
+> **Unknown (undeclared) fields — warn by default, opt-in strict.** Fields that
+> are neither declared nor in the `501` list are still dropped by
+> `extra="ignore"` (so a newer SDK client never 422s an older server), but the
+> route layer now logs a warning and emits a `UserWarning` so the drift is
+> observable. Set the `AZFUNC_LANGGRAPH_PLATFORM_STRICT` environment variable
+> (to any value other than empty/`0`/`false`/`no`) to reject unknown fields with
+> a `400` instead. This applies to all platform-compat request models
+> (assistants, threads, runs); the default remains "ignore" and is unchanged
+> for native invoke/stream endpoints.
 
 ### State
 

--- a/src/azure_functions_langgraph/platform/_assistants.py
+++ b/src/azure_functions_langgraph/platform/_assistants.py
@@ -8,8 +8,9 @@ import azure.functions as func
 from azure_functions_langgraph._validation import validate_body_size
 from azure_functions_langgraph.platform._common import (
     PlatformRouteDeps,
-    _platform_error,
-    _registration_to_assistant,
+    _check_unknown_platform_fields,
+_platform_error,
+_registration_to_assistant,
 )
 from azure_functions_langgraph.platform.contracts import (
     Assistant,
@@ -39,6 +40,9 @@ def register_assistant_routes(
         else:
             body = {}
 
+        unknown_err = _check_unknown_platform_fields(AssistantSearch, body)
+        if unknown_err is not None:
+            return unknown_err
         try:
             search = AssistantSearch.model_validate(body)
         except Exception as exc:
@@ -76,6 +80,9 @@ def register_assistant_routes(
         else:
             body = {}
 
+        unknown_err = _check_unknown_platform_fields(AssistantCount, body)
+        if unknown_err is not None:
+            return unknown_err
         try:
             count_req = AssistantCount.model_validate(body)
         except Exception as exc:

--- a/src/azure_functions_langgraph/platform/_common.py
+++ b/src/azure_functions_langgraph/platform/_common.py
@@ -3,9 +3,12 @@ from __future__ import annotations
 from datetime import datetime, timezone
 import json
 import logging
+import os
 from typing import Any
+import warnings
 
 import azure.functions as func
+from pydantic import BaseModel
 
 from azure_functions_langgraph._validation import (
     validate_body_size,
@@ -23,6 +26,68 @@ from azure_functions_langgraph.platform.stores import ThreadStore
 from azure_functions_langgraph.protocols import CloneableGraph
 
 logger = logging.getLogger(__name__)
+
+_PLATFORM_STRICT_ENV = "AZFUNC_LANGGRAPH_PLATFORM_STRICT"
+
+
+def _platform_strict_enabled() -> bool:
+    """Return ``True`` when the opt-in platform strict mode is enabled.
+
+    Controlled by the ``AZFUNC_LANGGRAPH_PLATFORM_STRICT`` environment variable.
+    Any value other than unset/empty/``0``/``false``/``no`` (case-insensitive)
+    enables strict mode, in which truly-unknown request fields are rejected with
+    a ``400`` instead of being warned-about and dropped.
+    """
+    raw = os.environ.get(_PLATFORM_STRICT_ENV, "")
+    return raw.strip().lower() not in ("", "0", "false", "no")
+
+
+def _unknown_request_fields(model_cls: type[BaseModel], body: Any) -> list[str]:
+    """Return body keys not declared (by name or alias) on *model_cls*.
+
+    Known-but-unsupported fields (e.g. ``interrupt_before``) are declared on the
+    models and rejected separately with ``501``; only *truly-unknown* fields are
+    reported here. Non-dict bodies carry no nameable extras, so return ``[]``.
+    """
+    if not isinstance(body, dict):
+        return []
+    allowed: set[str] = set()
+    for name, field in model_cls.model_fields.items():
+        allowed.add(name)
+        if field.alias is not None:
+            allowed.add(field.alias)
+    return sorted(key for key in body if key not in allowed)
+
+
+def _check_unknown_platform_fields(
+    model_cls: type[BaseModel], body: Any
+) -> func.HttpResponse | None:
+    """Observe or reject truly-unknown fields on a platform request body.
+
+    Default behaviour preserves ``extra="ignore"`` forward-compatibility: unknown
+    fields are logged and surfaced as a :class:`UserWarning`, then dropped. When
+    :func:`_platform_strict_enabled` is set, unknown fields become a ``400``
+    instead. Returns an error :class:`~azure.functions.HttpResponse` only in
+    strict mode; otherwise ``None`` so the caller proceeds normally.
+    """
+    unknown = _unknown_request_fields(model_cls, body)
+    if not unknown:
+        return None
+    joined = ", ".join(unknown)
+    if _platform_strict_enabled():
+        return _platform_error(
+            400,
+            f"Unknown request field(s) rejected in strict mode: {joined}. "
+            f"Unset {_PLATFORM_STRICT_ENV} to ignore unknown fields instead.",
+        )
+    message = (
+        f"{model_cls.__name__} request received unknown field(s) [{joined}] "
+        f"that are not part of the supported wire contract; they were ignored. "
+        f"Set {_PLATFORM_STRICT_ENV}=1 to reject unknown fields instead."
+    )
+    logger.warning(message)
+    warnings.warn(message, UserWarning, stacklevel=2)
+    return None
 
 
 def _platform_error(status_code: int, detail: str) -> func.HttpResponse:
@@ -197,6 +262,10 @@ def _parse_run_create(
 
     if require_dict_body and not isinstance(body, dict):
         return _platform_error(400, "Request body must be a JSON object")
+
+    unknown_err = _check_unknown_platform_fields(RunCreate, body)
+    if unknown_err is not None:
+        return unknown_err
 
     try:
         run_req = RunCreate.model_validate(body)

--- a/src/azure_functions_langgraph/platform/_threads.py
+++ b/src/azure_functions_langgraph/platform/_threads.py
@@ -13,7 +13,8 @@ from azure_functions_langgraph.platform._common import (
     _UNSUPPORTED_THREAD_FILTER_FIELDS,
     PlatformRouteDeps,
     _build_checkpoint_config,
-    _platform_error,
+    _check_unknown_platform_fields,
+_platform_error,
     _read_json_body,
     _resolve_thread_graph,
     _snapshot_to_thread_state,
@@ -49,6 +50,9 @@ def register_thread_routes(
         if isinstance(body, func.HttpResponse):
             return body
 
+        unknown_err = _check_unknown_platform_fields(ThreadCreate, body)
+        if unknown_err is not None:
+            return unknown_err
         try:
             create_req = ThreadCreate.model_validate(body)
         except Exception as exc:
@@ -89,6 +93,9 @@ def register_thread_routes(
         if isinstance(body, func.HttpResponse):
             return body
 
+        unknown_err = _check_unknown_platform_fields(ThreadUpdate, body)
+        if unknown_err is not None:
+            return unknown_err
         try:
             update_req = ThreadUpdate.model_validate(body)
         except Exception as exc:
@@ -145,6 +152,9 @@ def register_thread_routes(
                 f"Unsupported filter(s): {', '.join(sorted(unsupported))}",
             )
 
+        unknown_err = _check_unknown_platform_fields(ThreadSearch, body)
+        if unknown_err is not None:
+            return unknown_err
         try:
             search_req = ThreadSearch.model_validate(body)
         except Exception as exc:
@@ -176,6 +186,9 @@ def register_thread_routes(
                 f"Unsupported filter(s): {', '.join(sorted(unsupported))}",
             )
 
+        unknown_err = _check_unknown_platform_fields(ThreadCount, body)
+        if unknown_err is not None:
+            return unknown_err
         try:
             count_req = ThreadCount.model_validate(body)
         except Exception as exc:
@@ -246,6 +259,9 @@ def register_thread_routes(
         if isinstance(body, func.HttpResponse):
             return body
 
+        unknown_err = _check_unknown_platform_fields(ThreadStateUpdate, body)
+        if unknown_err is not None:
+            return unknown_err
         try:
             update_req = ThreadStateUpdate.model_validate(body)
         except Exception as exc:
@@ -312,6 +328,9 @@ def register_thread_routes(
         if isinstance(body, func.HttpResponse):
             return body
 
+        unknown_err = _check_unknown_platform_fields(ThreadHistoryRequest, body)
+        if unknown_err is not None:
+            return unknown_err
         try:
             hist_req = ThreadHistoryRequest.model_validate(body)
         except Exception as exc:

--- a/src/azure_functions_langgraph/platform/contracts.py
+++ b/src/azure_functions_langgraph/platform/contracts.py
@@ -13,8 +13,11 @@ instead of causing 422 errors. This is deliberate forward-compatibility:
   explicitly here and rejected with ``501 Not Implemented`` at the route
   layer (see ``platform/_runs.py`` and ``COMPATIBILITY.md``) rather than
   silently ignored — the caller always learns the feature is unsupported.
-* **Truly-unknown** future fields are dropped by ``extra="ignore"`` so a
-  newer SDK client does not break against an older server.
+* **Truly-unknown** future fields are still dropped by ``extra="ignore"`` so a
+  newer SDK client does not break against an older server, but the route
+  layer now logs a warning and emits a :class:`UserWarning` for them so the
+  drift is observable. Set ``AZFUNC_LANGGRAPH_PLATFORM_STRICT`` to reject
+  unknown fields with ``400`` instead (opt-in strict mode).
 
 The shapes target the **langgraph-sdk** ``>=0.2.2,<0.4`` wire format
 (``langgraph_sdk.schema``). This range is the single source of truth shared
@@ -226,8 +229,10 @@ class ThreadUpdate(BaseModel):
     """Request body to update a Thread.
 
     Covers ``PATCH /threads/{thread_id}``.
-    The SDK also sends a ``ttl`` field which is silently dropped
-    (``extra="ignore"``).
+    The SDK also sends a ``ttl`` field which is not supported: it is dropped
+    (``extra="ignore"``) but now surfaces a warning and a :class:`UserWarning`
+    at the route layer, or a ``400`` when
+    ``AZFUNC_LANGGRAPH_PLATFORM_STRICT`` is set.
     """
 
     model_config = ConfigDict(extra="ignore")

--- a/tests/test_platform_common.py
+++ b/tests/test_platform_common.py
@@ -6,10 +6,16 @@ de-duplicate the platform run handlers.
 
 from __future__ import annotations
 
+import pytest
+
 from azure_functions_langgraph.platform._common import (
     _build_sse_response,
+    _check_unknown_platform_fields,
     _normalize_stream_mode,
+    _platform_strict_enabled,
+    _unknown_request_fields,
 )
+from azure_functions_langgraph.platform.contracts import ThreadUpdate
 
 
 class TestBuildSSEResponse:
@@ -60,3 +66,58 @@ class TestNormalizeStreamMode:
         assert mode is None
         assert err is not None
         assert err.status_code == 501
+
+
+
+class TestUnknownRequestFields:
+    def test_returns_empty_for_non_dict_body(self) -> None:
+        assert _unknown_request_fields(ThreadUpdate, ["not", "a", "dict"]) == []
+        assert _unknown_request_fields(ThreadUpdate, None) == []
+
+    def test_returns_empty_when_all_fields_known(self) -> None:
+        assert _unknown_request_fields(ThreadUpdate, {"metadata": {"a": 1}}) == []
+
+    def test_reports_sorted_unknown_keys(self) -> None:
+        assert _unknown_request_fields(ThreadUpdate, {"ttl": 5, "foo": 1}) == [
+            "foo",
+            "ttl",
+        ]
+
+
+class TestPlatformStrictEnabled:
+    def test_unset_is_disabled(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("AZFUNC_LANGGRAPH_PLATFORM_STRICT", raising=False)
+        assert _platform_strict_enabled() is False
+
+    def test_falsey_values_disabled(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        for val in ("", "0", "false", "NO", " false "):
+            monkeypatch.setenv("AZFUNC_LANGGRAPH_PLATFORM_STRICT", val)
+            assert _platform_strict_enabled() is False
+
+    def test_truthy_values_enabled(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        for val in ("1", "true", "yes", "on"):
+            monkeypatch.setenv("AZFUNC_LANGGRAPH_PLATFORM_STRICT", val)
+            assert _platform_strict_enabled() is True
+
+
+class TestCheckUnknownPlatformFields:
+    def test_no_unknown_returns_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("AZFUNC_LANGGRAPH_PLATFORM_STRICT", raising=False)
+        assert _check_unknown_platform_fields(ThreadUpdate, {"metadata": {}}) is None
+
+    def test_default_warns_and_returns_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("AZFUNC_LANGGRAPH_PLATFORM_STRICT", raising=False)
+        with pytest.warns(UserWarning, match="ttl"):
+            result = _check_unknown_platform_fields(ThreadUpdate, {"ttl": 10})
+        assert result is None
+
+    def test_strict_mode_returns_400(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("AZFUNC_LANGGRAPH_PLATFORM_STRICT", "1")
+        result = _check_unknown_platform_fields(ThreadUpdate, {"ttl": 10})
+        assert result is not None
+        assert result.status_code == 400
+        assert b"ttl" in result.get_body()
+
+    def test_non_dict_body_returns_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("AZFUNC_LANGGRAPH_PLATFORM_STRICT", "1")
+        assert _check_unknown_platform_fields(ThreadUpdate, "not-a-dict") is None


### PR DESCRIPTION
## Summary
Closes #352.

Truly-unknown (undeclared) platform-compat request fields were silently dropped by `ConfigDict(extra="ignore")`. Silent drop can change semantics without the client noticing (e.g. a client sets an execution-control flag; the server ignores it). This adds observability plus an opt-in strict escape hatch **without changing the default forward-compatible behavior**.

## Changes
- `_common.py`: new helpers `_platform_strict_enabled`, `_unknown_request_fields`, and `_check_unknown_platform_fields`. Default behavior logs a warning + emits a `UserWarning`, then drops the field (preserving `extra="ignore"` forward-compat). When `AZFUNC_LANGGRAPH_PLATFORM_STRICT` is set (any value other than empty/`0`/`false`/`no`), unknown fields are rejected with `400`.
- Wired the guard into all 9 client-request parse sites: `RunCreate` (`_parse_run_create`), `AssistantSearch`/`AssistantCount`, and `ThreadCreate`/`ThreadUpdate`/`ThreadSearch`/`ThreadCount`/`ThreadStateUpdate`/`ThreadHistoryRequest`.
- Known-but-unsupported fields keep their existing `501` path unchanged (they are declared on the models, so they are never flagged as "unknown").
- Docs: documented the env var + default behavior in `COMPATIBILITY.md` and the `contracts.py` module / `ThreadUpdate` docstrings.

## Acceptance checklist (#352)
- [x] Warn (log + `UserWarning`) on unknown fields — default stays "ignore".
- [x] Opt-in strict mode via `AZFUNC_LANGGRAPH_PLATFORM_STRICT=1` → `400`.
- [x] Existing `501` path for known-unsupported fields unchanged.
- [x] Documented the env var and default behavior.
- [x] Tests for warn-default and strict-mode rejection.

## Out of scope
- Changing the default from ignore to strict.
- Native invoke/stream models (platform-compat only).

## Verification
- `hatch run lint` ✅
- `hatch run typecheck` ✅ (mypy strict, 66 files)
- `hatch run pytest --cov` ✅ — 1008 passed, coverage 96.11% (≥95 gate)