### PR TITLE
docs(platform): clarify core adapter vs experimental platform-compat boundary (#339)

### DIFF
--- a/PRD.md
+++ b/PRD.md
@@ -25,7 +25,7 @@ LangGraph is the most popular framework for building stateful AI agents with LLM
 1. **Graph Registration** — Accept `CompiledStateGraph` from LangGraph and auto-register HTTP endpoints
 2. **Invoke Endpoint** — `POST /api/graphs/{name}/invoke` for synchronous graph execution
 3. **Stream Endpoint** — `POST /api/graphs/{name}/stream` for SSE streaming responses
-4. **Health Endpoint** — `GET /api/health` listing registered graphs
+4. **Health Endpoint** — anonymous `GET /api/health` liveness probe (`{"status": "ok"}`) plus protected `GET /api/health/details` for the registered-graph inventory
 5. **Thread Support** — Pass `thread_id` via config for checkpointer-backed conversation state
 6. **Error Handling** — Consistent JSON error responses (400, 422, 500)
 
@@ -35,11 +35,45 @@ LangGraph is the most popular framework for building stateful AI agents with LLM
 2. **Azure Table Storage Checkpointer** — Azure-native checkpointer for conversation persistence
 3. **Auth Level Configuration** — Per-graph auth level overrides
 
-### Could Have (v0.3+)
+### Could Have (v0.3+) — delivered as experimental, optional surfaces
 
-1. **LangGraph Platform API Compatibility** — Mirror the LangGraph Platform REST API so `langgraph_sdk` can connect
+1. **LangGraph Platform API Compatibility** *(experimental, opt-in)* — Mirror the LangGraph Platform REST API so `langgraph_sdk` can connect. Delivered (v0.3+) but framed as an **optional** surface layered on the Core adapter; see "Product boundary" below.
 2. **Durable Functions Integration** — Use Durable Functions for long-running agent executions (>10 min timeout)
 3. **OpenAPI Generation** — Integration with `azure-functions-openapi-python` for auto-generated API docs
+
+## Product boundary: Core adapter vs Experimental Platform Compatibility
+
+This package is, first and foremost, **the most natural way to deploy an
+already-built LangGraph graph on Azure Functions** — a *deployment adapter*. It
+is deliberately **not** a reimplementation of LangGraph Platform on Azure
+Functions. To keep that identity crisp, the surface is split into two layers:
+
+- **Core adapter (stable).** Graph registration, `invoke` / `stream` / `state`
+  endpoints, health probes, auth, route + endpoint metadata, and checkpointer
+  pass-through. This is the supported product and the reason the package exists.
+- **Experimental Platform Compatibility (optional, opt-in).** The
+  `langgraph_sdk`-compatible thread / run / assistant / state surface under
+  `src/azure_functions_langgraph/platform/`. It is a genuinely useful
+  convenience for teams that already speak the Platform API, but it is layered
+  *on top of* the Core adapter and is not the package's core promise.
+
+**`platform_compat=False` is the default, and that default is the intentional
+expression of this boundary** — the Core adapter is always on; the Platform
+surface is something you explicitly opt into with `platform_compat=True`.
+
+### Store terminology (three distinct concepts)
+
+These are frequently conflated; they are **not** the same thing:
+
+- **Checkpointer** (e.g. `AzureBlobCheckpointSaver`) — persists *graph execution
+  state* (LangGraph checkpoints) so a thread can resume. This is LangGraph's
+  `BaseCheckpointSaver` contract.
+- **`AzureTableThreadStore`** — a *Platform thread-metadata registry* (thread
+  records, status, run locks) backing the experimental Platform Compatibility
+  routes. It exists to serve the Platform surface, not graph execution.
+- **LangGraph `BaseStore`** — LangGraph's *long-term, cross-thread memory*
+  abstraction. **This package does not implement `BaseStore`**; do not confuse
+  `AzureTableThreadStore` (Platform thread registry) with it.
 
 ## Non-Goals
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -38,6 +38,31 @@ flowchart TB
 
 Platform-compatible routes are registered when `platform_compat=True`, enabling the official `langgraph-sdk` Python client to communicate with Azure Functions–hosted graphs.
 
+## Core adapter vs Experimental Platform Compatibility
+
+The surface deliberately splits into two layers so the package's identity — **the
+most natural way to deploy an already-built LangGraph graph on Azure Functions** —
+stays crisp:
+
+- **Core adapter (stable).** Native routes (`invoke` / `stream` / `state` /
+  health), auth, route + endpoint metadata, and checkpointer pass-through. Always
+  registered; this is the supported product.
+- **Experimental Platform Compatibility (optional).** The `langgraph-sdk`-compatible
+  thread / run / assistant / state routes under `platform/`. Registered **only**
+  when `platform_compat=True`.
+
+**`platform_compat=False` is the default, and that default *is* the boundary** — you
+opt into the Platform surface explicitly. The package is a deployment adapter, not a
+reimplementation of LangGraph Platform on Azure Functions.
+
+> **Store terminology.** Three distinct concepts, often conflated: the
+> **checkpointer** (`AzureBlobCheckpointSaver`) persists *graph execution state*
+> (LangGraph `BaseCheckpointSaver`); **`AzureTableThreadStore`** is a *Platform
+> thread-metadata registry* (thread records, status, run locks) serving the
+> Platform-compatible routes; and LangGraph **`BaseStore`** (long-term cross-thread
+> memory) is **not implemented by this package**. `AzureTableThreadStore` is not a
+> `BaseStore`.
+
 ## Design Objectives
 
 - **Thin adapter, not a framework** — wrap LangGraph, don't replace it. All graph logic stays in LangGraph.


### PR DESCRIPTION
## Summary
Completes the parent-level (framing) acceptance items for the #339 umbrella. All 8 child issues (#340–#347) are already resolved; this PR realigns the product docs with the shipped scope.

- **PRD.md** — reframes "LangGraph Platform API Compatibility" from a future "Could Have" into a **delivered-but-experimental, opt-in** surface layered on the stable Core adapter. Adds a "Product boundary: Core adapter vs Experimental Platform Compatibility" section, documents `platform_compat=False` as the intentional expression of that boundary, and adds a store-terminology section (checkpointer vs `AzureTableThreadStore` vs LangGraph `BaseStore`). Also fixes the stale Health-endpoint line to match the anonymous liveness / protected details split.
- **docs/architecture.md** — adds a "Core adapter vs Experimental Platform Compatibility" subsection to the overview (two-layer framing, `platform_compat=False` default as the boundary, and the same store-terminology disambiguation).

## Acceptance mapping (#339 parent)
- [x] `PRD.md` Platform compatibility reflects real scope, labeled experimental/optional (not "Could Have")
- [x] Docs present two layers: Core adapter vs Experimental Platform Compatibility
- [x] `platform_compat=False` default documented as the intentional boundary
- [x] Naming clarified: `AzureTableThreadStore` (Platform thread registry) ≠ LangGraph `BaseStore` ≠ checkpointer

## Verification
- Docs-only change; no runtime/code paths touched.

Refs #339. All child issues (#340–#347) closed; umbrella can close once this merges.