### PR TITLE
fix(health): align docs with anonymous liveness / protected details split (#341)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -206,7 +206,7 @@ The core module. Contains:
 - `_GraphRegistration` — internal record for a registered graph (includes `request_model`/`response_model` since v0.5).
 - Route wiring — delegates to `_handlers.py` for native routes and `platform/routes.py` for SDK-compatible routes.
 - `get_app_metadata()` — returns an immutable `AppMetadata` snapshot with per-graph route metadata (v0.5+).
-- `health()` — health check handler returning registered graph list.
+- `health()` — anonymous liveness handler returning `{"status": "ok"}`; `health_details()` returns the registered-graph inventory (protected by default).
 
 
 ### `openapi.py` *(v0.5+)*

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -39,7 +39,7 @@ The `register()` method accepts:
 |-----------|------|----------|-------------|
 | `graph` | Any (must satisfy `InvocableGraph` protocol) | Yes | A compiled LangGraph graph or any object with an `invoke()` method |
 | `name` | `str` | Yes | Unique name used in URL routes (`/api/graphs/{name}/invoke`) |
-| `description` | `str` or `None` | No | Human-readable description shown in health endpoint |
+| `description` | `str` or `None` | No | Human-readable description shown in the `/api/health/details` endpoint |
 
 ```python
 app = LangGraphApp()
@@ -76,7 +76,7 @@ This creates endpoints for all three:
 - `POST /api/graphs/sales/stream`
 - `POST /api/graphs/triage/invoke`
 - `POST /api/graphs/triage/stream`
-- `GET /api/health`
+- `GET /api/health` (liveness probe; `GET /api/health/details` for the graph inventory, protected by default)
 
 ## Checkpointer configuration
 
@@ -103,7 +103,7 @@ Then pass `thread_id` in requests:
 }
 ```
 
-The health endpoint reports whether each graph has a checkpointer:
+The detailed health endpoint (`GET /api/health/details`, protected by default) reports whether each graph has a checkpointer:
 
 ```json
 {

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -58,7 +58,7 @@ This creates:
 - `POST /api/graphs/support/stream`
 - `POST /api/graphs/sales/invoke`
 - `POST /api/graphs/sales/stream`
-- `GET /api/health` (lists all)
+- `GET /api/health` (liveness probe; `GET /api/health/details` lists all, protected by default)
 
 ## What authentication options are available?
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,7 +14,7 @@ Deploy [LangGraph](https://github.com/langchain-ai/langgraph) agents as **Azure 
 - **Zero-boilerplate deployment** — register a compiled graph, get HTTP endpoints automatically
 - **Invoke endpoint** — `POST /api/graphs/{name}/invoke` for synchronous execution
 - **Stream endpoint** — `POST /api/graphs/{name}/stream` for buffered SSE responses
-- **Health endpoint** — `GET /api/health` listing registered graphs with checkpointer status
+- **Health endpoints** — anonymous `GET /api/health` liveness probe (`{"status": "ok"}`) plus protected `GET /api/health/details` listing registered graphs with checkpointer status
 - **Protocol-based** — works with any object that has `invoke()` and `stream()` methods
 - **Checkpointer pass-through** — thread-based conversation state via LangGraph's native config
 
@@ -51,7 +51,7 @@ This gives you:
 
 1. `POST /api/graphs/echo_agent/invoke` — invoke the agent
 2. `POST /api/graphs/echo_agent/stream` — stream agent responses (buffered SSE)
-3. `GET /api/health` — health check
+3. `GET /api/health` — anonymous liveness probe (`GET /api/health/details` for the protected graph inventory)
 
 ## Next steps
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -11,7 +11,8 @@ When you register a graph named `my_agent`, the following endpoints are created:
 | `POST` | `/api/graphs/my_agent/invoke` | Synchronous graph invocation |
 | `POST` | `/api/graphs/my_agent/stream` | Buffered SSE streaming |
 | `GET` | `/api/graphs/my_agent/threads/{thread_id}/state` | Thread state inspection |
-| `GET` | `/api/health` | Health check with registered graph list |
+| `GET` | `/api/health` | Anonymous liveness probe (`{"status": "ok"}`) |
+| `GET` | `/api/health/details` | Registered-graph inventory (protected by default) |
 
 ## Invoke endpoint
 
@@ -129,6 +130,23 @@ GET /api/health
 ```
 
 ### Response
+
+```json
+{"status": "ok"}
+```
+
+The anonymous liveness probe returns only `{"status": "ok"}` — it never
+enumerates registered graphs.
+
+### Detailed inventory
+
+```
+GET /api/health/details
+```
+
+Returns the registered-graph inventory. This surface is protected by
+`health_details_auth_level` (defaults to the app-level `auth_level`), so it
+requires a function key unless you opt it into `ANONYMOUS` explicitly.
 
 ```json
 {

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -121,7 +121,8 @@ gapp = LangGraphApp(thread_store=store, platform_compat=True)
 - `POST /api/graphs/{name}/invoke` — Invoke graph
 - `POST /api/graphs/{name}/stream` — Stream graph (buffered SSE)
 - `GET /api/graphs/{name}/threads/{thread_id}/state` — Get thread state
-- `GET /api/health` — Health check with registered graph info
+- `GET /api/health` — Anonymous liveness probe (`{"status": "ok"}`)
+- `GET /api/health/details` — Registered-graph inventory (protected by default)
 
 ### Platform-Compatible Routes (when `platform_compat=True`)
 - `POST /api/assistants/search` — List assistants

--- a/src/azure_functions_langgraph/app.py
+++ b/src/azure_functions_langgraph/app.py
@@ -153,7 +153,9 @@ class LangGraphApp:
 
     - ``POST /api/graphs/{name}/invoke`` — synchronous invocation
     - ``POST /api/graphs/{name}/stream`` — buffered SSE response (not true streaming)
-    - ``GET /api/health`` — health check with registered graph list
+    - ``GET /api/health`` — anonymous liveness probe (returns only ``{"status": "ok"}``)
+    - ``GET /api/health/details`` — registered-graph inventory (protected;
+      gated by ``health_details_auth_level``)
     - ``GET /api/graphs/{name}/threads/{thread_id}/state`` — thread state (StatefulGraph only)
 
     Note:


### PR DESCRIPTION
## Context
Closes #341. The anonymous `GET /api/health` liveness probe already returns only `{"status": "ok"}`, and the registered-graph inventory already lives on the protected `GET /api/health/details` surface (gated by `health_details_auth_level`, which defaults to the app-level `auth_level`). The runtime behaviour required by the issue was already shipped.

The remaining gap was documentation drift: several docs and the `LangGraphApp` docstring still claimed the anonymous `/api/health` enumerates registered graphs, which contradicts the shipped (safe) behaviour and could mislead operators into thinking anonymous callers see graph metadata.

## Change
Docs/docstring-only alignment — no runtime logic touched:
- `app.py` `LangGraphApp` docstring: split the health bullet into anonymous liveness vs protected `/details`.
- `docs/usage.md`: split the endpoint table + Health section into liveness (`{"status":"ok"}`) and protected detailed-inventory subsections.
- `docs/index.md`, `docs/faq.md`, `docs/configuration.md`, `docs/architecture.md`, `llms-full.txt`: corrected every remaining claim that `/api/health` lists graphs.

`README.md`, `docs/security.md`, and `docs/production-guide.md` already described the split correctly and are unchanged.

## Acceptance
- [x] Anonymous `GET /api/health` returns minimal body — already shipped (`HealthStatus()`), now documented consistently.
- [x] Detailed inventory on protected `GET /api/health/details` — already shipped, docs corrected.
- [x] Configurable via `health_details_auth_level` without breaking the default liveness contract — unchanged.
- [x] Docs/examples updated to reflect the split.
- [x] Tests cover both responses (`tests/test_app.py`), coverage ≥ 95% (no logic change).

## Out of scope
- Broader auth model changes (per-graph auth, FUNCTION default) — already shipped.