### PR TITLE
chore(deps): bump codeql-action init+analyze to v4.37.7 (matched pair)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,12 +22,12 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
+        uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
         with:
           languages: python
           queries: security-extended
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
+        uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
         with:
           category: "/language:python"


### PR DESCRIPTION
## Summary
- Bumps both `github/codeql-action/init` and `github/codeql-action/analyze` to **v4.37.7** (SHA `ff2f1c62`) in a single change.

## Why combined
CodeQL requires the `init` and `analyze` action versions to **match**. Dependabot split this into two PRs (#337 analyze-only, #338 init-only); each left the other half at v4.37.6, causing a version mismatch that failed the `Perform CodeQL Analysis` step. Merging both bumps together resolves it.

Supersedes #337 and #338.