### PR TITLE
ci(deps): verify langgraph-sdk contracts at max supported version (#340)

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -80,3 +80,35 @@ jobs:
         # it is a separate job from the coverage-enforcing matrix above, it
         # cannot mask coverage regressions -- the matrix job still enforces 95%.
         run: pytest tests/ --no-cov -q
+
+  langgraph-sdk-max:
+    name: langgraph-sdk compat (max supported)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Install package and dev dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev,azure-blob,azure-table]"
+
+      - name: Pin langgraph-sdk to the maximum supported line (<0.4)
+        # The floor is exercised by the langgraph-min lane (langgraph==1.0.0
+        # resolves langgraph-sdk 0.2.2). This lane proves the platform-compat
+        # wire-shape contracts also hold at the >=0.2.2,<0.4 ceiling so the
+        # supported range is verified at both ends (issue #340).
+        run: pip install "langgraph-sdk>=0.3,<0.4"
+
+      - name: Show resolved versions
+        run: pip show langgraph langgraph-sdk | grep -E '^(Name|Version):'
+
+      - name: Run SDK contract tests against maximum langgraph-sdk
+        # Compatibility smoke only: `--no-cov` disables the coverage gate for
+        # this pinned run (a separate job from the coverage-enforcing matrix).
+        run: pytest tests/test_sdk_contracts.py tests/test_sdk_compat.py --no-cov -q


### PR DESCRIPTION
## Context
Closes #340. Aligns and verifies the `langgraph-sdk` supported bounds.

Most of #340's acceptance was already satisfied in the current tree:
- `pyproject.toml`, `COMPATIBILITY.md`, and `platform/contracts.py` all declare `>=0.2.2,<0.4` consistently (no stale "as of 2025-06" comment remains).
- The `extra="ignore"` observability concern is handled by the platform-field warning work merged in #356.
- A drift guard (`test_installed_langgraph_sdk_within_supported_range`) already asserts the installed SDK stays within `(0,2) <= v < (0,4)`.

The remaining gap was acceptance item 4: *"Contract tests run against both the declared minimum and maximum supported SDK versions."*

## Change
Adds a `langgraph-sdk-max` CI lane that pins `langgraph-sdk>=0.3,<0.4` (the ceiling of the supported range) and runs `tests/test_sdk_contracts.py` + `tests/test_sdk_compat.py` against it. The existing `langgraph-min` lane already exercises the `0.2.2` floor (via `langgraph==1.0.0`), so the `>=0.2.2,<0.4` range is now verified at **both** ends.

CI-only change — no runtime source touched, so the coverage matrix is unaffected.

## Out of scope
- Support for new SDK features (durability, stream v2) — separate enhancement.
- Nightly-latest upstream drift CI — nice-to-have follow-up.