### PR TITLE
feat(platform): warn when Azure-hosted platform_compat defaults to InMemoryThreadStore

### DIFF
--- a/docs/production-guide.md
+++ b/docs/production-guide.md
@@ -379,6 +379,18 @@ The Blob backend needs `Storage Blob Data Contributor` on the lock container (or
 
 **Safety guard — `AZFUNC_LANGGRAPH_LOCK_BACKEND`.** In multi-instance environments, set this environment variable to `distributed` (or any non-empty value other than `inprocess`). When the value indicates a distributed backend is required and `thread_lock` resolves to the default `InProcessThreadLock`, `LangGraphApp.__post_init__` raises `RuntimeError` at construction — turning a silent-race deployment mistake into a fail-fast startup error. Set the value to `inprocess` (or leave it unset) in single-instance environments; the guard passes for any wired custom backend regardless of the environment value.
 
+**Safety guard — `AZFUNC_LANGGRAPH_THREAD_STORE` (platform-compat).** The thread *store* has the same scale-out footgun as the lock: when `platform_compat=True` and no store is supplied, `LangGraphApp` defaults to the per-instance `InMemoryThreadStore`, so on Azure scale-out (Consumption / Elastic Premium) each worker keeps its own threads and state diverges across instances. Two layered guards mirror the lock-backend precedent:
+
+- **Warn by default on Azure.** When the process looks Azure-hosted (the host sets `WEBSITE_INSTANCE_ID` / `WEBSITE_SITE_NAME`) and the default in-memory store is in use, `__post_init__` emits a `RuntimeWarning` pointing at `AzureTableThreadStore`. Local development (`func start`, where those markers are absent) stays warning-free.
+- **Fail-fast when declared.** Set `AZFUNC_LANGGRAPH_THREAD_STORE=distributed` (or any non-empty value other than `inmemory`) in Function App settings to escalate the warning to a `RuntimeError` at construction whenever the default in-memory store is still in use. Supply a real store — `app.thread_store = AzureTableThreadStore(...)` — to satisfy the guard.
+
+```python
+# Multi-instance production: fail-fast if the in-memory default slips through.
+# App setting: AZFUNC_LANGGRAPH_THREAD_STORE=distributed
+app = LangGraphApp(platform_compat=True, auth_level=func.AuthLevel.FUNCTION)
+app.thread_store = AzureTableThreadStore.from_connection_string(...)  # required
+```
+
 **Interaction with Platform-compatible runs.** `thread_lock` guards the *native* invoke/stream endpoints only. Platform-compatible runs (`platform_compat=True` with `AzureTableThreadStore`) use their own ETag-based run lock (`try_acquire_run_lock` / `release_run_lock` — see the *Run lock semantics* subsection under [Persistent storage in the README](https://github.com/yeongseon/azure-functions-langgraph-python#run-lock-semantics)) and are unaffected by the `thread_lock` argument. Deployments that expose both surfaces should configure both.
 
 

--- a/src/azure_functions_langgraph/app.py
+++ b/src/azure_functions_langgraph/app.py
@@ -51,6 +51,18 @@ _ROUTE_STREAM = "graphs/{name}/stream"
 _ROUTE_STATE = "graphs/{name}/threads/{{thread_id}}/state"
 
 
+# Environment markers set by the Azure Functions host at runtime. Their presence
+# means the process is running on a real Azure Function App (not local `func
+# start`, where these are absent), which is when a per-instance in-memory thread
+# store becomes a scale-out footgun.
+_AZURE_HOST_MARKERS = ("WEBSITE_INSTANCE_ID", "WEBSITE_SITE_NAME")
+
+
+def _is_azure_hosted() -> bool:
+    """Return ``True`` when Azure Functions host env markers are present."""
+    return any(os.environ.get(marker) for marker in _AZURE_HOST_MARKERS)
+
+
 @dataclass
 class _GraphRegistration:
     """Internal registration record for a compiled graph."""
@@ -226,6 +238,34 @@ class LangGraphApp:
             from azure_functions_langgraph.platform.stores import InMemoryThreadStore
 
             self._thread_store = InMemoryThreadStore()
+            # AZFUNC_LANGGRAPH_THREAD_STORE mirrors the lock-backend guard: the
+            # default InMemoryThreadStore is per-instance, so on Azure scale-out
+            # (Consumption / Elastic Premium) each worker gets its own store and
+            # thread state diverges across instances. Warn when the process looks
+            # Azure-hosted, and escalate to a startup RuntimeError when an
+            # operator explicitly declares a distributed/production requirement.
+            env_store = os.environ.get("AZFUNC_LANGGRAPH_THREAD_STORE", "").strip().lower()
+            if env_store and env_store not in ("", "inmemory"):
+                raise RuntimeError(
+                    f"AZFUNC_LANGGRAPH_THREAD_STORE={env_store!r} requires a "
+                    "distributed thread store (for example AzureTableThreadStore), "
+                    "but the app is still using the default in-memory store. Set "
+                    "app.thread_store = ... explicitly on LangGraphApp() or unset "
+                    "the env var for local dev."
+                )
+            if _is_azure_hosted():
+                warnings.warn(
+                    "platform_compat is enabled with the default in-memory thread "
+                    "store on an Azure-hosted Function App. InMemoryThreadStore is "
+                    "per-instance, so thread state will diverge across scaled-out "
+                    "instances.\n"
+                    "  Recommended: app.thread_store = AzureTableThreadStore(...)\n"
+                    "  Fail-fast:   set AZFUNC_LANGGRAPH_THREAD_STORE=distributed\n"
+                    "  See the 'Distributed thread locking' scale-out matrix in "
+                    "docs/production-guide.md",
+                    RuntimeWarning,
+                    stacklevel=2,
+                )
 
         # Instantiate default in-process lock backend if the user did not supply
         # a custom one. See azure_functions_langgraph.locks for backend details.

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1332,3 +1332,84 @@ class TestThreadLockConfig:
         custom = MagicMock()
         app = LangGraphApp(thread_lock=custom)
         assert app.thread_lock is custom
+
+
+class TestThreadStoreConfig:
+    """Default InMemoryThreadStore guard: Azure-host warning + env fail-fast."""
+
+    @staticmethod
+    def _clear_env(monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("WEBSITE_INSTANCE_ID", raising=False)
+        monkeypatch.delenv("WEBSITE_SITE_NAME", raising=False)
+        monkeypatch.delenv("AZFUNC_LANGGRAPH_THREAD_STORE", raising=False)
+
+    def test_local_default_is_warning_free(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """No Azure host markers → default in-memory store stays silent."""
+        self._clear_env(monkeypatch)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            app = LangGraphApp(platform_compat=True)
+        assert app.thread_store is not None
+
+    def test_azure_hosted_default_warns(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Azure host marker + default in-memory store → RuntimeWarning."""
+        self._clear_env(monkeypatch)
+        monkeypatch.setenv("WEBSITE_INSTANCE_ID", "abc123")
+        with pytest.warns(RuntimeWarning, match="in-memory thread store"):
+            LangGraphApp(platform_compat=True)
+
+    def test_azure_hosted_site_name_marker_warns(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        self._clear_env(monkeypatch)
+        monkeypatch.setenv("WEBSITE_SITE_NAME", "my-func-app")
+        with pytest.warns(RuntimeWarning, match="in-memory thread store"):
+            LangGraphApp(platform_compat=True)
+
+    def test_warning_category_is_runtimewarning(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The default-store warning is a RuntimeWarning, not a UserWarning."""
+        self._clear_env(monkeypatch)
+        monkeypatch.setenv("WEBSITE_INSTANCE_ID", "abc123")
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            LangGraphApp(platform_compat=True)
+        categories = {w.category for w in caught}
+        assert RuntimeWarning in categories
+
+    def test_non_platform_compat_creates_no_store(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        self._clear_env(monkeypatch)
+        monkeypatch.setenv("WEBSITE_INSTANCE_ID", "abc123")
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            app = LangGraphApp(platform_compat=False)
+        assert app.thread_store is None
+
+    def test_env_guard_raises_when_distributed_requested(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """AZFUNC_LANGGRAPH_THREAD_STORE=distributed with default store raises."""
+        self._clear_env(monkeypatch)
+        monkeypatch.setenv("AZFUNC_LANGGRAPH_THREAD_STORE", "distributed")
+        with pytest.raises(RuntimeError, match="AZFUNC_LANGGRAPH_THREAD_STORE"):
+            LangGraphApp(platform_compat=True)
+
+    def test_env_guard_case_and_whitespace_tolerant(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        self._clear_env(monkeypatch)
+        monkeypatch.setenv("AZFUNC_LANGGRAPH_THREAD_STORE", "  Distributed  ")
+        with pytest.raises(RuntimeError):
+            LangGraphApp(platform_compat=True)
+
+    def test_env_guard_inmemory_value_is_allowed(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Setting AZFUNC_LANGGRAPH_THREAD_STORE=inmemory is a no-op."""
+        self._clear_env(monkeypatch)
+        monkeypatch.setenv("AZFUNC_LANGGRAPH_THREAD_STORE", "inmemory")
+        app = LangGraphApp(platform_compat=True)
+        assert app.thread_store is not None


### PR DESCRIPTION
## Summary
Closes #353.

When `platform_compat=True` and no thread store is supplied, `LangGraphApp` defaults to the per-instance `InMemoryThreadStore`. On Azure scale-out (Consumption / Elastic Premium) each worker keeps its own threads, so thread state diverges silently across instances — a production footgun. This adds a guard that mirrors the existing `AZFUNC_LANGGRAPH_LOCK_BACKEND` precedent.

## Changes
- `app.py`: when defaulting to `InMemoryThreadStore`, emit a `RuntimeWarning` if the process looks Azure-hosted (`WEBSITE_INSTANCE_ID` / `WEBSITE_SITE_NAME` present). `AZFUNC_LANGGRAPH_THREAD_STORE=distributed` (any value other than empty/`inmemory`) escalates to a startup `RuntimeError`. New `_is_azure_hosted()` helper.
- Local dev (`func start`, where `WEBSITE_*` are absent) stays warning-free. `WEBSITE_*` markers are used instead of `FUNCTIONS_WORKER_RUNTIME` precisely because the latter is also set by local `func start`.
- `docs/production-guide.md`: documented the guard next to the distributed-lock scale-out matrix.

## Acceptance checklist (#353)
- [x] `RuntimeWarning` when `platform_compat=True`, no store supplied, Azure-hosted.
- [x] Env-var (`AZFUNC_LANGGRAPH_THREAD_STORE=distributed`) escalates to startup `RuntimeError`, mirroring the lock-backend guard.
- [x] Local dev (no Azure host markers) stays warning-free.
- [x] Documented in the production guide.
- [x] Tests: Azure-hosted warning, env-var fail-fast, clean local default.

## Verification
- `hatch run lint` / `hatch run typecheck` ✅
- `hatch run pytest --cov` ✅ — 1016 passed, coverage 96.12% (≥95 gate)