### PR TITLE
ci(deps): add azure-functions 2.x compatibility proof lane

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -112,3 +112,46 @@ jobs:
         # Compatibility smoke only: `--no-cov` disables the coverage gate for
         # this pinned run (a separate job from the coverage-enforcing matrix).
         run: pytest tests/test_sdk_contracts.py tests/test_sdk_compat.py --no-cov -q
+
+  azure-functions-2x:
+    name: azure-functions 2.x compat (Py 3.13)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up Python 3.13
+        # azure-functions 2.x declares Requires-Python >=3.13, so this proof
+        # lane must run on 3.13 (3.14 stays exploratory until Azure supports it).
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.13"
+
+      - name: Build wheel
+        # Issue #350 requires proving 2.x against a WHEEL-installed build, not an
+        # editable/source tree, so we build and install the distribution artifact.
+        run: |
+          python -m pip install --upgrade pip build
+          python -m build --wheel --outdir dist
+
+      - name: Install wheel with dev + storage extras
+        run: pip install "$(ls dist/azure_functions_langgraph-*.whl)[dev,azure-blob,azure-table]"
+
+      - name: Upgrade azure-functions to the 2.x line
+        # pyproject caps azure-functions <2.0.0 until 2.x is certified on real
+        # Azure (issue #350). This lane deliberately overrides that cap to PROVE
+        # the adapter surface (FunctionApp route discovery, HttpRequest.get_json,
+        # HttpResponse status/headers/body, buffered-SSE stream) holds under 2.x.
+        # pip warns about the intentional override; that is expected.
+        run: pip install "azure-functions>=2,<3"
+
+      - name: Show resolved versions
+        run: pip show azure-functions langgraph langgraph-sdk | grep -E '^(Name|Version):'
+
+      - name: Run compat suite against the wheel + azure-functions 2.x
+        # Compatibility smoke only: `--no-cov` disables the coverage gate for this
+        # pinned run (a separate job from the coverage-enforcing matrix). The repo
+        # pytest config sets `pythonpath = ["src", "."]`, which would shadow the
+        # installed wheel with the source tree; `-o pythonpath=` clears it so the
+        # suite genuinely exercises the wheel-installed package.
+        run: pytest tests/ --no-cov -q -o "pythonpath="

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,8 +23,12 @@ classifiers = [
 ]
 
 dependencies = [
-    # Cap below 2.0.0: azure-functions v2 may change worker function-indexing
-    # behavior this package relies on. See knowledge#46 / dx#8.
+    # Cap below 2.0.0 pending real-Azure certification of azure-functions 2.x.
+    # 2.x requires Python >=3.13 and may change worker function-indexing. A CI
+    # proof lane (ci-test.yml: "azure-functions 2.x compat (Py 3.13)") already
+    # verifies the adapter surface holds against a wheel-installed 2.x build; the
+    # cap is lifted only after e2e-azure.yml certifies 2.x on real Azure (#350).
+    # See knowledge#46 / dx#8.
     "azure-functions>=1.17,<2.0.0",
     "langgraph>=1.0,<2.0",
     "pydantic>=2.0,<3.0",


### PR DESCRIPTION
## Context

Partially addresses #350. `azure-functions` 2.x has shipped (latest 2.2.0) and the `<2.0.0` cap now guards against an already-released major — i.e. the package is **unverified** against current Azure Functions rather than protected from it. Per the issue's Oracle-validated sequencing, we add a **proof lane first** and keep the cap until 2.x is certified on real Azure.

## Key finding

`azure-functions` 2.x declares **`Requires-Python >=3.13`**. It cannot install on 3.10–3.12, so the proof lane runs on Python 3.13.

Empirically verified locally (Python 3.13 + azure-functions 2.2.0, wheel-installed): the full suite passes (exit 0; only Azurite/cosmos integration tests skip). Route discovery, `HttpRequest.get_json`, `HttpResponse`, and the buffered-SSE stream paths are all exercised by the passing suite.

## Changes

- **`.github/workflows/ci-test.yml`** — new `azure-functions 2.x compat (Py 3.13)` job. Builds the wheel, installs it with `[dev,azure-blob,azure-table]`, upgrades to `azure-functions>=2,<3`, and runs the suite with `-o "pythonpath="` so the **installed wheel** (not the `src/` tree, which the repo's `pythonpath = ["src", "."]` would otherwise shadow) is genuinely exercised.
- **`pyproject.toml`** — pin comment updated to record the proof lane and the real-Azure certification gate. **The `<2.0.0` cap is intentionally unchanged.**

## Acceptance checklist status (#350)

- [x] CI lane installing latest `azure-functions` 2.x on Python 3.13
- [x] Verify FunctionApp route discovery/indexing under 2.x (via suite)
- [x] Verify `HttpRequest.get_json()` + `HttpResponse` under 2.x (via suite)
- [x] Verify buffered-SSE stream endpoint under 2.x (via suite)
- [x] Run the lane against a **wheel-installed** build
- [ ] Extend real-Azure certification (`e2e-azure.yml`) to 2.x + Py 3.13 — **cloud-gated, follow-up**
- [ ] Raise the cap — **gated on the real-Azure certification above**

## Out of scope (tracked, remain in #350)

- Extending `e2e-azure.yml` (requires an Azure subscription dispatch + confirmation that the Azure Functions Python 3.13 runtime is GA).
- Lifting the `<2.0.0` cap (blocked on that certification).

## References

- #350