### PR TITLE
ci(deps): pin artifact actions to v4 canonical pair via Dependabot ignore

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,3 +20,14 @@ updates:
       - "dependencies"
       - "github-actions"
     open-pull-requests-limit: 10
+    ignore:
+      # actions/upload-artifact + actions/download-artifact are managed as a v4
+      # "canonical pair" by tools/lint_release_workflows.py (release-gate drift
+      # lint). download-artifact v5+ ships breaking behavior (Node 24 runner
+      # minimum, digest-mismatch fail-by-default) that would break the gate lint
+      # and CI, so major bumps are adopted deliberately, not by Dependabot.
+      # See issue #334.
+      - dependency-name: "actions/upload-artifact"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "actions/download-artifact"
+        update-types: ["version-update:semver-major"]

--- a/tools/lint_release_workflows.py
+++ b/tools/lint_release_workflows.py
@@ -43,6 +43,13 @@ CANONICAL_ACTIONS: dict[str, tuple[str, str]] = {
     "actions/setup-python": ("5fda3b95a4ea91299a34e894583c3862153e4b97", "v7.0.0"),
     # renovate: datasource=github-tags depName=azure/login versioning=github-tags
     "azure/login": ("f5d393ae46f8fde4be8b75f32e3fc50e654ad0ca", "v3.0.1"),
+    # actions/upload-artifact + actions/download-artifact are deliberately held
+    # as a v4 "canonical pair". Newer majors are NOT adopted automatically:
+    # download-artifact v5+ raises the runner floor to Node 24 and flips
+    # digest-mismatch to fail-by-default, which would break this gate lint and
+    # the release-gate workflows. Dependabot is configured to ignore major bumps
+    # for both (see .github/dependabot.yml); adopt new majors deliberately, in
+    # lockstep, and update these SHAs together. See issue #334.
     # renovate: datasource=github-tags depName=actions/upload-artifact versioning=github-tags
     "actions/upload-artifact": ("ea165f8d65b6e75b540449e92b4886f43607fa02", "v4"),
     # renovate: datasource=github-tags depName=actions/download-artifact versioning=github-tags


### PR DESCRIPTION
## Context

Addresses #334. Dependabot opened major bumps for the artifact actions — #329 (`actions/upload-artifact` 4.6.2 → 7.0.1) and #330 (`actions/download-artifact` 4.3.0 → 8.0.1) — that would break the release-gate drift lint (`tools/lint_release_workflows.py`), which intentionally manages these two as a **v4 canonical pair**. `download-artifact` v5+ also ships breaking behavior (Node 24 runner minimum, digest-mismatch fail-by-default).

## Changes

- **`.github/dependabot.yml`** — add `ignore` rules for `semver-major` bumps of both artifact actions so those PRs are not re-opened. The `github-actions` ecosystem stays managed for everything else. (The issue's "remove the `github-actions` ecosystem" step is gated on Renovate being confirmed as the actions manager; Renovate is **not** configured yet, so removing the ecosystem outright would leave that surface unmanaged. The ignore rules achieve the issue's actual goal non-destructively.)
- **`tools/lint_release_workflows.py`** — document the v4-canonical-pin rationale directly above the `CANONICAL_ACTIONS` entries so the constraint is discoverable at the lint source.

## Verification

- `python tools/lint_release_workflows.py` — "pins and publish gate are canonical."
- `python tools/lint_workflow_pins.py` — "every action is SHA-pinned, local, or documented-exempt."
- `pytest tests/test_release_workflow_pins.py` — pass

## Acceptance checklist status (#334)

- [x] Close/ignore #329 and #330 (keep artifact actions on the v4 canonical pair) — closing #329/#330 + Dependabot ignore rules
- [ ] Remove `github-actions` ecosystem from `.github/dependabot.yml` once Renovate is confirmed — **deferred (Renovate not configured yet)**
- [x] Document the v4-canonical-pin rationale next to the release-gate lint config

## References

- #334, #329, #330