### PR TITLE
docs(prd): correct storage backend terminology and tighten conformance test types

### DIFF
--- a/PRD.md
+++ b/PRD.md
@@ -32,7 +32,7 @@ LangGraph is the most popular framework for building stateful AI agents with LLM
 ### Should Have (v0.2)
 
 1. **State Endpoint** — `GET /api/graphs/{name}/threads/{thread_id}/state` for thread state inspection
-2. **Azure Table Storage Checkpointer** — Azure-native checkpointer for conversation persistence
+2. **Azure-native persistent storage** — Azure Blob Storage checkpointer and Azure Table Storage thread store for conversation persistence
 3. **Auth Level Configuration** — Per-graph auth level overrides
 
 ### Could Have (v0.3+) — delivered as experimental, optional surfaces

--- a/tests/integration/test_checkpoint_conformance.py
+++ b/tests/integration/test_checkpoint_conformance.py
@@ -15,11 +15,11 @@ unaffected.
 from __future__ import annotations
 
 import importlib
-from typing import Any, Iterator, Sequence
+from typing import Any, AsyncIterator, Iterator, Sequence
 import uuid
 
 from langchain_core.runnables import RunnableConfig
-from langgraph.checkpoint.base import Checkpoint, CheckpointMetadata
+from langgraph.checkpoint.base import Checkpoint, CheckpointMetadata, CheckpointTuple
 import pytest
 
 from azure_functions_langgraph.checkpointers.azure_blob import AzureBlobCheckpointSaver
@@ -72,7 +72,7 @@ class _AsyncConformanceSaver(AzureBlobCheckpointSaver):
     ) -> None:
         self.put_writes(config, writes, task_id, task_path)
 
-    async def aget_tuple(self, config: RunnableConfig) -> Any:
+    async def aget_tuple(self, config: RunnableConfig) -> CheckpointTuple | None:
         return self.get_tuple(config)
 
     async def alist(
@@ -82,7 +82,7 @@ class _AsyncConformanceSaver(AzureBlobCheckpointSaver):
         filter: dict[str, Any] | None = None,
         before: RunnableConfig | None = None,
         limit: int | None = None,
-    ) -> Any:
+    ) -> AsyncIterator[CheckpointTuple]:
         for item in self.list(config, filter=filter, before=before, limit=limit):
             yield item
 


### PR DESCRIPTION
## Context

Post-merge reviewer pass for #361 and #362, which were authored and self-merged in the same session without a separate review. An independent Oracle review of both merged PRs found **no blocking defects**; this PR addresses its one non-blocking finding plus two low-priority typing nits. No runtime/behavioral changes.

## Changes

- **PRD.md** — Fix stale "Azure Table Storage **Checkpointer**" wording in the v0.2 roadmap. Corrected to reflect actual terminology: Azure **Blob** Storage is the checkpointer; Azure **Table** Storage is the thread store. Now consistent with README, `docs/architecture.md`, and the terminology clarified in #362.
- **tests/integration/test_checkpoint_conformance.py** — Tighten async wrapper return types to better preserve the conformance contract: `aget_tuple -> CheckpointTuple | None`, `alist -> AsyncIterator[CheckpointTuple]` (previously `Any`).

## Verification

- `hatch run lint` — clean
- `hatch run typecheck` — clean (67 files)
- `hatch run pytest --cov` — 96.12% (gate 95%); conformance test collects and skips cleanly without Azurite

## References

- #361, #362 (reviewed PRs)
- #344, #339 (originating issues)